### PR TITLE
Swap to old audio thing now that we're using rbServe™

### DIFF
--- a/aws/client/lib/BFRenderer.ts
+++ b/aws/client/lib/BFRenderer.ts
@@ -842,8 +842,8 @@ export default class BFRenderer {
   }
 
   async setupAudioRendering() {
-    return await this.setupAudioRenderingUsingVideoElement();
-    // return await this.setupAudioRenderingUsingFetch();
+    // return await this.setupAudioRenderingUsingVideoElement();
+    return await this.setupAudioRenderingUsingFetch();
   }
 
   async seekVideoElements(currentTimecode: number) {


### PR DESCRIPTION
Swap to old audio thing now that we're using rbServe™




Summary:

We originally hacked in this way of making audio b/c it takes forever to download the original video... but now we've moved our setup to rbServe™ so we shouldn't have this issue anymore. This method is much more reliable to extract audio which is synced.

Test Plan:
<!-- GitContextStart -->
- - -
This pull request can be reviewed on [<img src="https://gitcontext.com/logo/GitContextButton.svg" height="32" align="absmiddle" alt="GitContext.com"/>](https://gitcontext.com/app/prs/github/bolt-foundry/bolt-foundry/204)
<!-- GitContextEnd -->