### PR TITLE
Remove packages from replit.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,11 +40,23 @@
         # Add to this to make it available in VS Code and most places on the system. The larger this is, the larger the deploy, so try to keep it slim.
         # Be sure to run `bff nix` to build
         defaultPackages = with pkgs; [
+          watchman
+          sapling
+          gh
+          jupyter
         ];
 
         # These are dev-only packages, used for building etc. They're only available where direnv is available, ie the replit shell.
         # these packages show up with "direnv allow"
         devShellPackages = with pkgs; [
+          jq
+          emscripten
+          pkg-config
+          clang_12
+          ccls
+          gdb
+          gnumake
+          emscripten
         ];
 
         deployPackages = with pkgs; [

--- a/replit.nix
+++ b/replit.nix
@@ -4,18 +4,7 @@
   ];
   dev = {
     deps = with pkgs; [
-      jq
-      emscripten
-      pkg-config
-      clang_12
-      ccls
-      gdb
-      gnumake
-      emscripten
-      watchman
-      sapling
-      gh
-      jupyter
+      
     ];
   };
 }


### PR DESCRIPTION
Remove packages from replit.nix




Summary:

Had to remove a bunch of pkgs here b/c they show up in the size reported to replit or something.

Test Plan:
<!-- GitContextStart -->
- - -
This pull request can be reviewed on [<img src="https://gitcontext.com/logo/GitContextButton.svg" height="32" align="absmiddle" alt="GitContext.com"/>](https://gitcontext.com/app/prs/github/bolt-foundry/bolt-foundry/168)
<!-- GitContextEnd -->