### PR TITLE
VCS: fix text layout for non-span strings

### DIFF
--- a/thirdParty/daily-vcs-main/js/src/comp-backing-model.js
+++ b/thirdParty/daily-vcs-main/js/src/comp-backing-model.js
@@ -885,7 +885,7 @@ class TextNode extends StyledNodeBase {
       }
 
       this.attrStringDesc = makeAttributedStringDesc(
-        this.spans || [[this.text]],
+        this.spans || [{ string: this.text }],
         this.style || {},
         this.container.viewportSize,
         this.container.pixelsPerGridUnit


### PR DESCRIPTION
Fix for crash when rendering text overlays in baseline comp