### PR TITLE
[1/4] transcript model/graphql

### DIFF
--- a/infra/__generated__/_nexustypes.ts
+++ b/infra/__generated__/_nexustypes.ts
@@ -130,6 +130,9 @@ export interface NexusGenObjects {
     email?: string | null; // String
     name?: string | null; // String
   }
+  BfTranscript: { // root type
+    transcript?: string | null; // String
+  }
   IBfCurrentViewerInternalAdmin: { // root type
     role?: NexusGenEnums['AccountRole'] | null; // AccountRole
   }
@@ -153,7 +156,7 @@ export interface NexusGenObjects {
 
 export interface NexusGenInterfaces {
   BfCurrentViewer: core.Discriminate<'BfCurrentViewerAccessToken', 'required'> | core.Discriminate<'BfCurrentViewerAnon', 'required'> | core.Discriminate<'IBfCurrentViewerInternalAdmin', 'required'>;
-  BfNode: core.Discriminate<'BfAccount', 'required'> | core.Discriminate<'BfClip', 'required'> | core.Discriminate<'BfClipReview', 'required'> | core.Discriminate<'BfGoogleDriveFolder', 'required'> | core.Discriminate<'BfOrganization', 'required'> | core.Discriminate<'BfPerson', 'required'>;
+  BfNode: core.Discriminate<'BfAccount', 'required'> | core.Discriminate<'BfClip', 'required'> | core.Discriminate<'BfClipReview', 'required'> | core.Discriminate<'BfOrganization', 'required'> | core.Discriminate<'BfPerson', 'required'> | core.Discriminate<'BfTranscript', 'required'>;
   IBfGraphQLNode: any;
 }
 
@@ -239,12 +242,18 @@ export interface NexusGenFieldTypes {
     id: string; // ID!
     name: string | null; // String
   }
+  BfTranscript: { // field return type
+    id: string; // ID!
+    transcript: string | null; // String
+  }
   IBfCurrentViewerInternalAdmin: { // field return type
     organization: NexusGenRootTypes['BfOrganization'] | null; // BfOrganization
     person: NexusGenRootTypes['BfPerson'] | null; // BfPerson
     role: NexusGenEnums['AccountRole'] | null; // AccountRole
   }
   Mutation: { // field return type
+    createTranscript: NexusGenRootTypes['BfTranscript'] | null; // BfTranscript
+    deleteTranscript: NexusGenRootTypes['BfTranscript'] | null; // BfTranscript
     linkAdvancedGoogleAuth: NexusGenRootTypes['BfCurrentViewer'] | null; // BfCurrentViewer
     loginWithGoogle: NexusGenRootTypes['BfCurrentViewerAccessToken'] | null; // BfCurrentViewerAccessToken
     logout: NexusGenRootTypes['BfCurrentViewer'] | null; // BfCurrentViewer
@@ -269,6 +278,7 @@ export interface NexusGenFieldTypes {
     currentViewer: NexusGenRootTypes['BfCurrentViewer'] | null; // BfCurrentViewer
     node: NexusGenRootTypes['BfNode'] | null; // BfNode
     organizations: NexusGenRootTypes['BfOrganizationConnection'] | null; // BfOrganizationConnection
+    transcripts: Array<NexusGenRootTypes['BfTranscript'] | null>; // [BfTranscript]!
   }
   SubmitContactFormPayload: { // field return type
     message: string | null; // String
@@ -362,12 +372,18 @@ export interface NexusGenFieldTypeNames {
     id: 'ID'
     name: 'String'
   }
+  BfTranscript: { // field return type name
+    id: 'ID'
+    transcript: 'String'
+  }
   IBfCurrentViewerInternalAdmin: { // field return type name
     organization: 'BfOrganization'
     person: 'BfPerson'
     role: 'AccountRole'
   }
   Mutation: { // field return type name
+    createTranscript: 'BfTranscript'
+    deleteTranscript: 'BfTranscript'
     linkAdvancedGoogleAuth: 'BfCurrentViewer'
     loginWithGoogle: 'BfCurrentViewerAccessToken'
     logout: 'BfCurrentViewer'
@@ -392,6 +408,7 @@ export interface NexusGenFieldTypeNames {
     currentViewer: 'BfCurrentViewer'
     node: 'BfNode'
     organizations: 'BfOrganizationConnection'
+    transcripts: 'BfTranscript'
   }
   SubmitContactFormPayload: { // field return type name
     message: 'String'
@@ -428,6 +445,12 @@ export interface NexusGenArgTypes {
     }
   }
   Mutation: {
+    createTranscript: { // args
+      transcript: string; // String!
+    }
+    deleteTranscript: { // args
+      id: string; // String!
+    }
     linkAdvancedGoogleAuth: { // args
       code: string; // String!
     }
@@ -472,7 +495,7 @@ export interface NexusGenArgTypes {
 
 export interface NexusGenAbstractTypeMembers {
   BfCurrentViewer: "BfCurrentViewerAccessToken" | "BfCurrentViewerAnon" | "IBfCurrentViewerInternalAdmin"
-  BfNode: "BfAccount" | "BfClip" | "BfClipReview" | "BfGoogleDriveFolder" | "BfOrganization" | "BfPerson"
+  BfNode: "BfAccount" | "BfClip" | "BfClipReview" | "BfOrganization" | "BfPerson" | "BfTranscript"
 }
 
 export interface NexusGenTypeInterfaces {
@@ -484,6 +507,7 @@ export interface NexusGenTypeInterfaces {
   BfGoogleDriveFolder: "BfNode"
   BfOrganization: "BfNode"
   BfPerson: "BfNode"
+  BfTranscript: "BfNode"
   IBfCurrentViewerInternalAdmin: "BfCurrentViewer"
   IBfGraphQLNode: "BfNode"
 }

--- a/infra/graphql/schema.graphql
+++ b/infra/graphql/schema.graphql
@@ -192,6 +192,13 @@ type BfPerson implements BfNode {
   name: String
 }
 
+"""A transcript of a clip."""
+type BfTranscript implements BfNode {
+  """Unique identifier for the resource"""
+  id: ID!
+  transcript: String
+}
+
 """The `File` scalar type represents a file upload."""
 scalar File
 
@@ -208,7 +215,9 @@ interface IBfGraphQLNode implements BfNode {
 }
 
 type Mutation {
-  linkAdvancedGoogleAuth(code: String!): BfCurrentViewer
+  createTranscript(transcript: String!): BfTranscript
+  deleteTranscript(id: String!): BfTranscript
+  linkAdvancedGoogleAuth(code: String): BfCurrentViewer
   loginWithGoogle(credential: String!): BfCurrentViewerAccessToken
   logout: BfCurrentViewer
   pickGoogleDriveFolder(folderId: String, name: String): BfGoogleDriveFolder
@@ -265,6 +274,7 @@ type Query {
     """Returns the last n elements from the list."""
     last: Int
   ): BfOrganizationConnection
+  transcripts: [BfTranscript]!
 }
 
 input SubmitContactFormInput {

--- a/packages/__generated__/_nexustypes.ts
+++ b/packages/__generated__/_nexustypes.ts
@@ -120,6 +120,9 @@ export interface NexusGenObjects {
     email?: string | null; // String
     name?: string | null; // String
   }
+  BfTranscript: { // root type
+    transcript?: string | null; // String
+  }
   Mutation: {};
   PageInfo: { // root type
     endCursor?: string | null; // String
@@ -136,7 +139,7 @@ export interface NexusGenObjects {
 
 export interface NexusGenInterfaces {
   BfCurrentViewer: core.Discriminate<'BfCurrentViewerAccessToken', 'required'> | core.Discriminate<'BfCurrentViewerAnon', 'required'>;
-  BfNode: core.Discriminate<'BfAccount', 'required'> | core.Discriminate<'BfClip', 'required'> | core.Discriminate<'BfClipReview', 'required'> | core.Discriminate<'BfGoogleDriveFolder', 'required'> | core.Discriminate<'BfOrganization', 'required'> | core.Discriminate<'BfPerson', 'required'>;
+  BfNode: core.Discriminate<'BfAccount', 'required'> | core.Discriminate<'BfClip', 'required'> | core.Discriminate<'BfClipReview', 'required'> | core.Discriminate<'BfOrganization', 'required'> | core.Discriminate<'BfPerson', 'required'> | core.Discriminate<'BfTranscript', 'required'>;
 }
 
 export interface NexusGenUnions {
@@ -211,7 +214,13 @@ export interface NexusGenFieldTypes {
     id: string; // ID!
     name: string | null; // String
   }
+  BfTranscript: { // field return type
+    id: string; // ID!
+    transcript: string | null; // String
+  }
   Mutation: { // field return type
+    createTranscript: NexusGenRootTypes['BfTranscript'] | null; // BfTranscript
+    deleteTranscript: NexusGenRootTypes['BfTranscript'] | null; // BfTranscript
     linkAdvancedGoogleAuth: NexusGenRootTypes['BfCurrentViewer'] | null; // BfCurrentViewer
     loginWithGoogle: NexusGenRootTypes['BfCurrentViewerAccessToken'] | null; // BfCurrentViewerAccessToken
     logout: NexusGenRootTypes['BfCurrentViewer'] | null; // BfCurrentViewer
@@ -230,6 +239,7 @@ export interface NexusGenFieldTypes {
   Query: { // field return type
     currentViewer: NexusGenRootTypes['BfCurrentViewer'] | null; // BfCurrentViewer
     node: NexusGenRootTypes['BfNode'] | null; // BfNode
+    transcripts: Array<NexusGenRootTypes['BfTranscript'] | null>; // [BfTranscript]!
   }
   SubmitContactFormPayload: { // field return type
     message: string | null; // String
@@ -310,7 +320,13 @@ export interface NexusGenFieldTypeNames {
     id: 'ID'
     name: 'String'
   }
+  BfTranscript: { // field return type name
+    id: 'ID'
+    transcript: 'String'
+  }
   Mutation: { // field return type name
+    createTranscript: 'BfTranscript'
+    deleteTranscript: 'BfTranscript'
     linkAdvancedGoogleAuth: 'BfCurrentViewer'
     loginWithGoogle: 'BfCurrentViewerAccessToken'
     logout: 'BfCurrentViewer'
@@ -329,6 +345,7 @@ export interface NexusGenFieldTypeNames {
   Query: { // field return type name
     currentViewer: 'BfCurrentViewer'
     node: 'BfNode'
+    transcripts: 'BfTranscript'
   }
   SubmitContactFormPayload: { // field return type name
     message: 'String'
@@ -362,6 +379,12 @@ export interface NexusGenArgTypes {
     }
   }
   Mutation: {
+    createTranscript: { // args
+      transcript: string; // String!
+    }
+    deleteTranscript: { // args
+      id: string; // String!
+    }
     linkAdvancedGoogleAuth: { // args
       code: string; // String!
     }
@@ -396,7 +419,7 @@ export interface NexusGenArgTypes {
 
 export interface NexusGenAbstractTypeMembers {
   BfCurrentViewer: "BfCurrentViewerAccessToken" | "BfCurrentViewerAnon"
-  BfNode: "BfAccount" | "BfClip" | "BfClipReview" | "BfGoogleDriveFolder" | "BfOrganization" | "BfPerson"
+  BfNode: "BfAccount" | "BfClip" | "BfClipReview" | "BfOrganization" | "BfPerson" | "BfTranscript"
 }
 
 export interface NexusGenTypeInterfaces {
@@ -408,6 +431,7 @@ export interface NexusGenTypeInterfaces {
   BfGoogleDriveFolder: "BfNode"
   BfOrganization: "BfNode"
   BfPerson: "BfNode"
+  BfTranscript: "BfNode"
 }
 
 export type NexusGenObjectNames = keyof NexusGenObjects;

--- a/packages/bfDb/bfDb.ts
+++ b/packages/bfDb/bfDb.ts
@@ -263,6 +263,23 @@ export async function bfQueryItems<
   }
 }
 
+export async function bfDeleteItem(bfOid: BfOid, bfGid: BfGid): Promise<void> {
+  try {
+    logger.trace("bfDeleteItem", { bfOid, bfGid });
+    const result = await sql`
+      DELETE FROM bfdb
+      WHERE bf_oid = ${bfOid} AND bf_gid = ${bfGid}
+    `;
+    if (result.rowCount === 0) {
+      throw new BfDbError(`No item found with bfOid: ${bfOid} and bfGid: ${bfGid}`);
+    }
+    logger.trace(`Deleted item with bfOid: ${bfOid} and bfGid: ${bfGid}`);
+  } catch (e) {
+    logger.error(e);
+    throw new BfDbError("Failed to delete item from the database");
+  }
+}
+
 export async function bfQueryItemsForGraphQLConnection<
   TProps = Props,
   TMetadata extends BfBaseModelMetadata = BfBaseModelMetadata,

--- a/packages/bfDb/classes/BfModel.ts
+++ b/packages/bfDb/classes/BfModel.ts
@@ -18,6 +18,7 @@ import {
 import type { ConnectionArguments, ConnectionInterface } from "relay-runtime";
 import { generateUUID } from "lib/generateUUID.ts";
 import {
+  bfDeleteItem,
   bfGetItem,
   bfGetItemByBfGid,
   bfPutItem,
@@ -79,6 +80,17 @@ abstract class BfBaseModel<
     return newModel as
       & InstanceType<TThis>
       & BfBaseModelMetadata<TCreationMetadata>;
+  }
+
+  public async delete() {
+    await this.validatePermissions(ACCOUNT_ACTIONS.DELETE);
+    try {
+      await bfDeleteItem(this.metadata.bfOid, this.metadata.bfGid);
+      log(`Deleted ${this.constructor.name} with bfOid: ${this.metadata.bfOid} and bfGid: ${this.metadata.bfGid}`);
+    } catch (error) {
+      log(`Failed to delete ${this.constructor.name}:`, error);
+      throw error;
+    }
   }
 
   static async find<

--- a/packages/bfDb/models/BfTranscript.ts
+++ b/packages/bfDb/models/BfTranscript.ts
@@ -1,0 +1,25 @@
+import { BfNode } from "packages/bfDb/coreModels/BfNode.ts";
+import { BfCurrentViewer } from "packages/bfDb/classes/BfCurrentViewer.ts";
+import { BfGid, toBfSid, toBfTid } from "packages/bfDb/classes/BfBaseModelIdTypes.ts";
+import { BfEdge } from "packages/bfDb/coreModels/BfEdge.ts";
+
+type BfTranscriptProps = {
+  transcript: string;
+};
+
+export class BfTranscript extends BfNode<BfTranscriptProps> {
+  async createNewTranscript(text: string) {
+    const newTranscript = await BfTranscript.create(this.currentViewer, {
+      transcript: text,
+    });
+    return newTranscript;
+  }
+
+  static async findTranscriptsByViewer(bfCurrentViewer: BfCurrentViewer) {
+    const transcripts = await this.query(bfCurrentViewer, {
+      bfOid: bfCurrentViewer.organizationBfGid,
+      className: 'BfTranscript',
+    });
+    return transcripts;
+  }
+}

--- a/packages/graphql/schema.graphql
+++ b/packages/graphql/schema.graphql
@@ -167,11 +167,20 @@ type BfPerson implements BfNode {
   name: String
 }
 
+"""A transcript of a clip."""
+type BfTranscript implements BfNode {
+  """Unique identifier for the resource"""
+  id: ID!
+  transcript: String
+}
+
 """The `File` scalar type represents a file upload."""
 scalar File
 
 type Mutation {
-  linkAdvancedGoogleAuth(code: String!): BfCurrentViewer
+  createTranscript(transcript: String!): BfTranscript
+  deleteTranscript(id: String!): BfTranscript
+  linkAdvancedGoogleAuth(code: String): BfCurrentViewer
   loginWithGoogle(credential: String!): BfCurrentViewerAccessToken
   logout: BfCurrentViewer
   pickGoogleDriveFolder(folderId: String, name: String): BfGoogleDriveFolder
@@ -209,6 +218,7 @@ type PageInfo {
 type Query {
   currentViewer: BfCurrentViewer
   node(id: ID!): BfNode
+  transcripts: [BfTranscript]!
 }
 
 input SubmitContactFormInput {

--- a/packages/graphql/types/BfGraphQLTranscript.ts
+++ b/packages/graphql/types/BfGraphQLTranscript.ts
@@ -1,0 +1,67 @@
+import {
+  arg,
+  extendType,
+  mutationField,
+  nonNull,
+  objectType,
+  stringArg,
+} from "packages/graphql/deps.ts";
+import { BfNodeGraphQLType } from "packages/graphql/types/BfGraphQLNode.ts";
+import { BfTranscript } from "packages/bfDb/models/BfTranscript.ts";
+import { getLogger } from "deps.ts";
+
+const logger = getLogger(import.meta);
+
+export const BfGraphQLTranscriptType = objectType({
+  name: "BfTranscript",
+  description: "A transcript of a clip.",
+  definition: (t) => {
+    t.implements(BfNodeGraphQLType);
+    t.string("transcript");
+  },
+});
+
+export const BfGraphQLTranscriptsQuery = extendType({
+  type: 'Query',
+  definition(t) {
+    t.nonNull.list.field('transcripts', {
+      type: BfGraphQLTranscriptType,
+      resolve: async (_, __, { bfCurrentViewer }) => {
+        logger.debug('Fetching all transcripts');
+        const transcripts = await BfTranscript.findTranscriptsByViewer(bfCurrentViewer);
+        logger.debug('Fetched all transcripts successfully', transcripts);
+        return transcripts.map(transcript => transcript.toGraphql());
+      },
+    });
+  },
+});
+
+export const BfGraphQLTranscriptCreateMutation = mutationField("createTranscript", {
+  type: BfGraphQLTranscriptType,
+  args: {
+    transcript: nonNull(stringArg()),
+  },
+  resolve: async (_, { transcript }, { bfCurrentViewer }) => {
+    logger.debug("createTranscript", { transcript });
+    const newTranscript = await BfTranscript.create(bfCurrentViewer, {
+      transcript,
+    });
+    logger.debug("Created new transcript successfully", newTranscript);
+    return newTranscript.toGraphql();
+  },
+});
+
+
+export const BfGraphQLTranscriptDeleteMutation = mutationField("deleteTranscript", {
+  type: BfGraphQLTranscriptType,
+  args: {
+    id: nonNull(stringArg()),
+  },
+  resolve: async (_, { id }, { bfCurrentViewer }) => {
+    const transcript = await BfTranscript.find(bfCurrentViewer, id)
+    logger.debug("deleteTranscript", { id });
+    await transcript.delete();
+    logger.debug("Deleted transcript successfully");
+    return transcript.toGraphql();
+  },
+});

--- a/packages/graphql/types/mod.ts
+++ b/packages/graphql/types/mod.ts
@@ -16,5 +16,6 @@ export * from "packages/graphql/types/BfGraphQLGoogleDriveFolder.ts";
 export * from "packages/graphql/types/BfGraphQLNode.ts";
 export * from "packages/graphql/types/BfGraphQLOrganization.ts";
 export * from "packages/graphql/types/BfGraphQLPerson.ts";
+export * from "packages/graphql/types/BfGraphQLTranscript.ts";
 export * from "packages/graphql/types/File.ts";
 export * from "packages/graphql/types/Url.ts";


### PR DESCRIPTION
[1/4] transcript model/graphql

Summary: Added BfTranscript model and BfGraphQLTranscript.
Added `delete` to Model and bfDb

Test Plan:

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/322).
* #343
* #342
* #341
* #329
* #328
* #324
* __->__ #322