### PR TITLE
clean up edit modes

### DIFF
--- a/aws/client/components/ClipList.tsx
+++ b/aws/client/components/ClipList.tsx
@@ -25,6 +25,7 @@ import {
 } from "aws/types/settings.ts";
 import useIntersectionObserver from "aws/client/hooks/useIntersectionObserver.tsx";
 import { RenderSettings } from "aws/types/settings.ts";
+import { ClipProvider } from "/aws/client/contexts/ClipContext.tsx";
 
 const { useEffect, useState, useRef, Suspense } = React;
 
@@ -419,27 +420,29 @@ export default function ClipList({ project$key, gotoClip, videoSrc }: Props) {
             kind="clip editor"
             contentXstyle={styles.contentXstyle}
           >
-            <ClipEdit
-              clip$key={clipItemsToRender[selectedClipIndex]
-                ?.node as useClipEditData_clip$key}
-              clipIndex={selectedClipIndex}
-              isSaved={false}
-              setClipChanged={setClipChanged}
-              setClickOutsideToCloseModal={setClickOutsideToCloseModal}
-              settings={settings}
-              transcriptId={transcriptId}
-              transcriptWords={transcriptWords}
-              videoUrl={data?.opurl ?? data?.videoUrl ?? ""}
-              onEditClip={() => {
-                setClipChanged(false);
-                setSelectedClipIndex(null);
-              }}
-              onSaveClip={(wordsToUpdate) => {
-                updateTranscriptWords(wordsToUpdate);
-                setClipChanged(false);
-                setSelectedClipIndex(null);
-              }}
-            />
+            <ClipProvider>
+              <ClipEdit
+                clip$key={clipItemsToRender[selectedClipIndex]
+                  ?.node as useClipEditData_clip$key}
+                clipIndex={selectedClipIndex}
+                isSaved={false}
+                setClipChanged={setClipChanged}
+                setClickOutsideToCloseModal={setClickOutsideToCloseModal}
+                settings={settings}
+                transcriptId={transcriptId}
+                transcriptWords={transcriptWords}
+                videoUrl={data?.opurl ?? data?.videoUrl ?? ""}
+                onEditClip={() => {
+                  setClipChanged(false);
+                  setSelectedClipIndex(null);
+                }}
+                onSaveClip={(wordsToUpdate) => {
+                  updateTranscriptWords(wordsToUpdate);
+                  setClipChanged(false);
+                  setSelectedClipIndex(null);
+                }}
+              />
+            </ClipProvider>
           </Modal>
         )}
     </>

--- a/aws/client/components/CropModeWord.tsx
+++ b/aws/client/components/CropModeWord.tsx
@@ -1,88 +1,126 @@
 import { React } from "aws/client/deps.ts";
 import Icon from "/aws/client/ui_components/Icon.tsx";
 import { DGWord } from "/aws/types/transcript.ts";
