### PR TITLE
Add default packages to shell env

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -77,7 +77,7 @@
 
         # `nix develop` and direnv
         devShells.default = pkgs.mkShell {
-          nativeBuildInputs = sharedPackages ++ devShellPackages;
+          nativeBuildInputs = sharedPackages ++ devShellPackages ++ defaultPackages;
         };
       }
     );


### PR DESCRIPTION
Add default packages to shell env

Summary:

This ensures the shell env and the vscode env have all packages.

Test Plan:
https://replit.com/t/bolt-foundry/xjbbzx/repls/fixathon etc.
