### PR TITLE
Deploy fewer dependencies to prod

### DIFF
--- a/infra/bff/friends/build.bff.ts
+++ b/infra/bff/friends/build.bff.ts
@@ -9,7 +9,7 @@ register("build", "Builds the client.", async (_options) => {
 });
 
 register("build:deploy", "build the client and include building the environment", async (_options) => {
-  await buildNix();
+  await buildNix(".#deploy");
   await buildRelay();
   await build();
   return 0;

--- a/infra/bff/friends/nix.bff.ts
+++ b/infra/bff/friends/nix.bff.ts
@@ -1,10 +1,14 @@
 import { runShellCommand } from "infra/bff/shellBase.ts";
 import { register } from "infra/bff/mod.ts";
 
-export function buildNix() {
-  return runShellCommand(["nix", "build", "--out-link", "build/system"]);
+export function buildNix(profile = ".") {
+  return runShellCommand(["nix", "build", profile, "--out-link", "build/system"]);
 }
 
 register("nix", "Builds the current nix system using flake.nix", () => {
   return buildNix();
+});
+
+register("nix:deploy", "Builds the current nix system using flake.nix with only deployment packages", () => {
+  return buildNix(".#deploy");
 });


### PR DESCRIPTION
Deploy fewer dependencies to prod




Summary:

This should shrink the amount of dependencies that make it to production deployments

Test Plan:

`bff nix:deploy` should break sapling
`bff nix` should fix it
<!-- GitContextStart -->
- - -
This pull request can be reviewed on [<img src="https://gitcontext.com/logo/GitContextButton.svg" height="32" align="absmiddle" alt="GitContext.com"/>](https://gitcontext.com/app/prs/github/bolt-foundry/bolt-foundry/107)
<!-- GitContextEnd -->