### PR TITLE
Fix bff commit

### DIFF
--- a/infra/bff/friends/commit.bff.ts
+++ b/infra/bff/friends/commit.bff.ts
@@ -86,8 +86,8 @@ register(
       "config",
       "--user",
       "github.preferred_submit_command",
-      "pr"
-    ])
+      "pr",
+    ]);
     await runShellCommand([
       "sl",
       "pull",
@@ -100,11 +100,10 @@ register(
     const localhostUrl = `http://localhost:8283/${
       Deno.env.get("REPLIT_SESSION")
     }/files/open-multiple`;
+    
     const vscodeUrl = `vscode://vscode-remote/ssh-remote+${
       Deno.env.get("REPL_ID")
-    }@ssh.${Deno.env.get("REPLIT_CLUSTER")}.replit.dev:22/${
-      Deno.env.get("HOME")
-    }/${REPL_SLUG}`;
+    }@${Deno.env.get("REPLIT_DEV_DOMAIN")}:22${Deno.env.get("REPL_HOME")}`;
 
     await fetch(localhostUrl, {
       method: "POST",


### PR DESCRIPTION
Fix bff commit




Summary:

Replit disabled their old style ssh gateway.

Test Plan:

`bff commit` on any repl
<!-- GitContextStart -->
- - -
This pull request can be reviewed on [<img src="https://gitcontext.com/logo/GitContextButton.svg" height="32" align="absmiddle" alt="GitContext.com"/>](https://gitcontext.com/app/prs/github/bolt-foundry/bolt-foundry/100)
<!-- GitContextEnd -->