### PR TITLE
Update sapling version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1713344939,
-        "narHash": "sha256-jpHkAt0sG2/J7ueKnG7VvLLkBYUMQbXQ2L8OBpVG53s=",
+        "lastModified": 1714531828,
+        "narHash": "sha256-ILsf3bdY/hNNI/Hu5bSt2/KbmHaAVhBbNUOdGztTHEg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e402c3eb6d88384ca6c52ef1c53e61bdc9b84ddd",
+        "rev": "0638fe2715d998fa81d173aad264eb671ce2ebc1",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1713248628,
-        "narHash": "sha256-NLznXB5AOnniUtZsyy/aPWOk8ussTuePp2acb9U+ISA=",
+        "lastModified": 1714253743,
+        "narHash": "sha256-mdTQw2XlariysyScCv2tTE45QSU9v/ezLcHJ22f0Nxc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5672bc9dbf9d88246ddab5ac454e82318d094bb8",
+        "rev": "58a1abdbae3217ca6b702f03d3b35125d88a2994",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,7 @@
           jupyter
           watchman
           git
+          unstablePkgs.sapling
         ];
 
         deployPackages = with pkgs; [


### PR DESCRIPTION
Update sapling version


# IMPORTANT:
requires updating the bf base replit path b/c of the flake update

Summary:
Updates sapling version by moving it to unstablepkgs


Test Plan:

```
~/update-sapling/bolt-foundry$ sl --version
Sapling 0.2.20231113
(see https://sapling-scm.com/ for more information)
~/update-sapling/bolt-foundry$ kill 1
~/update-sapling$ sl --version
Sapling 0.2.20240116
(see https://sapling-scm.com/ for more information)
```
<!-- GitContextStart -->
- - -
This pull request can be reviewed on [<img src="https://gitcontext.com/logo/GitContextButton.svg" height="32" align="absmiddle" alt="GitContext.com"/>](https://gitcontext.com/app/prs/github/bolt-foundry/bolt-foundry/31)
<!-- GitContextEnd -->