### PR TITLE
Throw error if you're not logged in when accessing the graphql endpoint

### DIFF
--- a/packages/web/web.ts
+++ b/packages/web/web.ts
@@ -10,6 +10,8 @@ import { handler as graphQlHandler } from "packages/graphql/graphql.ts";
 import { getGoogleOauthUrl } from "lib/googleOauth.ts";
 import { redirectIfNotLoggedIn, theAwsApp } from "/aws/clientRenderer/main.ts";
 import { getHeaders } from "/experimental/randallb/watcher/ingest.ts";
+import { getContextFromRequest } from "packages/bfDb/getCurrentViewer.ts";
+import { BfCurrentViewerAccessToken } from "packages/bfDb/classes/BfCurrentViewer.ts";
 
 const logger = getLogger(import.meta);
 export enum DeploymentTypes {
@@ -240,6 +242,11 @@ routes.set("/google/oauth/end", (req) => {
 
 routes.set("/graphql", graphQlHandler);
 routes.set("/aws-graphql", async (req) => {
+  const { bfCurrentViewer } = await getContextFromRequest(req);
+  if (!(bfCurrentViewer instanceof BfCurrentViewerAccessToken)) {
+    throw new Error('no thanks.')
+  }
+  
   const headersFromGraphql = await getHeaders();
   const {
     headers,


### PR DESCRIPTION
Throw error if you're not logged in when accessing the graphql endpoint




Summary:

Test Plan:
<!-- GitContextStart -->
- - -
This pull request can be reviewed on [<img src="https://gitcontext.com/logo/GitContextButton.svg" height="32" align="absmiddle" alt="GitContext.com"/>](https://gitcontext.com/app/prs/github/bolt-foundry/bolt-foundry/171)
<!-- GitContextEnd -->