### PR TITLE
Write video data to the build directory

### DIFF
--- a/lib/ffmpegInterface.ts
+++ b/lib/ffmpegInterface.ts
@@ -3,45 +3,62 @@ import startSpinner from "lib/terminalSpinner.ts";
 
 const logger = getLogger(import.meta);
 
-export async function streamFileToFfmpegForChunking(fileStream: ReadableStream<Uint8Array>) {
+const BF_PATH = Deno.env.get("BF_PATH");
+const BF_TEMP_DIR = `${BF_PATH}/build/tmp`;
+const BF_OUT_PATH = `${BF_TEMP_DIR}/chunks`;
+
+export async function streamFileToFfmpegForChunking(
+  fileStream: ReadableStream<Uint8Array>,
+) {
+  // Step 0: recursively create the temp directory
+  Promise.all([
+    Deno.mkdir(BF_TEMP_DIR, { recursive: true }),
+    Deno.mkdir(BF_OUT_PATH, { recursive: true }),
+  ]);
+
   // Step 1: Create a temporary file
-  const tempFilePath = await Deno.makeTempFile();
+  const tempFilePath = await Deno.makeTempFile({
+    dir: BF_TEMP_DIR,
+  });
   const file = await Deno.create(tempFilePath);
-  await Deno.mkdir(`/tmp/bff`, { recursive: true })
+  await Deno.mkdir(`/tmp/bff`, { recursive: true });
 
   // Step 2: Write the file stream to the temporary file
   const writer = file.writable.getWriter();
   logger.info(`writing to ${tempFilePath}`);
   let totalWritten = 0;
   const interval = setInterval(() => {
-    logger.info(`wrote ${(totalWritten / 1_000_000_000).toFixed(2)} gb`);
-  }, 500)
+    logger.info(
+      `wrote ${
+        (totalWritten / 1_000_000_000).toFixed(2)
+      } gb to ${tempFilePath}`,
+    );
+  }, 500);
   const stopSpinner = startSpinner();
   for await (const chunk of fileStream) {
     await writer.write(chunk);
     totalWritten += chunk.length;
   }
   stopSpinner();
-  
+
   clearInterval(interval);
   logger.info(`wrote to ${tempFilePath}`);
   await writer.close();
 
   const filename = tempFilePath.split("/").pop() as string;
-  
 
   // Step 3: Set up ffmpeg arguments to read from temp file
-  const ffmpegArgs = []
-  ffmpegArgs.push('-i', tempFilePath);
-  ffmpegArgs.push('-vf', 'crop=ih*(16/9):ih,scale=1920:1080');
-  ffmpegArgs.push('-c:v', 'libx264');
-  ffmpegArgs.push('-b:v', '7M');  // Set bitrate to 7 Megabits per second
-  ffmpegArgs.push('-c:a', 'aac');
-  ffmpegArgs.push('-b:a', '128k');
-  ffmpegArgs.push('-f', 'segment');
-  ffmpegArgs.push('-segment_time', '1800');  // Maximum segment length (~30 minutes)
-  ffmpegArgs.push('-reset_timestamps', '1');
-  ffmpegArgs.push(`/tmp/bff/${filename}%03d.mp4`);
+  const ffmpegArgs = [];
+  ffmpegArgs.push("-i", tempFilePath);
+  ffmpegArgs.push("-vf", "crop=ih*(16/9):ih,scale=1920:1080");
+  ffmpegArgs.push("-c:v", "libx264");
+  ffmpegArgs.push("-b:v", "7M"); // Set bitrate to 7 Megabits per second
+  ffmpegArgs.push("-c:a", "aac");
+  ffmpegArgs.push("-b:a", "128k");
+  ffmpegArgs.push("-f", "segment");
+  ffmpegArgs.push("-segment_time", "1800"); // Maximum segment length (~30 minutes)
+  ffmpegArgs.push("-reset_timestamps", "1");
+  ffmpegArgs.push(`${BF_OUT_PATH}/${filename}_⚡️_%03d.mp4`);
 
   // Step 4: Run ffmpeg
   const cmd = new Deno.Command("ffmpeg", {


### PR DESCRIPTION
Write video data to the build directory




Summary:

For now, replit has a bug where if you store to /tmp it can die... so we're storing it in our build directory.

Test Plan:
<!-- GitContextStart -->
- - -
This pull request can be reviewed on [<img src="https://gitcontext.com/logo/GitContextButton.svg" height="32" align="absmiddle" alt="GitContext.com"/>](https://gitcontext.com/app/prs/github/bolt-foundry/bolt-foundry/128)
<!-- GitContextEnd -->