### PR TITLE
Add route for redirecting to boltfoundry.wtf in dev

### DIFF
--- a/packages/main.ts
+++ b/packages/main.ts
@@ -11,6 +11,12 @@ export enum DeploymentTypes {
   "WORKER" = "WORKER",
   "DEVELOPMENT" = "DEVELOPMENT",
 }
+
+export enum DeploymentEnvs {
+  "DEVELOPMENT" = "DEVELOPMENT",
+  "STAGING" = "STAGING",
+  "PRODUCTION" = "PRODUCTION",
+}
 type Handler = (
   request: Request,
 ) => Promise<Response> | Response;
@@ -74,10 +80,19 @@ const defaultRoute = () => {
 const deploymentType = Deno.env.get("DEPLOYMENT_TYPE") ??
   DeploymentTypes.DEVELOPMENT;
 
-const shouldLaunchWeb = deploymentType === DeploymentTypes.WEB ||
-  deploymentType === DeploymentTypes.DEVELOPMENT;
-const shouldLaunchWorker = deploymentType === DeploymentTypes.WORKER ||
-  deploymentType === DeploymentTypes.DEVELOPMENT;
+let shouldLaunchWeb = true;
+let shouldLaunchWorker = true;
+
+switch (deploymentType) {
+  case DeploymentTypes.WEB: {
+    shouldLaunchWorker = false;
+    break;
+  }
+  case DeploymentTypes.WORKER: {
+    shouldLaunchWeb = false;
+    break;
+  }
+}
 
 if (import.meta.main) {
   if (shouldLaunchWeb) {
@@ -92,7 +107,7 @@ if (import.meta.main) {
   }
 
   if (shouldLaunchWorker) {
-    const worker = new Worker(
+    const _worker = new Worker(
       import.meta.resolve("packages/worker/worker.ts"),
       { type: "module" },
     );
@@ -101,4 +116,5 @@ if (import.meta.main) {
       const keepaliveLogger = getLogger("workerKeepalive");
       keepaliveLogger.disableAll();
     }
-  }}
+  }
+}

--- a/packages/main.ts
+++ b/packages/main.ts
@@ -48,8 +48,26 @@ routes.set("/build/Client.js", async () => {
   });
 });
 
-routes.set("/google/oauth/start", (req) => {
-  const redirectable = getGoogleOauthUrl(req);
+routes.set("/login", (...args) => {
+  const deploymentEnvironment = Deno.env.get("BF_ENV");
+  switch (deploymentEnvironment) {
+    case DeploymentEnvs.DEVELOPMENT: {
+      return new Response(null, {
+        status: 302,
+        headers: {
+          location: `https://boltfoundry.wtf/login?sourceRepl=${
+            Deno.env.get("REPL_ID")
+          }&sourceCluster=${Deno.env.get("REPLIT_CLUSTER")}`,
+        },
+      });
+    }
+  }
+
+  return clientRenderer(...args);
+});
+
+routes.set("/google/oauth/start", (_req) => {
+  const redirectable = getGoogleOauthUrl();
   // create temporary redirect response 302
   return new Response(null, {
     status: 302,


### PR DESCRIPTION
Add route for redirecting to boltfoundry.wtf in dev

Summary:

Google doesn't provide a way for us to programatically change oauth urls so instead we're going to have our staging environment handle redirects so we can send stuff around properly.

Test Plan:

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/34).
* #36
* #35
* __->__ #34
* #33