### PR TITLE
Change deploy so it deletes the histfile

### DIFF
--- a/infra/bff/friends/deploy.bff.ts
+++ b/infra/bff/friends/deploy.bff.ts
@@ -49,6 +49,7 @@ register(
       "-m",
       logInfo.summary,
     ]);
+    await Deno.remove(Deno.env.get("HISTFILE")!);
     return 0;
   },
 );


### PR DESCRIPTION
Change deploy so it deletes the histfile




Summary:

Removes histfile from repls so future users don't have any history

Test Plan:
