### PR TITLE
Add sort_value column on the db

### DIFF
--- a/packages/bfDb/bfDb.ts
+++ b/packages/bfDb/bfDb.ts
@@ -38,6 +38,7 @@ type Row<
   class_name: string;
   created_at: string;
   last_updated: string;
+  sort_value: number;
 };
 
 export async function bfGetItem<
@@ -119,12 +120,13 @@ export async function bfGetItemByBfGid<
 
 export async function bfPutItem<
   TProps = Props,
-  TMetadata extends BfBaseModelMetadata = BfBaseModelMetadata,
+  TMetadata extends BfBaseModelMetadata = BfBaseModelMetadata
 >(
   itemProps: TProps,
   itemMetadata: TMetadata,
 ): Promise<void> {
   logger.trace({ itemProps, itemMetadata });
+  const sortValue = Date.now(); // Set the sort_value as the current timestamp in milliseconds
   try {
     let createdAtTimestamp, lastUpdatedTimestamp;
 
@@ -140,21 +142,25 @@ export async function bfPutItem<
       lastUpdatedTimestamp = new Date(itemMetadata.lastUpdated).toISOString();
     }
 
-    await sql`INSERT INTO bfdb(bf_gid, bf_oid, bf_cid, bf_sid, bf_tid, class_name, created_at, last_updated, props)
-                     VALUES(${itemMetadata.bfGid}, ${itemMetadata.bfOid}, ${itemMetadata.bfCid}, ${
+    // Insert or Update with conditional sort_value
+    await sql`
+    INSERT INTO bfdb(bf_gid, bf_oid, bf_cid, bf_sid, bf_tid, class_name, created_at, last_updated, props, sort_value)
+    VALUES(${itemMetadata.bfGid}, ${itemMetadata.bfOid}, ${itemMetadata.bfCid}, ${
       itemMetadata.bfSid || null
     }, ${itemMetadata.bfTid}, ${itemMetadata.className}, ${createdAtTimestamp}, ${lastUpdatedTimestamp}, ${
       JSON.stringify(itemProps)
-    })
-                     ON CONFLICT (bf_gid) DO UPDATE SET
-                       bf_oid = EXCLUDED.bf_oid,
-                       bf_cid = EXCLUDED.bf_cid,
-                       bf_sid = EXCLUDED.bf_sid,
-                       bf_tid = EXCLUDED.bf_tid,
-                       class_name = EXCLUDED.class_name,
-                       created_at = EXCLUDED.created_at,
-                       last_updated = CURRENT_TIMESTAMP,
-                       props = EXCLUDED.props;`;
+    }, ${sortValue}) 
+    ON CONFLICT (bf_gid) DO UPDATE SET
+      bf_oid = EXCLUDED.bf_oid,
+      bf_cid = EXCLUDED.bf_cid,
+      bf_sid = EXCLUDED.bf_sid,
+      bf_tid = EXCLUDED.bf_tid,
+      class_name = EXCLUDED.class_name,
+      created_at = EXCLUDED.created_at,
+      last_updated = CURRENT_TIMESTAMP,
+      props = EXCLUDED.props,
+      sort_value = CASE WHEN bfdb.created_at IS NULL THEN EXCLUDED.sort_value ELSE bfdb.sort_value END;`; // Update sort_value only if it's a new record
+
     logger.trace(
       `bfPutItem: Successfully inserted or updated item with ${
         JSON.stringify(itemMetadata)
@@ -167,21 +173,28 @@ export async function bfPutItem<
   }
 }
 
-const VALID_METADATA_COLUMN_NAMES = ["bf_gid", "bf_oid", "bf_cid", "bf_sid", "bf_tid", "class_name"];
-
+const VALID_METADATA_COLUMN_NAMES = [
+  "bf_gid",
+  "bf_oid",
+  "bf_cid",
+  "bf_sid",
+  "bf_tid",
+  "class_name",
+  "sort_value",
+];
 export async function bfQueryItems<
   TProps = Props,
   TMetadata extends BfBaseModelMetadata = BfBaseModelMetadata,
 >(
   metadataToQuery: Partial<TMetadata>,
   propsToQuery: Partial<TProps> = {},
+  orderBy: keyof Row = "sort_value", // Default to sort by sort_value
+  orderDirection: "ASC" | "DESC" = "ASC", // Default to ascending order
 ): Promise<Array<DbItem<TProps, BfBaseModelMetadata>>> {
-  logger.trace({ metadataToQuery, propsToQuery });
-
+  logger.trace({ metadataToQuery, propsToQuery, orderBy, orderDirection });
   const metadataConditions: string[] = [];
   const propsConditions: string[] = [];
   const variables = [];
-
   for (const [originalKey, value] of Object.entries(metadataToQuery)) {
     // convert key from camelCase to snake_case
     const key = originalKey.replace(/([a-z])([A-Z])/g, "$1_$2" as const);
@@ -191,28 +204,26 @@ export async function bfQueryItems<
       metadataConditions.push(`${key} = $${valuePosition}`);
     }
   }
-
   for (const [key, value] of Object.entries(propsToQuery)) {
-    variables.push(key)
+    variables.push(key);
     const keyPosition = variables.length;
     variables.push(value);
     const valuePosition = variables.length;
     propsConditions.push(`props->>$${keyPosition} = $${valuePosition}`);
   }
-
   const allConditions = [...metadataConditions, ...propsConditions].join(
     " AND ",
   );
-  const query = `SELECT * FROM bfdb WHERE ${allConditions}`;
-
+  const query =
+    `SELECT * FROM bfdb WHERE ${allConditions} ORDER BY ${orderBy} ${orderDirection}`;
   try {
     logger.trace("Executing query", query, variables);
-    const rows = await sql(query, variables);
+    const rows = await sql(query, ...variables) as Row<TProps>[];
     const items = rows.map((row) => ({
       props: row.props,
       metadata: {
         bfGid: row.bf_gid,
-        bfSid: row.bf_pid,
+        bfSid: row.bf_sid,
         bfOid: row.bf_oid,
         bfTid: row.bf_tid,
         bfCid: row.bf_cid,

--- a/packages/bfDb/classes/BfModel.ts
+++ b/packages/bfDb/classes/BfModel.ts
@@ -12,7 +12,6 @@ import {
   BfAnyid,
   BfCid,
   BfGid,
-  BfSortValue,
   getAvailableActionsForRole,
   JsUnixtime,
 } from "packages/bfDb/classes/BfBaseModelIdTypes.ts";
@@ -163,6 +162,7 @@ abstract class BfBaseModel<
         & BfBaseModelMetadata<TCreationMetadata>;
     });
   }
+    
 
   private static generateDefaultMetadata<
     TCreationMetadata extends CreationMetadata = CreationMetadata,
@@ -184,10 +184,8 @@ abstract class BfBaseModel<
     };
   }
 
-  protected static generateSortValue(): BfSortValue | undefined {
-    if (this.isSorted) {
-      return Date.now().toString() as BfSortValue;
-    }
+  protected static generateSortValue(): number {
+    return Date.now();
   }
 
   /*
@@ -228,7 +226,6 @@ instance methods at the bottom alphabetized. This is to make it easier to find t
         currentViewer.accountBfGid,
         metadata.bfGid,
         bfOid,
-        metadata.sortValue,
       );
     this.metadata = { ...defaultMetadata, ...metadata };
   }

--- a/packages/bfDb/schema.sql
+++ b/packages/bfDb/schema.sql
@@ -7,5 +7,6 @@ CREATE TABLE IF NOT EXISTS bfDb (
   class_name VARCHAR(255),
   last_updated TIMESTAMP WITHOUT TIME ZONE,
   created_at TIMESTAMP WITHOUT TIME ZONE,
-  props JSONB NOT NULL
+  props JSONB NOT NULL,
+  sort_value BIGINT NOT NULL
 );


### PR DESCRIPTION
Add sort_value column on the db




Summary:

Makes it so we can sort items. Initially, we're not going to expose the sort value to bfmodel etc. Eventually we might, but for now the sort value is the js date epoch and only gets generated on insert.

I anticipate adding it to bfmodel when we want to do things like update the sort order of something.

When we use cursors in graphql, if the sort order gets corrupted b/c a sort value gets changed, we'll have to handle that case.

Test Plan:

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/273).
* #275
* #274
* __->__ #273
* #272