-import { VideoPlayerHandles } from "/aws/client/components/VideoPlayer.tsx";
-import { ManualCrop } from "/aws/client/components/ManualCropMenu.tsx";
+import { ManualCrop, getCurrentCrop } from "/aws/client/components/ManualCropMenu.tsx";
+import { WordData } from "/aws/client/components/ClipEdit.tsx";
+import classnames from "/aws/client/lib/classnames.ts";
+import { useClipContext } from "/aws/client/contexts/ClipContext.tsx";
+import { ClipReducerState } from "/aws/client/hooks/useClipEditData.tsx";
 
 type Props = {
-  handleChangeManualCropStartTime: (word: DGWord, newStartTime: number) => void;
+  goto: (time: number) => void;
   manualCrop: Array<ManualCrop>;
-  videoPlayerRef: React.RefObject<VideoPlayerHandles>;
-  word: DGWord;
+  updateManualCrop: (manualCrop: Array<ManualCrop>) => void;
+  state: ClipReducerState,
+  wordData: WordData;
 };
 
 export function CropModeWord(
   {
-    handleChangeManualCropStartTime,
+    goto,
     manualCrop,
-    videoPlayerRef,
-    word,
+    updateManualCrop,
+    state,
+    wordData,
   }: Props,
 ) {
-  const [newStartTime, setNewStartTime] = React.useState(word.start);
-  const [inputValue, setInputValue] = React.useState(word.start);
+  const {
+    setCroppingWord,
+  } = useClipContext();
+  const {
+    index,
+    word,
+    renderedWord,
+    isCurrentWord,
+    isExtraText,
+  } = wordData;
+  const [inputValue, setInputValue] = React.useState<number | null>(null);
   const [rangeWidth, setRangeWidth] = React.useState(0);
   const rangeInputRef = React.useRef<HTMLInputElement>(null);
   const cropLineRef = React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {
-    const currentCropIndex = manualCrop.findIndex((crop) =>
-      crop.start >= word.start && crop.start < word.end
-    );
-    const currentCrop = currentCropIndex !== -1
-      ? manualCrop[currentCropIndex]
-      : undefined;
-    // Set initial value based on saved start time
-    const start = currentCrop?.start ?? word.start;
-    setNewStartTime(start);
-    setInputValue(start);
+    if (inputValue) {
+      goto(inputValue);
+    }
+  }, [inputValue])
+
+  React.useEffect(() => {
     // Set the width of the range input to match the cropLine element's width
     if (cropLineRef.current) {
       setRangeWidth(cropLineRef.current.getBoundingClientRect().width);
     }
-  }, [word]);
+  }, [cropLineRef])
 
-  const handleRangeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newValue = parseFloat(e.target.value);
-    setNewStartTime(newValue);
-    videoPlayerRef.current?.gotoTime(newValue);
-  };
+  const currentCrop = getCurrentCrop(state.manualCrop, word.start);
+  const initialValue = currentCrop?.start;
+
+  function handleChangeManualCropStartTime(word: DGWord, newCropStart: number) {
+    const manualCropData = [...state.manualCrop] as Array<ManualCrop>;
+    const currentCropIndex = manualCropData.findIndex((crop) =>
+      crop.start >= word.start && crop.start < word.end
+    );
+    if (currentCropIndex > -1) {
+      manualCropData[currentCropIndex].start = newCropStart;
+    }
+    updateManualCrop(manualCropData);
+  }
+
+  function handleEditCrop(cropWord: DGWord, start: number) {
+    goto(start);
+    setCroppingWord(cropWord);
+  }
+
   const handleRangeCommit = () => {
-    handleChangeManualCropStartTime(word, newStartTime);
+    handleChangeManualCropStartTime(word, inputValue ?? initialValue);
   };
   const isCropKeyframe = manualCrop.some(
     (crop) => crop.start >= word.start && crop.start < word.end,
   );
 
   return (
-    <div className="cropLine" ref={cropLineRef}>
-      {isCropKeyframe && (
-        <>
-          <div className="isCroppedIcon">
-            <Icon
-              color="white"
-              name="crop"
-              size={12}
+    <span
+      key={index}
+      className={classnames([
+        "clipWord",
+        { clipWordLight: isExtraText },
+        { clipCurrentWord: isCurrentWord },
+      ])}
+      onClick={() =>
+        goto(word.start)}
+      onDoubleClick={() => {
+        handleEditCrop(word, currentCrop?.start ?? word.start);
+      }}
+    >
+      {renderedWord}
+      <div className="lineHighlight cropLine" ref={cropLineRef}>
+        {isCropKeyframe && (
+          <>
+            <div className="isCroppedIcon">
+              <Icon
+                color="white"
+                name="crop"
+                size={12}
+              />
+            </div>
+            <input
+              ref={rangeInputRef}
+              type="range"
+              min={word.start}
+              max={word.end}
+              step={0.01}
+              value={inputValue ?? initialValue}
+              onChange={(e) => {
+                setInputValue(parseFloat(e.target.value));
+              }}
+              onMouseUp={handleRangeCommit}
+              onTouchEnd={handleRangeCommit}
+              className="cropRangeInput"
+              style={{ width: rangeWidth }}
             />
-          </div>
-          <input
-            ref={rangeInputRef}
-            type="range"
-            min={word.start}
-            max={word.end}
-            step={0.01}
-            value={inputValue}
-            onChange={(e) => {
-              handleRangeChange(e);
-              setInputValue(parseFloat(e.target.value));
-            }}
-            onMouseUp={handleRangeCommit}
-            onTouchEnd={handleRangeCommit}
-            className="cropRangeInput"
-            style={{ width: rangeWidth }}
-          />
-        </>
-      )}
-    </div>
+          </>
+        )}
+      </div>
+    </span>
   );
 }

