### PR TITLE
Make it so spinners can be optional for shell commands

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,7 +1,1 @@
 use flake
-export DENO_DIR="$PWD/.deno"
-export PATH="$PWD/.deno/bin:$PATH"
-export PATH="$PWD/infra/bff/bin:$PATH"
-export PATH="$PWD/node_modules/.bin:$PATH"
-export BFF_ROOT="$PWD"
-export PATH="$PATH:$BFF_ROOT/node_modules/.bin"

--- a/infra/bff/friends/build.bff.ts
+++ b/infra/bff/friends/build.bff.ts
@@ -1,5 +1,5 @@
 import { build } from "infra/build/build.ts";
-import { buildRelay } from "infra/bff/friends/relay.bff.ts";
+// import { buildRelay } from "infra/bff/friends/relay.bff.ts";
 import { register } from "infra/bff/mod.ts";
 
 register("build", "Builds the client.", async (_options) => {

--- a/infra/bff/shellBase.ts
+++ b/infra/bff/shellBase.ts
@@ -3,11 +3,15 @@ import startSpinner from "lib/terminalSpinner.ts";
 
 export async function runShellCommand(
   commandArray: Array<string>,
+  useSpinner = true,
 ): Promise<number> {
   // deno-lint-ignore no-console
   console.log(`Running command: ${commandArray.join(" ")}`);
-  const stopSpinner = startSpinner();
-  const cwd = Deno.env.get("BFF_ROOT") ?? Deno.cwd();
+  let stopSpinner;
+  if (useSpinner) {
+    stopSpinner = startSpinner();
+  }
+  const cwd = Deno.env.get("BF_PATH") ?? Deno.cwd();
 
   const cmd = new Deno.Command(commandArray[0], {
     args: commandArray.slice(1),
@@ -18,7 +22,7 @@ export async function runShellCommand(
 
   const process = cmd.spawn();
   const { code, success } = await process.output();
-  stopSpinner();
+  stopSpinner ? stopSpinner() : null;
 
   if (success) {
     // deno-lint-ignore no-console


### PR DESCRIPTION
Make it so spinners can be optional for shell commands


Summary:

Test Plan:

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/4).
* #8
* #7
* #6
* #5
* __->__ #4
* #3
* #2