### PR TITLE
Make BfOrganization own accounts instead of the account creating it

### DIFF
--- a/infra/bff/friends/commit.bff.ts
+++ b/infra/bff/friends/commit.bff.ts
@@ -15,7 +15,7 @@ register(
     const REPL_SLUG = Deno.env.get("REPL_SLUG") ?? "";
     const HOME = Deno.env.get("HOME") ?? "";
 
-    if (REPL_SLUG === "BF-Base") {
+    if (REPL_SLUG === "Bolt-Foundry-Base") {
       throw new Error("Don't log into the base please! Fork instead.");
     }
 

--- a/packages/bfDb/models/BfOrganization.ts
+++ b/packages/bfDb/models/BfOrganization.ts
@@ -38,7 +38,9 @@ export class BfOrganization extends BfNode<BfOrganizationRequiredProps> {
       role: ACCOUNT_ROLE.OWNER,
       displayName: this.props.name,
     };
-    const newAccount = await BfAccount.create(currentViewer, props);
+    const newAccount = await BfAccount.create(currentViewer, props, {
+      bfOid: this.metadata.bfOid,
+    });
     return newAccount;
   }
 }


### PR DESCRIPTION
Make BfOrganization own accounts instead of the account creating it




Summary:

This kicks the account problem down the road... accounts today are like half an edge... they don't inherit from bfedge but essentially they work like an edge.

Test Plan:

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/250).
* __->__ #250
* #249
<!-- GitContextStart -->
- - -
This pull request can be reviewed on [<img src="https://gitcontext.com/logo/GitContextButton.svg" height="32" align="absmiddle" alt="GitContext.com"/>](https://gitcontext.com/app/prs/github/bolt-foundry/bolt-foundry/250)
<!-- GitContextEnd -->