### PR TITLE
Add ingestion -> ffmpeg stuff

### DIFF
--- a/lib/ffmpegInterface.ts
+++ b/lib/ffmpegInterface.ts
@@ -1,0 +1,58 @@
+import { getLogger } from "deps.ts";
+import startSpinner from "lib/terminalSpinner.ts";
+
+const logger = getLogger(import.meta);
+
+export async function streamFileToFfmpegForChunking(fileStream: ReadableStream<Uint8Array>) {
+  // Step 1: Create a temporary file
+  const tempFilePath = await Deno.makeTempFile();
+  const file = await Deno.create(tempFilePath);
+  await Deno.mkdir(`/tmp/bff`, { recursive: true })
+
+  // Step 2: Write the file stream to the temporary file
+  const writer = file.writable.getWriter();
+  logger.info(`writing to ${tempFilePath}`);
+  let totalWritten = 0;
+  const interval = setInterval(() => {
+    logger.info(`wrote ${(totalWritten / 1_000_000_000).toFixed(2)} gb`);
+  }, 500)
+  const stopSpinner = startSpinner();
+  for await (const chunk of fileStream) {
+    await writer.write(chunk);
+    totalWritten += chunk.length;
+  }
+  stopSpinner();
+  
+  clearInterval(interval);
+  logger.info(`wrote to ${tempFilePath}`);
+  await writer.close();
+
+  const filename = tempFilePath.split("/").pop() as string;
+  
+
+  // Step 3: Set up ffmpeg arguments to read from temp file
+  const ffmpegArgs = []
+  ffmpegArgs.push('-i', tempFilePath);
+  ffmpegArgs.push('-vf', 'crop=ih*(16/9):ih,scale=1920:1080');
+  ffmpegArgs.push('-c:v', 'libx264');
+  ffmpegArgs.push('-b:v', '7M');  // Set bitrate to 7 Megabits per second
+  ffmpegArgs.push('-c:a', 'aac');
+  ffmpegArgs.push('-b:a', '128k');
+  ffmpegArgs.push('-f', 'segment');
+  ffmpegArgs.push('-segment_time', '1800');  // Maximum segment length (~30 minutes)
+  ffmpegArgs.push('-reset_timestamps', '1');
+  ffmpegArgs.push(`/tmp/bff/${filename}%03d.mp4`);
+
+  // Step 4: Run ffmpeg
+  const cmd = new Deno.Command("ffmpeg", {
+    args: ffmpegArgs,
+    env: Deno.env.toObject(),
+  });
+
+  const ffmpegProcess = cmd.spawn();
+  const output = await ffmpegProcess.output();
+  logger.info(`ffmpeg status: ${output.success} / ${output.code}`);
+
+  // Step 5: Clean up temp file
+  await Deno.remove(tempFilePath);
+}

--- a/lib/googleDriveApi.ts
+++ b/lib/googleDriveApi.ts
@@ -1,0 +1,40 @@
+type GoogleDriveMetadata = {
+  id: string;
+  name: string;
+  mimeType: string;
+  parents: string[];
+  webViewLink: string;
+};
+
+export async function fetchMetadata(
+  accessToken: string,
+  fileId: string,
+): Promise<GoogleDriveMetadata> {
+  const url =
+    `https://www.googleapis.com/drive/v3/files/${fileId}?supportsAllDrives=true`;
+  const response = await fetch(url, {
+    method: "GET",
+    headers: new Headers({
+      "Authorization": `Bearer ${accessToken}`,
+      "Accept": "application/json",
+    }),
+  });
+
+  return await response.json();
+}
+
+export async function fetchFile(
+  accessToken: string,
+  fileId: string,
+): Promise<Response> {
+  const url =
+    `https://www.googleapis.com/drive/v3/files/${fileId}?alt=media&supportsAllDrives=true`;
+  const response = await fetch(url, {
+    method: "GET",
+    headers: new Headers({
+      "Authorization": `Bearer ${accessToken}`,
+    }),
+  });
+
+  return response;
+}

--- a/packages/bfDb/models/BfNodeGoogleDriveFile.ts
+++ b/packages/bfDb/models/BfNodeGoogleDriveFile.ts
@@ -1,4 +1,10 @@
 import { BfNode } from "packages/bfDb/coreModels/BfNode.ts";
+import { BfPerson } from "packages/bfDb/models/BfPerson.ts";
+import { fetchFile } from "lib/googleDriveApi.ts";
+import { getLogger } from "deps.ts";
+import { streamFileToFfmpegForChunking } from "lib/ffmpegInterface.ts";
+
+const logger = getLogger(import.meta);
 
 type BfNodeGoogleDriveFileRequiredProps = {
   googleDriveFileId: string,
@@ -6,4 +12,19 @@ type BfNodeGoogleDriveFileRequiredProps = {
 
 export class BfNodeGoogleDriveFile extends BfNode<BfNodeGoogleDriveFileRequiredProps> {
   __typename = "BfNodeGoogleDriveFile" as const;
+  afterCreate() {
+    this.ingest();
+  }
+  async ingest() {
+    const currentViewerAccessToken = await BfPerson.findGoogleApiTokenForCurrentViewer(this.currentViewer);
+    const accessToken = await currentViewerAccessToken.getCurrentAccessToken();
+    const fileResponse = await fetchFile(accessToken, this.props.googleDriveFileId);
+    const fileStream = fileResponse.body;
+    if (fileStream) {
+      await streamFileToFfmpegForChunking(fileStream);
+      logger.info("probably streamed?")
+    }
+    
+  }
+  
 }


### PR DESCRIPTION
Add ingestion -> ffmpeg stuff

Summary:

Downloads videos from google drive to the replit in /tmp and runs them through ffmpeg, outputting them to /tmp/bff/x.mp4

Test Plan:

https://github.com/bolt-foundry/bolt-foundry/assets/448694/0c83a758-5270-4148-be2a-06489f991b00
