### PR TITLE
fix gh no display name

### DIFF
--- a/infra/bff/friends/commit.bff.ts
+++ b/infra/bff/friends/commit.bff.ts
@@ -49,8 +49,11 @@ register(
 
     // who needs a yaml parser when you live on the edge?
     const token = hostsYml.split("oauth_token:")[1].trim().split("\n")[0];
-    // bootcampTASK: some users might not have a display name which will cause an error when committing.
-    const name = nameRaw.trim() ?? "unknown Bolt Foundry Replit contributor";
+    let name = nameRaw.trim();
+    if (name == "") {
+      logger.warn("\n Github user should create a display name on their profile page.\n");
+      name = "unknown Bolt Foundry Replit contributor";
+    }
     const email = emailRaw.trim() ?? "unknown@boltfoundry.com";
     const gitFile = `${XDG_CONFIG_HOME}/git/config`;
     try {
@@ -100,7 +103,7 @@ register(
     const localhostUrl = `http://localhost:8283/${
       Deno.env.get("REPLIT_SESSION")
     }/files/open-multiple`;
-    
+
     const vscodeUrl = `vscode://vscode-remote/ssh-remote+${
       Deno.env.get("REPL_ID")
     }@${Deno.env.get("REPLIT_DEV_DOMAIN")}:22${Deno.env.get("REPL_HOME")}`;

--- a/lib/_readme.md
+++ b/lib/_readme.md
@@ -1,0 +1,3 @@
+The lib directories store typescript components used through the codebase. There are three lib directories so far. The lib directory that a component should go in is determined by its dependencies. 
+
+If the component or file imports app level dependencies, it should go in packages/lib, if it imports client or frontend dependencies it should go in packages/client/lib. If the component doesn't import any dependencies, or imports dependencies from the top level lib, then it will go in /lib

--- a/packages/client/lib/_readme.md
+++ b/packages/client/lib/_readme.md
@@ -1,0 +1,3 @@
+The lib directories store typescript components used through the codebase. There are three lib directories so far. The lib directory that a component should go in is determined by its dependencies. 
+
+If the component or file imports app level dependencies, it should go in packages/lib, if it imports client or frontend dependencies it should go in packages/client/lib. If the component doesn't import any dependencies, or imports dependencies from the top level lib, then it will go in /lib

--- a/packages/lib/_readme.md
+++ b/packages/lib/_readme.md
@@ -1,0 +1,3 @@
+The lib directories store typescript components used through the codebase. There are three lib directories so far. The lib directory that a component should go in is determined by its dependencies. 
+
+If the component or file imports app level dependencies, it should go in packages/lib, if it imports client or frontend dependencies it should go in packages/client/lib. If the component doesn't import any dependencies, or imports dependencies from the top level lib, then it will go in /lib


### PR DESCRIPTION
fix gh no display name

Summary:
Allows user to commit even if they don't have a display name on gh. Shows warning message on console to add display name.

Test Plan:
🥑

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/114).
* __->__ #114
* #113