### PR TITLE
Change graphql errors to remove the string prefix "graphql error"

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,7 @@
           gdb
           gnumake
           emscripten
+          watchman
         ];
 
         deployPackages = with pkgs; [

--- a/lib/BfError.ts
+++ b/lib/BfError.ts
@@ -1,3 +1,4 @@
+// #BOOTCAMPTASK move this to packages/client/lib because the frontend needs it or something.
 import { getLogger } from "deps.ts";
 const logger = getLogger(import.meta);
 export class BfError extends Error {

--- a/lib/classnames.ts
+++ b/lib/classnames.ts
@@ -12,6 +12,9 @@
  * ]);
  */
 
+// #BOOTCAMPTASK move this to packages/client/lib because the frontend needs it or something.
+
+
 export function classnames(
   items: (string | { [key: string]: boolean | null | undefined })[],
 ) {

--- a/lib/color.ts
+++ b/lib/color.ts
@@ -1,3 +1,5 @@
+// #BOOTCAMPTASK move this to packages/client/lib because the frontend needs it or something.
+
 export function hexToRgb(hex: string) {
   // Remove the hash at the front if it's there
   hex = hex.replace(/^#/, "");

--- a/lib/download.ts
+++ b/lib/download.ts
@@ -1,3 +1,5 @@
+// #BOOTCAMPTASK move this to packages/client/lib because the frontend needs it or something.
+
 import { captureEvent } from "packages/events/mod.ts";
 
 export function downloadText(

--- a/lib/googleOauth.ts
+++ b/lib/googleOauth.ts
@@ -1,9 +1,20 @@
 import { OAuth2Client } from "https://esm.sh/google-auth-library@9.2.0";
+import { BfError } from "lib/BfError.ts";
 const GOOGLE_OAUTH_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth";
 const GOOGLE_OAUTH_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
 const GOOGLE_OAUTH_CLIENT_ID = Deno.env.get("GOOGLE_OAUTH_CLIENT_ID");
 const GOOGLE_OAUTH_REDIRECT_URL = Deno.env.get("GOOGLE_OAUTH_REDIRECT_URL");
 const GOOGLE_OAUTH_CLIENT_SECRET = Deno.env.get("GOOGLE_OAUTH_CLIENT_SECRET");
+
+if (!GOOGLE_OAUTH_CLIENT_ID) {
+  throw new BfError("Missing GOOGLE_OAUTH_CLIENT_ID");
+}
+if (!GOOGLE_OAUTH_REDIRECT_URL) {
+  throw new BfError("Missing GOOGLE_OAUTH_REDIRECT_URL");
+}
+if (!GOOGLE_OAUTH_CLIENT_SECRET) {
+  throw new BfError("Missing GOOGLE_OAUTH_CLIENT_SECRET");
+}
 
 export function getGoogleOauthUrl() {
   const paramsInit = {
@@ -33,7 +44,7 @@ export async function exchangeCodeForToken(
   const params = new URLSearchParams({
     code,
     client_id: GOOGLE_OAUTH_CLIENT_ID!,
-    client_secret: Deno.env.get("GOOGLE_OAUTH_CLIENT_SECRET")!,
+    client_secret: GOOGLE_OAUTH_CLIENT_SECRET!,
     redirect_uri: GOOGLE_OAUTH_REDIRECT_URL!,
     grant_type: "authorization_code",
   });

--- a/lib/opfs.ts
+++ b/lib/opfs.ts
@@ -1,3 +1,5 @@
+// #BOOTCAMPTASK move this to packages/client/lib because the frontend needs it or something.
+
 import { getLogger, rxjs } from "deps.ts";
 import { BfError } from "lib/BfError.ts";
 const { ReplaySubject } = rxjs;

--- a/lib/poseFilter.ts
+++ b/lib/poseFilter.ts
@@ -1,3 +1,5 @@
+// #BOOTCAMPTASK move this to packages/client/lib because the frontend needs it or something.
+
 export default class PoseFilter {
   private initialized: boolean;
   private Q: number; // Process noise covariance

--- a/lib/terminalSpinner.ts
+++ b/lib/terminalSpinner.ts
@@ -1,3 +1,4 @@
+// backend only, idk how to represent that yet? #BOOTCAMPTASK l1
 const moonFrames = ["🌑", "🌒", "🌓", "🌔", "🌕", "🌖", "🌗", "🌘", "🌑"];
 function spinner(isATTY: boolean, frames = moonFrames) {
   let i = 0;

--- a/packages/client/relay/environment.ts
+++ b/packages/client/relay/environment.ts
@@ -1,6 +1,7 @@
 import { RelayRuntime } from "deps.ts";
 import { GraphqlWs } from "packages/client/deps.ts";
 import { getLogger } from "deps.ts";
+import { BfError } from "lib/BfError.ts";
 
 const logger = getLogger(import.meta);
 const { Environment, Network, RecordSource, Store, Observable } = RelayRuntime;
@@ -49,7 +50,7 @@ const subscribe = (operation, variables) => {
   });
 };
 
-class CustomError extends Error {
+class CustomError extends BfError {
   code?: string;
 
   constructor(message?: string, code?: string) {
@@ -110,10 +111,9 @@ async function fetchQuery(
   const returnResponse = await response.json();
   if (returnResponse.errors) {
     logger.error(returnResponse.errors);
-    const error = new CustomError(
-      `GraphQL Error: ${returnResponse.errors[0].message}`,
+    const error = new BfError(
+      `${returnResponse.errors[0].message}`,
     );
-    error.code = returnResponse.errors[0].extensions?.code;
     throw error;
   }
   return returnResponse as RelayRuntime.GraphQLResponse;


### PR DESCRIPTION
Change graphql errors to remove the string prefix "graphql error"




Summary:

this makes it so we can write user facing messages on the backend.

Test Plan:

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/74).
* #76
* #75
* __->__ #74
* #73
* #72
* #71