### PR TITLE
Update cursor to use web standard instead of node buffers

### DIFF
--- a/infra/__generated__/_graphql_imports.ts
+++ b/infra/__generated__/_graphql_imports.ts
@@ -1,6 +1,6 @@
 /* @generated */
 import "infra/__generated__/LoginPageLogoutMutation.graphql.ts"
-import "infra/__generated__/LoginPageLoginWithGoogleMutation.graphql.ts"
 import "infra/__generated__/LoginPageCVQuery.graphql.ts"
 import "infra/__generated__/PlaygroundPageMutation.graphql.ts"
 import "infra/__generated__/RandallPlaygroundPageMutation.graphql.ts"
+import "infra/__generated__/LoginPageLoginWithGoogleMutation.graphql.ts"

--- a/packages/__generated__/_graphql_imports.ts
+++ b/packages/__generated__/_graphql_imports.ts
@@ -1,5 +1,5 @@
 /* @generated */
 import "packages/__generated__/ContactUsSubmitFormMutation.graphql.ts"
 import "packages/__generated__/LoginPageCVQuery.graphql.ts"
-import "packages/__generated__/LoginFormLoginWithGoogleMutation.graphql.ts"
 import "packages/__generated__/LoginPageLogoutMutation.graphql.ts"
+import "packages/__generated__/LoginFormLoginWithGoogleMutation.graphql.ts"

--- a/packages/bfDb/bfDb.ts
+++ b/packages/bfDb/bfDb.ts
@@ -208,10 +208,11 @@ export async function bfQueryItems<
   for (const [originalKey, value] of Object.entries(metadataToQuery)) {
     // convert key from camelCase to snake_case
     const key = originalKey.replace(/([a-z])([A-Z])/g, "$1_$2" as const);
-    if (VALID_METADATA_COLUMN_NAMES.includes(key.toLowerCase())) {
+    const lowercaseKey = key.toLowerCase();
+    if (VALID_METADATA_COLUMN_NAMES.includes(lowercaseKey)) {
       variables.push(value);
       const valuePosition = variables.length;
-      metadataConditions.push(`${key} = $${valuePosition}`);
+      metadataConditions.push(`${lowercaseKey} = $${valuePosition}`);
     }
   }
 
@@ -290,10 +291,11 @@ export async function bfQueryItemsForGraphQLConnection<
   for (const [originalKey, value] of Object.entries(metadata)) {
     // convert key from camelCase to snake_case
     const key = originalKey.replace(/([a-z])([A-Z])/g, "$1_$2" as const);
-    if (VALID_METADATA_COLUMN_NAMES.includes(key.toLowerCase())) {
+    const lowerCaseKey = key.toLowerCase();
+    if (VALID_METADATA_COLUMN_NAMES.includes(lowerCaseKey)) {
       variables.push(value);
       const valuePosition = variables.length;
-      metadataConditions.push(`${key} = $${valuePosition}`);
+      metadataConditions.push(`${lowerCaseKey} = $${valuePosition}`);
     }
   }
   for (const [_, value] of Object.entries(props)) {
@@ -314,6 +316,7 @@ export async function bfQueryItemsForGraphQLConnection<
     }
     const edges: EdgeInterface<DbItem<TProps, TMetadata>>[] = rows.map(
       (row) => {
+        logger.trace("row", row);
         const cursor = sortValueToCursor(row.sort_value);
         return {
           cursor,

--- a/packages/bfDb/bfDb.ts
+++ b/packages/bfDb/bfDb.ts
@@ -361,9 +361,22 @@ export async function bfQueryItemsForGraphQLConnection<
   }
 }
 
+// Function to convert sortValue to base64 cursor
 function sortValueToCursor(sortValue: number): string {
-  return Buffer.from(sortValue.toString()).toString("base64");
+  // Convert number to string and then Uint8Array
+  const uint8Array = new TextEncoder().encode(sortValue.toString());
+  // Convert Uint8Array to base64
+  return btoa(String.fromCharCode(...uint8Array));
 }
+
+// Function to convert base64 cursor back to sortValue
 function cursorToSortValue(cursor: string): number {
-  return parseInt(Buffer.from(cursor, "base64").toString("ascii"), 10);
+  // Convert base64 to string
+  const decodedString = atob(cursor);
+  // Convert string to Uint8Array
+  const uint8Array = new Uint8Array(
+    [...decodedString].map((char) => char.charCodeAt(0))
+  );
+  // Decode Uint8Array to original string and convert to number
+  return parseInt(new TextDecoder().decode(uint8Array), 10);
 }


### PR DESCRIPTION
Update cursor to use web standard instead of node buffers

Summary:

Test Plan:

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/281).
* #290
* #289
* #288
* #287
* #286
* #285
* #284
* #283
* #282
* __->__ #281
* #280
* #279