--- a/aws/client/components/ManualCropMenu.tsx
+++ b/aws/client/components/ManualCropMenu.tsx
@@ -22,6 +22,14 @@ export function getCurrentCropIndex(
   }
   return manualCrop.findLastIndex((crop) => currentTime >= crop.start);
 }
+export function getCurrentCrop(
+  manualCrop: Array<ManualCrop>,
+  currentTime: number,
+  startTimecode?: number,
+): ManualCrop {
+  const currentCropIndex = getCurrentCropIndex(manualCrop, currentTime, startTimecode);
+  return manualCrop[currentCropIndex];
+}
 export const DEFAULT_CROP = {
   start: 0,
   top: 0,

--- a/aws/client/components/StickerModeWord.tsx
+++ b/aws/client/components/StickerModeWord.tsx
@@ -1,89 +1,116 @@
 import { React } from "aws/client/deps.ts";
 import Icon from "/aws/client/ui_components/Icon.tsx";
 import { DGWord } from "/aws/types/transcript.ts";
-import { VideoPlayerHandles } from "/aws/client/components/VideoPlayer.tsx";
-
+import { WordData } from "/aws/client/components/ClipEdit.tsx";
+import { useClipContext } from "/aws/client/contexts/ClipContext.tsx";
+import classnames from "/aws/client/lib/classnames.ts";
 
 type Props = {
-  handleChangeStickerStartTime (word: DGWord) : void;
-  handleChangeStickerEndTime (word: DGWord) : void;
-  videoPlayerRef: React.RefObject<VideoPlayerHandles>;
-  word: DGWord;
+  goto: (index: number) => void;
+  wordData: WordData;
 };
 
 export function StickerModeWord(
   {
-    handleChangeStickerStartTime,
-    handleChangeStickerEndTime,
-    videoPlayerRef,
-    word,
+    goto,
+    wordData,
   }: Props,
 ) {
-  return null;
-  // const [newStartTime, setNewStartTime] = React.useState(word.start);
-  // const [inputValue, setInputValue] = React.useState(word.start);
-  // const [rangeWidth, setRangeWidth] = React.useState(0);
-  // const rangeInputRef = React.useRef<HTMLInputElement>(null);
-  // const stickerLineRef = React.useRef<HTMLDivElement>(null);
+  const {
+    stickerStartWord,
+    setStickerStartWord,
+    stickerEndWord,
+    setStickerEndWord,
+  } = useClipContext();
+  const {
+    index,
+    word,
+    renderedWord,
+    isCurrentWord,
+    isExtraText,
+  } = wordData;
+  const [inputValue, setInputValue] = React.useState(word.start);
+  const [rangeWidth, setRangeWidth] = React.useState(0);
+  const rangeInputRef = React.useRef<HTMLInputElement>(null);
+  const stickerLineRef = React.useRef<HTMLDivElement>(null);
 
-  // React.useEffect(() => {
-  //   const currentStickerIndex = .findIndex(() =>
-  //     crop.start >= word.start && crop.start < word.end
-  //   );
-  //   const currentCrop = currentCropIndex !== -1
-  //     ? manualCrop[currentCropIndex]
-  //     : undefined;
-  //   // Set initial value based on saved start time
-  //   const start = currentCrop?.start ?? word.start;
-  //   setNewStartTime(start);
-  //   setInputValue(start);
-  //   // Set the width of the range input to match the cropLine element's width
-  //   if (cropLineRef.current) {
-  //     setRangeWidth(cropLineRef.current.getBoundingClientRect().width);
-  //   }
-  // }, [word]);
+  function handleChangeStickerStartTime(word: DGWord) {
+    setStickerStartWord(word)
+  }
+  function handleChangeStickerEndTime(word: DGWord) {
+    setStickerEndWord(word)
+  }
 
-  // const handleRangeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-  //   const newValue = parseFloat(e.target.value);
-  //   setNewStartTime(newValue);
-  //   videoPlayerRef.current?.gotoTime(newValue);
-  // };
-  // const handleRangeCommit = () => {
-  //   handleChangeStickerStartTime(word, newStartTime);
-  // };
-  // const isCropKeyframe = manualCrop.some(
+  const handleRangeCommit = () => {
+    handleChangeStickerStartTime(word);
+  };
+  const isStickerKeyframe = false;
+  // const isStickerKeyframe = manualCrop.some(
   //   (crop) => crop.start >= word.start && crop.start < word.end,
   // );
 
-  // return (
-  //   <div className="cropLine" ref={cropLineRef}>
-  //     {isCropKeyframe && (
-  //       <>
-  //         <div className="isCroppedIcon">
-  //           <Icon
-  //             color="white"
-  //             name="crop"
-  //             size={12}
-  //           />
-  //         </div>
-  //         <input
-  //           ref={rangeInputRef}
-  //           type="range"
-  //           min={word.start}
-  //           max={word.end}
-  //           step={0.01}
-  //           value={inputValue}
-  //           onChange={(e) => {
-  //             handleRangeChange(e);
-  //             setInputValue(parseFloat(e.target.value));
-  //           }}
-  //           onMouseUp={handleRangeCommit}
-  //           onTouchEnd={handleRangeCommit}
-  //           className="cropRangeInput"
-  //           style={{ width: rangeWidth }}
-  //         />
-  //       </>
-  //     )}
-  //   </div>
-  // );
+  return (
+    <span
+      key={index}
+      className={classnames([
+        "clipWord",
+        { clipWordLight: isExtraText },
+        { clipCurrentWord: isCurrentWord },
+      ])}
+      onClick={() =>
+        goto(word.start)}
+      onDoubleClick={() => {
+        if (stickerStartWord) {
+          setStickerEndWord(word);
+          // handleDispatchAction(
+          //   ActionType.SET_STICKER_END_TIME,
+          //   word.end,
+          // );
+          console.log("last word set");
+          console.log(stickerStartWord);
+          console.log(stickerEndWord);
+        } else {
+          setStickerStartWord(word);
+          // handleDispatchAction(
+          //   ActionType.SET_STICKER_START_TIME,
+          //   word.start,
+          // );
+
+          console.log("first word set");
+          console.log(stickerStartWord);
+          console.log(stickerEndWord);
+        }
+      }}
+    >
+      {renderedWord}
+      <div className="lineHighlight stickerLine" ref={stickerLineRef}>
+        {isStickerKeyframe && (
+          <>
+            <div className="isCroppedIcon">
+              <Icon
+                color="white"
+                name="starSolid"
+                size={12}
+              />
+            </div>
+            <input
+              ref={rangeInputRef}
+              type="range"
+              min={word.start}
+              max={word.end}
+              step={0.01}
+              value={inputValue}
+              onChange={(e) => {
+                setInputValue(parseFloat(e.target.value));
+              }}
+              onMouseUp={handleRangeCommit}
+              onTouchEnd={handleRangeCommit}
+              className="cropRangeInput"
+              style={{ width: rangeWidth }}
+            />
+          </>
+        )}
+      </div>
+    </span>
+  );
 }

--- a/aws/client/components/TextModeWord.tsx
+++ b/aws/client/components/TextModeWord.tsx
@@ -1,0 +1,131 @@
+import {React} from "aws/client/deps.ts";
+import classnames from "/aws/client/lib/classnames.ts";
+import WordMenu from "/aws/client/components/WordMenu.tsx";
+import { useClipContext } from "/aws/client/contexts/ClipContext.tsx";
+import { ActionType, ClipReducerAction, ClipReducerState } from "/aws/client/hooks/useClipEditData.tsx";
+import { WordData } from "/aws/client/components/ClipEdit.tsx";
+
+type Props = {
+  endTimeOverride: number | null;
+  wordData: WordData;
+  state: ClipReducerState;
+  dispatch: React.Dispatch<ClipReducerAction>;
+  goto: (time: number) => void;
+}
+
+export default function TextModeWord({
+  endTimeOverride,
+  wordData, 
+  state,
+  dispatch,
+  goto,
+}: Props) {
+  const {
+    editingWord,
+    setEditingWord,
+    selectedWordIndex,
+    setSelectedWordIndex,
+    setTrimmingWord,
+  } = useClipContext();
+
+  const {
+    index,
+    word,
+    renderedWord,
+    isCurrentWord,
+    isExtraText,
+    isHighlighted,
+    nextStart
+  } = wordData;
+
+  const handleWordClick = (index: number | null) => {
+    // if first word, add more words to the beginning
+    if (index === state.editableText?.[0].index) {
+      dispatch({
+        type: ActionType.SET_EDITABLE_TEXT_PRE,
+        payload: state.editableTextPre + 10,
+      });
+    }
+    // if last word, add more words to the end
+    if (index === state.editableText?.[state.editableText.length - 1].index) {
+      dispatch({
+        type: ActionType.SET_EDITABLE_TEXT_POST,
+        payload: state.editableTextPost + 10,
+      });
+    }
+    if (selectedWordIndex != null && selectedWordIndex === index) {
+      setSelectedWordIndex(null);
+      return;
+    }
+    setSelectedWordIndex(index);
+    const gotoTime = state.editableText?.find((x) => x.index === index)?.item
+      ?.start;
+    if (gotoTime) goto(gotoTime);
+  };
+
+  const handleEditWord = () => {
+    setEditingWord(word);
+  };
+
+  const menuOpen = selectedWordIndex === index;
+  return <span
+    key={index}
+    className={classnames([
+      "clipWord",
+      { clipWordLight: isExtraText },
+      { clipHighlight: isHighlighted || menuOpen },
+      { clipCurrentWord: isCurrentWord },
+    ])}
+    onClick={() => handleWordClick(index)}
+    onDoubleClick={() => {
+      handleWordClick(index);
+      handleEditWord();
+    }}
+  >
+    {renderedWord}
+    {menuOpen && (
+      <WordMenu
+        index={index}
+        startIndex={state.startIndex}
+        endIndex={state.endIndex}
+        editingWord={editingWord}
+        handleWordClick={() => handleWordClick(null)}
+        setStartIndex={(i: number) => {
+          dispatch({
+            type: ActionType.SET_START_INDEX,
+            payload: i,
+          });
+          setSelectedWordIndex(null);
+        }}
+        setEndIndex={(i: number) => {
+          dispatch({
+            type: ActionType.SET_END_INDEX,
+            payload: i,
+          });
+          setSelectedWordIndex(null);
+        }}
+        setStartHighlightIndex={(i: number | null) =>
+          dispatch({
+            type: ActionType.SET_HIGHLIGHT_START_INDEX,
+            payload: i,
+          })}
+        setEndHighlightIndex={(i: number | null) =>
+          dispatch({
+            type: ActionType.SET_HIGHLIGHT_END_INDEX,
+            payload: i,
+          })}
+        handleEditWord={() => {
+          handleEditWord();
+          setSelectedWordIndex(null);
+        }}
+        handleTrimWord={() => {
+          setTrimmingWord({
+            currentValue: endTimeOverride,
+            startTime: word.start,
+            endTime: nextStart,
+          });
+        }}
+      />
+    )}
+  </span>
+}

--- a/aws/client/contexts/ClipContext.tsx
+++ b/aws/client/contexts/ClipContext.tsx
@@ -1,0 +1,76 @@
+import { React } from "aws/client/deps.ts";
+import { DGWord } from "/aws/types/transcript.ts";
+const { createContext, useContext, useState } = React;
+import { type TrimmingType } from "aws/client/components/Trim.tsx";
+
+interface ClipContextValue {
+  croppingWord: DGWord | null;
+  setCroppingWord: (word: DGWord | null) => void
+  editingWord: DGWord | null;
+  setEditingWord: (word: DGWord | null) => void
+  selectedWordIndex: number | null;
+  setSelectedWordIndex: (index: number | null) => void;
+  trimmingWord: Partial<TrimmingType> | null;
+  stickerStartWord: DGWord | null,
+  setStickerStartWord: (word: DGWord | null) => void,
+  stickerEndWord: DGWord | null,
+  setStickerEndWord: (word: DGWord | null) => void,
+  setTrimmingWord: (word: Partial<TrimmingType> | null) => void;
+}
+
+const ClipContext = createContext<ClipContextValue>({
+  croppingWord: null,
+  setCroppingWord: () => {},
+  editingWord: null,
+  setEditingWord: () => {},
+  selectedWordIndex: null,
+  setSelectedWordIndex: () => {},
+  trimmingWord: null,
+  stickerStartWord: null,
+  setStickerStartWord: () => {},
+  stickerEndWord: null,
+  setStickerEndWord: () => {},
+  setTrimmingWord: () => {},
+});
+
+type ClipProviderProps = React.PropsWithChildren;
+
+export const ClipProvider = ({ children }: ClipProviderProps) => {
+  const [croppingWord, setCroppingWord] = React.useState<DGWord | null>(null);
+  const [editingWord, setEditingWord] = useState<DGWord | null>(null);
+  const [selectedWordIndex, setSelectedWordIndex] = useState<number | null>(null);
+  const [trimmingWord, setTrimmingWord] = useState<Partial<TrimmingType> | null>(null);
+  const [stickerStartWord, setStickerStartWord] = React.useState<
+    DGWord | null
+  >(null);
+  const [stickerEndWord, setStickerEndWord] = React.useState<DGWord | null>(null);
+  
+  const value = {
+    croppingWord,
+    setCroppingWord,
+    editingWord,
+    setEditingWord,
+    selectedWordIndex,
+    setSelectedWordIndex,
+    trimmingWord,
+    stickerStartWord,
+    setStickerStartWord,
+    stickerEndWord,
+    setStickerEndWord,
+    setTrimmingWord,
+  }
+
+  return (
+    <ClipContext.Provider value={value}>
+      {children}
+    </ClipContext.Provider>
+  );
+};
+
+export const useClipContext = () => {
+  const context = useContext(ClipContext);
+  if (!context) {
+    throw new Error("useClipContext must be used within a ClipProvider");
+  }
+  return context;
+};

--- a/aws/client/hooks/useClipEditData.tsx
+++ b/aws/client/hooks/useClipEditData.tsx
@@ -43,7 +43,7 @@ export enum ActionType {
   SET_MANUAL_CROP_ACTIVE = "SET_MANUAL_CROP_ACTIVE",
 }
 
-type ClipReducerState = {
+export type ClipReducerState = {
   startIndex: number;
   endIndex: number;
   endTimeOverride: number | null;
@@ -58,7 +58,7 @@ type ClipReducerState = {
   manualCropActive: boolean;
 };
 
-type ClipReducerAction =
+export type ClipReducerAction =
   | { type: ActionType.SET_START_INDEX; payload: number }
   | { type: ActionType.SET_END_INDEX; payload: number }
   | { type: ActionType.SET_END_TIME_OVERRIDE; payload: number }

--- a/resources/aws-style.css
+++ b/resources/aws-style.css
@@ -245,12 +245,17 @@ a.dark:visited {
   text-align: center;
   font-weight: bold;
 }
-.cropLine {
+.lineHighlight {
   width: 100%;
   height: 15px;
-  background-color: var(--fourtharyColor030);
   top: 8px;
   position: absolute;
+}
+.cropLine {
+  background-color: var(--fourtharyColor030);
+}
+.stickerLine {
+  background-color: var(--fourtharyColor030);
 }
 .isCroppedIcon {
   position: absolute;


### PR DESCRIPTION
clean up edit modes

Summary: move word spans and functions into new components to clean up clip edit a little

Test Plan:

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/223).
* #225
* __->__ #223