### PR TITLE
Bugfix: Allow import.meta to fail

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -61,7 +61,8 @@ export function getLogger(importMeta: ImportMeta | string) {
     return log.getLogger(url.pathname);
   }
   // get relative url and remove leading slash
-  const pathName = url.pathname.split(Deno.cwd())[1].replace(/^\//, "");
+  const relativePathname = url.pathname.split(Deno.cwd())[1];
+  const pathName = relativePathname ? relativePathname.replace(/^\//, "") : url.pathname;
   return log.getLogger(pathName);
 }
 

--- a/infra/lib/jupyterUtils.ts
+++ b/infra/lib/jupyterUtils.ts
@@ -1,0 +1,16 @@
+import { getLogger } from "deps.ts";
+import { BfAccount } from "packages/bfDb/models/BfAccount.ts";
+import { BfCurrentViewerAccessToken } from "packages/bfDb/classes/BfCurrentViewer.ts";
+
+const logger = getLogger(import.meta);
+
+export async function getJupyterCurrentUser() {
+  const refreshToken = Deno.env.get("JUPYTER_USER_REFRESH_TOKEN")
+  const accessToken = await BfAccount.getRefreshedAccessToken(
+    import.meta,
+    refreshToken,
+  );
+  const currentViewer = await BfCurrentViewerAccessToken.create(import.meta, accessToken);
+  logger.info(`${import.meta.url} - impersonating ${currentViewer.personBfGid}`);
+  return currentViewer;
+}


### PR DESCRIPTION
Bugfix: Allow import.meta to fail




Summary:

Jupyter, it turns out, runs outside of the BF_PATH folder, so our logger will fail in interesting ways in jupyter notebooks. This fixes it to use the full pathname if the cwd isn't in the path.

Test Plan:
👀🔥👀🔥👀🔥👀
