### PR TITLE
Move deploy to the proper spot

### DIFF
--- a/infra/bff/friends/deploy.bff.ts
+++ b/infra/bff/friends/deploy.bff.ts
@@ -1,12 +1,23 @@
-import { runShellCommand } from "infra/bff/shellBase.ts";
+import { runShellCommand, runShellCommandWithOutput } from "infra/bff/shellBase.ts";
 import { register } from "infra/bff/mod.ts";
 
 register(
-  "deploy:prep",
-  "Prep for deploy",
+  "deploy",
+  "Pulls changes down. WILL OVERWRITE ANY CURRENT CHANGES.",
   async () => {
-    await runShellCommand(["sl", "pull"]);
-    await runShellCommand(["sl", "goto", "main", "--clean"]);
+    const ghToken = await runShellCommandWithOutput([
+      "replit-git-askpass",
+      "Password for 'https://token@github.com': ",
+    ]);
+    if (ghToken.trim() === "no GitHub token available") {
+      throw new Error("No token, can't proceed.")
+    }
+    console.log(
+      "This command will overwrite any changes you have made to the current branch. ctrl + c now. You have 5 seconds",)
+    await runShellCommand(['sleep', '5']);
+    await runShellCommand(["sl", "pull"], { GH_TOKEN: ghToken });
+    await runShellCommand(["sl", "goto", "main", "--clean"], { GH_TOKEN: ghToken });
     return 0;
   },
 );
+


### PR DESCRIPTION
Move deploy to the proper spot




Summary:

Also moves the github confirmation step earlier and fails if the gh token isn't found.

Test Plan:
<!-- GitContextStart -->
- - -
This pull request can be reviewed on [<img src="https://gitcontext.com/logo/GitContextButton.svg" height="32" align="absmiddle" alt="GitContext.com"/>](https://gitcontext.com/app/prs/github/bolt-foundry/bolt-foundry/39)
<!-- GitContextEnd -->