### PR TITLE
Remove log spew

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -5,7 +5,7 @@ import * as RelayRuntime from "relay-runtime";
 // @deno-types="https://esm.sh/v135/@types/react@18.2.38/index.d.ts";
 import * as React from "react";
 export * as rxjs from "https://esm.sh/rxjs@7.8.1";
-export { RelayRuntime }
+export { RelayRuntime };
 RelayRuntime.RelayFeatureFlags.ENABLE_RELAY_RESOLVERS = true;
 
 // log stuff and random exports
@@ -18,7 +18,7 @@ chalk.level = 3;
 
 export { React };
 
-log.setDefaultLevel(log.levels.TRACE);
+log.setDefaultLevel(log.levels.INFO);
 
 const colors = {
   TRACE: chalk.magenta,
@@ -29,9 +29,10 @@ const colors = {
 };
 
 if (!isBrowser()) {
-  console.log("No enabled loggers specified, enabling all loggers");
-  log.enableAll();
-
+  const defaultLogLevelString = Deno.env.get("LOG_LEVEL") ?? "INFO";
+  const defaultLogLevel =
+    log.levels[defaultLogLevelString as keyof typeof log.levels];
+  log.setDefaultLevel(defaultLogLevel);
   logLevelPrefixPlugin.reg(log);
   logLevelPrefixPlugin.apply(log, {
     template: "%n - %l: ",
@@ -62,8 +63,15 @@ export function getLogger(importMeta: ImportMeta | string) {
   }
   // get relative url and remove leading slash
   const relativePathname = url.pathname.split(Deno.cwd())[1];
-  const pathName = relativePathname ? relativePathname.replace(/^\//, "") : url.pathname;
-  return log.getLogger(pathName);
+  const pathName = relativePathname
+    ? relativePathname.replace(/^\//, "")
+    : url.pathname;
+  const logger = log.getLogger(pathName);
+  const defaultLogLevelString = Deno.env.get("LOG_LEVEL") ?? "INFO";
+  const defaultLogLevel =
+    log.levels[defaultLogLevelString as keyof typeof log.levels];
+  logger.setDefaultLevel(defaultLogLevel);
+  return logger;
 }
 
 export type Maybe<T> = T | null | undefined;

--- a/infra/build/bffEsbuild.ts
+++ b/infra/build/bffEsbuild.ts
@@ -15,7 +15,6 @@ const vendorManifestFile = await Deno.readTextFile(vendorManifestFilePath);
 const vendorManifest = JSON.parse(vendorManifestFile);
 
 const cacheLocations = await getCacheLocations();
-
 const extractGraphqlTags = (contents: string) => {
   const matches = Array.from(contents.matchAll(/graphql`([\s\S]+?)`/g)).map(
     (match) => match[1].trim(),
@@ -253,7 +252,7 @@ export const denoPlugin = {
           const [specifierWithNoSlash, ...rest] = url.pathname.split("/")
           const specifier = `npm:${specifierWithNoSlash}`;
           const resolvedSpecifier = denoLock.packages.specifiers[specifier];
-          logger.debug(
+          logger.trace(
             `Resolved specifier: ${resolvedSpecifier} for ${specifier} from ${args.path}`,
           );
           const packageSpecifier =
@@ -262,7 +261,7 @@ export const denoPlugin = {
           const packagePath =
             `${cacheLocations.npmModulesCache}/${packageName}/${packageVersion}`;
           const packageJsonPath = join(packagePath, "package.json");
-          logger.debug(`Loading ${packageJsonPath}`);
+          logger.trace(`Loading ${packageJsonPath}`);
           const packageJsonString = await Deno.readTextFile(packageJsonPath);
           const packageJson = JSON.parse(packageJsonString);
           const main = packageJson.main ?? "index.js";
@@ -328,7 +327,7 @@ export const denoPlugin = {
       const ext = args.path.match(/[^.]+$/);
       const loader = (ext ? ext[0] : "ts") as esbuild.Loader;
 
-      logger.debug(`Loading local module: ${args.path}`);
+      logger.trace(`Loading local module: ${args.path}`);
       return { contents, loader };
     });
 
@@ -345,7 +344,7 @@ export const denoPlugin = {
       `;
       const loader = "js"; // JavaScript loader for the content
 
-      logger.debug(`Handling 'empty' namespace for module: ${args.path}`);
+      logger.trace(`Handling 'empty' namespace for module: ${args.path}`);
       return { contents, loader };
     });
   },

--- a/infra/graphql/graphql.ts
+++ b/infra/graphql/graphql.ts
@@ -30,11 +30,11 @@ export async function handler(request: Request): Promise<Response> {
   const ctx = await getContextFromRequest(request);
 
   const yogaResponse = await yoga(request, ctx);
-  logger.debug("headers", ctx.responseHeaders);
+  logger.trace("headers", ctx.responseHeaders);
   for (const [key, value] of ctx.responseHeaders.entries()) {
     yogaResponse.headers.append(key, value);
   }
 
-  logger.debug("yoga response", yogaResponse);
+  logger.trace("yoga response", yogaResponse);
   return yogaResponse;
 }

--- a/packages/bfDb/classes/BfModel.ts
+++ b/packages/bfDb/classes/BfModel.ts
@@ -34,8 +34,8 @@ import {
 } from "packages/bfDb/classes/BfModelError.ts";
 import { getLogger } from "deps.ts";
 const logger = getLogger(import.meta);
-const logVerbose = logger.debug;
-const log = logger.info;
+const logVerbose = logger.trace;
+const log = logger.trace;
 
 function metadataToBfPk(metadata: BfBaseModelMetadata): BfPk {
   if (metadata.bfPid) {


### PR DESCRIPTION
Remove log spew




Summary:

Removes a lot of rando log spew from the console. Building right now is still erroring, but we can figure that out later.

Test Plan:

run, check logs. Change env var LOG_LEVEL if you want.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/132).
* #133
* __->__ #132
* #131