### PR TITLE
Add a bootcamp task note for lib files

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,7 @@
           gdb
           gnumake
           emscripten
+          watchman
         ];
 
         deployPackages = with pkgs; [

--- a/lib/BfError.ts
+++ b/lib/BfError.ts
@@ -1,3 +1,4 @@
+// #BOOTCAMPTASK move this to packages/client/lib because the frontend needs it or something.
 import { getLogger } from "deps.ts";
 const logger = getLogger(import.meta);
 export class BfError extends Error {

--- a/lib/classnames.ts
+++ b/lib/classnames.ts
@@ -12,6 +12,9 @@
  * ]);
  */
 
+// #BOOTCAMPTASK move this to packages/client/lib because the frontend needs it or something.
+
+
 export function classnames(
   items: (string | { [key: string]: boolean | null | undefined })[],
 ) {

--- a/lib/color.ts
+++ b/lib/color.ts
@@ -1,3 +1,5 @@
+// #BOOTCAMPTASK move this to packages/client/lib because the frontend needs it or something.
+
 export function hexToRgb(hex: string) {
   // Remove the hash at the front if it's there
   hex = hex.replace(/^#/, "");

--- a/lib/download.ts
+++ b/lib/download.ts
@@ -1,3 +1,5 @@
+// #BOOTCAMPTASK move this to packages/client/lib because the frontend needs it or something.
+
 import { captureEvent } from "packages/events/mod.ts";
 
 export function downloadText(

--- a/lib/opfs.ts
+++ b/lib/opfs.ts
@@ -1,3 +1,5 @@
+// #BOOTCAMPTASK move this to packages/client/lib because the frontend needs it or something.
+
 import { getLogger, rxjs } from "deps.ts";
 import { BfError } from "lib/BfError.ts";
 const { ReplaySubject } = rxjs;

--- a/lib/poseFilter.ts
+++ b/lib/poseFilter.ts
@@ -1,3 +1,5 @@
+// #BOOTCAMPTASK move this to packages/client/lib because the frontend needs it or something.
+
 export default class PoseFilter {
   private initialized: boolean;
   private Q: number; // Process noise covariance

--- a/lib/terminalSpinner.ts
+++ b/lib/terminalSpinner.ts
@@ -1,3 +1,4 @@
+// backend only, idk how to represent that yet? #BOOTCAMPTASK l1
 const moonFrames = ["🌑", "🌒", "🌓", "🌔", "🌕", "🌖", "🌗", "🌘", "🌑"];
 function spinner(isATTY: boolean, frames = moonFrames) {
   let i = 0;


### PR DESCRIPTION
Add a bootcamp task note for lib files




Summary:

If a developer adds anything that touches the backend to this, since it's used in the frontend, it'll die. We should probably scope all libs that are client dependent into `packages/client/lib`.

Test Plan:

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/72).
* #76
* #75
* #74
* #73
* __->__ #72
* #71