### PR TITLE
Show last settings preset selected

### DIFF
--- a/aws/client/components/SettingsForm.tsx
+++ b/aws/client/components/SettingsForm.tsx
@@ -131,6 +131,9 @@ export default function SettingsForm(
     setInitialSettings,
   }: Props,
 ) {
+
+  const [currentPreset, setCurrentPreset] = React.useState<string | null>(null);
+
   const settings = useFragment(settingsFragment, settings$key);
   const initialSettings = settings ?? DEFAULT_SETTINGS;
   const enableToggleWatermark = useFeatureFlag("toggle_watermark");
@@ -210,13 +213,14 @@ export default function SettingsForm(
               <DropdownSelector
                 options={settingsPresetsOptions}
                 onChange={(preset) => {
+                  setCurrentPreset(preset);
                   const newSettings = {
                     ...draftSettings,
                     ...settingsPresets[preset],
                   };
                   setDraftSettings(newSettings);
                 }}
-                value=""
+                value={currentPreset ?? ""}
                 placeholder="Load a preset..."
                 testId="presetSelector"
               />


### PR DESCRIPTION
Show last settings preset selected

Summary:
Adds an onChange functionality that will save the last selected settings preset to a new state variable. The preset drop down menu will show that state or the default tet.

Test Plan: 🐡

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/199).
* #201
* #200
* __->__ #199