### PR TITLE
Add a util to reset db stuff

### DIFF
--- a/infra/bff/friends/db.bff.ts
+++ b/infra/bff/friends/db.bff.ts
@@ -1,0 +1,15 @@
+
+
+import { register } from "infra/bff/mod.ts";
+import { __DANGEROUSLY_DESTROY_THE_DATABASE__ } from "packages/bfDb/utils.ts";
+import { upsertBfDb } from "packages/bfDb/utils.ts";
+
+
+register("db:reset", "Resets the db, but only in development mode", async () => {
+  if (Deno.env.get("BF_ENV") === "DEVELOPMENT") {
+    await __DANGEROUSLY_DESTROY_THE_DATABASE__("I KNOW THIS IS GOING TO DESTROY EVERYTHING AND I WANT TO DO THAT");
+    await upsertBfDb();
+    return 0;
+  }
+  return 1337
+});


### PR DESCRIPTION
Add a util to reset db stuff




Summary:

Test Plan:

`bff db:reset` should only work in dev.
<!-- GitContextStart -->
- - -
This pull request can be reviewed on [<img src="https://gitcontext.com/logo/GitContextButton.svg" height="32" align="absmiddle" alt="GitContext.com"/>](https://gitcontext.com/app/prs/github/bolt-foundry/bolt-foundry/156)
<!-- GitContextEnd -->