### PR TITLE
Add useEffect for presets

### DIFF
--- a/aws/client/components/SettingsForm.tsx
+++ b/aws/client/components/SettingsForm.tsx
@@ -131,6 +131,9 @@ export default function SettingsForm(
     setInitialSettings,
   }: Props,
 ) {
+
+  const [currentPreset, setCurrentPreset] = React.useState<string | null>(null);
+
   const settings = useFragment(settingsFragment, settings$key);
   const initialSettings = settings ?? DEFAULT_SETTINGS;
   const enableToggleWatermark = useFeatureFlag("toggle_watermark");
@@ -210,13 +213,14 @@ export default function SettingsForm(
               <DropdownSelector
                 options={settingsPresetsOptions}
                 onChange={(preset) => {
+                  setCurrentPreset(preset);
                   const newSettings = {
                     ...draftSettings,
                     ...settingsPresets[preset],
                   };
                   setDraftSettings(newSettings);
                 }}
-                value=""
+                value={currentPreset ?? ""}
                 placeholder="Load a preset..."
                 testId="presetSelector"
               />

--- a/aws/client/components/SettingsForm.tsx
+++ b/aws/client/components/SettingsForm.tsx
@@ -131,7 +131,6 @@ export default function SettingsForm(
     setInitialSettings,
   }: Props,
 ) {
-
   const [currentPreset, setCurrentPreset] = React.useState<string | null>(null);
 
   const settings = useFragment(settingsFragment, settings$key);
@@ -150,6 +149,37 @@ export default function SettingsForm(
       setInitialSettings(initialSettings as Partial<Settings>);
     }
   }, [initialSettings]);
+
+  // Compare initial settings with presets whenever initialSettings change
+  React.useEffect(() => {
+    /**
+     * Compare initial settings with available presets.
+     * @returns {string|null} The key of the matching preset, or null if no match is found.
+     */
+    const compareInitialSettingsWithPresets = (): string | null => {
+      // Iterate over each preset to find a match
+      for (const presetKey of Object.keys(settingsPresets)) {
+        const preset = settingsPresets[presetKey];
+        // Check if all the keys in the preset match the initial settings
+        if (
+          Object.keys(preset).every((key) => {
+            const keyTyped = key as keyof Settings;
+            const areEqual = initialSettings[keyTyped] ===
+              (preset as Partial<Settings>)[keyTyped];
+            return areEqual;
+          })
+        ) {
+          return presetKey; // Return the key of the matching preset
+        }
+      }
+      return null; // Return null if no matching preset is found
+    };
+    // Get the key of the matching preset
+    const presetKey = compareInitialSettingsWithPresets();
+    if (presetKey) {
+      setCurrentPreset(presetKey); // Set the current preset state if match is found
+    }
+  }, []);
 
   const captionColorValue = rgbToHex(
     draftSettings.captionColor ?? initialSettings.captionColor ??

--- a/aws/client/components/SettingsProjectSidebar.tsx
+++ b/aws/client/components/SettingsProjectSidebar.tsx
@@ -41,7 +41,7 @@ export default function Settings({ project$key }: Props) {
   }
   const data = useFragment(fragment, project$key);
 
-  const [initialSettings, setIntialSettings] = React.useState<
+  const [initialSettings, setInitialSettings] = React.useState<
     Partial<Settings>
   >(data.effectiveSettings as Partial<Settings>);
   const [draftSettings, setDraftSettings] = React.useState({});
@@ -86,7 +86,7 @@ export default function Settings({ project$key }: Props) {
         setDraftSettings={setDraftSettings}
         changedSettings={changedSettings}
         settings$key={data.effectiveSettings}
-        setInitialSettings={setIntialSettings}
+        setInitialSettings={setInitialSettings}
       />
       <div className="submitRow">
         <Button


### PR DESCRIPTION
Add useEffect for presets

Summary:
Preset selector will now show current preset after page refresh.

Test Plan:

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/200).
* #201
* __->__ #200
* #199