### PR TITLE
Add Playground to Infra

### DIFF
--- a/infra/__generated__/PlaygroundPageMutation.graphql.ts
+++ b/infra/__generated__/PlaygroundPageMutation.graphql.ts
@@ -1,0 +1,97 @@
+/**
+ * @generated SignedSource<<db274378db3c0070d47ebe1b1788efc4>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Mutation } from 'relay-runtime';
+export type PlaygroundPageMutation$variables = {
+  input: string;
+};
+export type PlaygroundPageMutation$data = {
+  readonly playgroundMutation: {
+    readonly message: string | null | undefined;
+    readonly success: boolean;
+  } | null | undefined;
+};
+export type PlaygroundPageMutation = {
+  response: PlaygroundPageMutation$data;
+  variables: PlaygroundPageMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "PlaygroundMutationPayload",
+    "kind": "LinkedField",
+    "name": "playgroundMutation",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "success",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "message",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "PlaygroundPageMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "PlaygroundPageMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "376383a7c62854850480f79f4665f236",
+    "id": null,
+    "metadata": {},
+    "name": "PlaygroundPageMutation",
+    "operationKind": "mutation",
+    "text": "mutation PlaygroundPageMutation(\n  $input: String!\n) {\n  playgroundMutation(input: $input) {\n    success\n    message\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "44171af1e6b2cb05217f4fb6ce227d95";
+
+export default node;

--- a/infra/__generated__/_graphql_imports.ts
+++ b/infra/__generated__/_graphql_imports.ts
@@ -2,3 +2,4 @@
 import "infra/__generated__/LoginPageLogoutMutation.graphql.ts"
 import "infra/__generated__/LoginPageLoginWithGoogleMutation.graphql.ts"
 import "infra/__generated__/LoginPageCVQuery.graphql.ts"
+import "infra/__generated__/PlaygroundPageMutation.graphql.ts"

--- a/infra/__generated__/_nexustypes.ts
+++ b/infra/__generated__/_nexustypes.ts
@@ -130,6 +130,10 @@ export interface NexusGenObjects {
     hasPreviousPage: boolean; // Boolean!
     startCursor?: string | null; // String
   }
+  PlaygroundMutationPayload: { // root type
+    message?: string | null; // String
+    success: boolean; // Boolean!
+  }
   Query: {};
   SubmitContactFormPayload: { // root type
     message?: string | null; // String
@@ -222,6 +226,7 @@ export interface NexusGenFieldTypes {
   Mutation: { // field return type
     loginWithGoogle: NexusGenRootTypes['BfCurrentViewerAccessToken'] | null; // BfCurrentViewerAccessToken
     logout: NexusGenRootTypes['BfCurrentViewer'] | null; // BfCurrentViewer
+    playgroundMutation: NexusGenRootTypes['PlaygroundMutationPayload'] | null; // PlaygroundMutationPayload
     readTextFile: string | null; // String
     submitContactForm: NexusGenRootTypes['SubmitContactFormPayload'] | null; // SubmitContactFormPayload
     switchAccount: NexusGenRootTypes['BfCurrentViewerAccessToken'] | null; // BfCurrentViewerAccessToken
@@ -232,6 +237,10 @@ export interface NexusGenFieldTypes {
     hasNextPage: boolean; // Boolean!
     hasPreviousPage: boolean; // Boolean!
     startCursor: string | null; // String
+  }
+  PlaygroundMutationPayload: { // field return type
+    message: string | null; // String
+    success: boolean; // Boolean!
   }
   Query: { // field return type
     currentViewer: NexusGenRootTypes['BfCurrentViewer'] | null; // BfCurrentViewer
@@ -329,6 +338,7 @@ export interface NexusGenFieldTypeNames {
   Mutation: { // field return type name
     loginWithGoogle: 'BfCurrentViewerAccessToken'
     logout: 'BfCurrentViewer'
+    playgroundMutation: 'PlaygroundMutationPayload'
     readTextFile: 'String'
     submitContactForm: 'SubmitContactFormPayload'
     switchAccount: 'BfCurrentViewerAccessToken'
@@ -339,6 +349,10 @@ export interface NexusGenFieldTypeNames {
     hasNextPage: 'Boolean'
     hasPreviousPage: 'Boolean'
     startCursor: 'String'
+  }
+  PlaygroundMutationPayload: { // field return type name
+    message: 'String'
+    success: 'Boolean'
   }
   Query: { // field return type name
     currentViewer: 'BfCurrentViewer'
@@ -395,6 +409,9 @@ export interface NexusGenArgTypes {
   Mutation: {
     loginWithGoogle: { // args
       credential: string; // String!
+    }
+    playgroundMutation: { // args
+      input: string; // String!
     }
     readTextFile: { // args
       file: NexusGenScalars['File']; // File!

--- a/infra/graphql/schema.graphql
+++ b/infra/graphql/schema.graphql
@@ -218,6 +218,7 @@ interface IBfGraphQLNode implements BfNode {
 type Mutation {
   loginWithGoogle(credential: String!): BfCurrentViewerAccessToken
   logout: BfCurrentViewer
+  playgroundMutation(input: String!): PlaygroundMutationPayload
   readTextFile(file: File!): String
   submitContactForm(input: SubmitContactFormInput!): SubmitContactFormPayload
   switchAccount(accountId: ID!): BfCurrentViewerAccessToken
@@ -247,6 +248,11 @@ type PageInfo {
   The cursor corresponding to the first nodes in edges. Null if the connection is empty.
   """
   startCursor: String
+}
+
+type PlaygroundMutationPayload {
+  message: String
+  success: Boolean!
 }
 
 type Query {

--- a/infra/graphql/types/IBfPlaygroundMutation.ts
+++ b/infra/graphql/types/IBfPlaygroundMutation.ts
@@ -1,0 +1,45 @@
+import {
+  arg,
+  booleanArg,
+  connectionFromArray,
+  extendType,
+  idArg,
+  mutationField,
+  nonNull,
+  objectType,
+  stringArg,
+} from "packages/graphql/deps.ts";
+import { BfNodeGraphQLType } from "packages/graphql/types/BfGraphQLNode.ts";
+import { GraphQLContext } from "packages/graphql/graphql.ts";
+
+
+
+// Define the output type for the mutation response
+const playgroundMutationPayload = objectType({
+  name: "PlaygroundMutationPayload",
+  definition(t) {
+    t.nonNull.boolean("success");
+    t.string("message");
+  },
+});
+
+export const playgroundMutation = mutationField("playgroundMutation", {
+  type: playgroundMutationPayload,
+  args: {
+    input: nonNull(stringArg()),
+  },
+  resolve: async (_root, { input }, { bfCurrentViewer }: GraphQLContext) => {
+    try {
+      return {
+        success: true,
+        message: input,
+      };
+    } catch (error) {
+      console.error("Form submission error:", error);
+      return {
+        success: false,
+        message: "Form submission failed.",
+      };
+    }
+  },
+});

--- a/infra/graphql/types/mod.ts
+++ b/infra/graphql/types/mod.ts
@@ -1,2 +1,3 @@
 export * from "packages/graphql/types/mod.ts";
 export * from "infra/graphql/types/IBfGraphQLNode.ts";
+export * from "infra/graphql/types/IBfPlaygroundMutation.ts";

--- a/infra/internalbf.com/client/components/App.tsx
+++ b/infra/internalbf.com/client/components/App.tsx
@@ -14,6 +14,7 @@ import { ProjectsPage } from "infra/internalbf.com/client/pages/ProjectsPage.tsx
 import { QcPage } from "infra/internalbf.com/client/pages/QcPage.tsx";
 import { ChangesPage } from "infra/internalbf.com/client/pages/ChangesPage.tsx";
 import { ClipChangesPage } from "infra/internalbf.com/client/pages/ClipChangesPage.tsx";
+import { PlaygroundPage } from "infra/internalbf.com/client/pages/PlaygroundPage.tsx";
 
 export const routes = new Map([
   ["/media", { Component: MediaPage, allowLoggedOut: true }],
@@ -25,6 +26,7 @@ export const routes = new Map([
     allowLoggedOut: true,
   }],
   ["/login", { Component: LoginPage, allowLoggedOut: true }],
+  ["/colby", { Component: PlaygroundPage, allowLoggedOut: true}],
 ]);
 
 export function App() {

--- a/infra/internalbf.com/client/pages/PlaygroundPage.tsx
+++ b/infra/internalbf.com/client/pages/PlaygroundPage.tsx
@@ -1,0 +1,61 @@
+import { React } from "deps.ts";
+import { graphql, ReactRelay } from "infra/internalbf.com/client/deps.ts";
+
+const { useLazyLoadQuery, useMutation } = ReactRelay;
+
+const testMutation = await graphql`
+  mutation PlaygroundPageMutation($input: String!) {
+    playgroundMutation(input: $input) {
+      success
+      message
+    }
+  }
+`;
+
+export function PlaygroundPage() {
+  const [commit, isInFlight] = useMutation(testMutation);
+
+  let [aiResponse, setAiResponse] = React.useState("");
+
+  const handleSubmit = (value) => {
+    commit({
+      variables: {
+        input: value,
+      },
+      onCompleted: (response) => {
+        setAiResponse(response.playgroundMutation.message);
+      }
+    });
+  }
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();// Prevents a new line from being added
+      handleSubmit(e.target.value);
+      e.target.value = "";
+    }
+  };
+
+  
+  return (
+    <div style={{ padding: '20px' }}>
+      <div
+        style={mainDivStyle}>
+        <textarea 
+          onKeyDown={handleKeyDown}
+          style={{width: "80%",
+                  marginTop: "20px",
+                 }} 
+          ></textarea>
+      </div>
+      <div style={mainDivStyle}><p>{aiResponse}</p></div>
+    </div>
+  );
+}
+
+
+const mainDivStyle = 
+  { display: "flex",
+    justifyContent: "center",
+    width: "100%",
+   };


### PR DESCRIPTION
Add Playground to Infra

Summary: Adds a new endpoint "/colby" to internalbf.com with a corresponding graphql endpoint. The page is boilerplate at the moment, just an integration test. Functionality will be added later.

Test Plan: 🦧
