### PR TITLE
add notion task on upload success

### DIFF
--- a/experimental/randallb/watcher/addClipToNotion.ts
+++ b/experimental/randallb/watcher/addClipToNotion.ts
@@ -1,0 +1,40 @@
+#! /usr/bin/env -S deno run -A
+
+import { notifyDiscord } from "./ingest.ts";
+import { addRowToNotion } from "./notionApi.ts";
+
+if (import.meta.main) {
+  const res = await addClipToNotion(
+    "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    "main test",
+  );
+  const url = (await res.json()).url;
+  await notifyDiscord(`<@&1210008885193211944> New task: ${url}`);
+}
+
+export function addClipToNotion(urlToSandbox: string, taskTitle: string) {
+  return addRowToNotion({
+    icon: {
+      type: "emoji",
+      emoji: "📎", // You can change this icon according to your requirement.
+    },
+    properties: {
+      "Task name": {
+        type: "title",
+        title: [
+          {
+            type: "text",
+            text: {
+              content: taskTitle,
+            },
+          },
+        ],
+      },
+      "link to sandbox": {
+        type: "url",
+        url: urlToSandbox,
+      },
+    },
+    children: [],
+  });
+}

--- a/experimental/randallb/watcher/notionApi.ts
+++ b/experimental/randallb/watcher/notionApi.ts
@@ -1,0 +1,33 @@
+const NOTION_API_KEY = Deno.env.get("NOTION_API_KEY");
+const BFI_NOTION_DATABASE_ID = Deno.env.get("BFI_NOTION_DATABASE_ID");
+
+interface ClipTaskNotionRow<T = Record<string, unknown>> {
+  icon: Record<string, unknown>;
+  properties: T;
+  children: Record<string, unknown>[];
+}
+
+export async function addRowToNotion(
+  row: ClipTaskNotionRow,
+): Promise<Response> {
+  const url = `https://api.notion.com/v1/pages`;
+
+  const payload = {
+    ...row,
+    parent: { database_id: BFI_NOTION_DATABASE_ID },
+  };
+
+  const headers = {
+    "Authorization": `Bearer ${NOTION_API_KEY}`,
+    "Content-Type": "application/json",
+    "Notion-Version": "2022-06-28",
+  };
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: headers,
+    body: JSON.stringify(payload),
+  });
+
+  return response;
+}


### PR DESCRIPTION
add notion task on upload success

Summary:  a task gets made in notion for the chuncked file and notifies in Discord

Test Plan:<img width="957" alt="Screenshot 2024-06-20 at 12 57 51 PM" src="https://github.com/bolt-foundry/bolt-foundry/assets/87879951/74ae1bd4-cda2-46a1-98c2-0b4beb6a8667">
<img width="1276" alt="Screenshot 2024-06-20 at 12 58 08 PM" src="https://github.com/bolt-foundry/bolt-foundry/assets/87879951/4b5cc49d-9f46-4b6c-892b-2514ee5b9edb">
