### PR TITLE
VCS batch runner: print out full error and exit

### DIFF
--- a/thirdParty/daily-vcs-main/js/src/loader-base.js
+++ b/thirdParty/daily-vcs-main/js/src/loader-base.js
@@ -72,7 +72,10 @@ export function makeVCSRootContainer(
       console.error(msg);
     }
 
-    static getDerivedStateFromError(_error) {
+    static getDerivedStateFromError(error) {
+      if (errorCb) {
+        errorCb(error);
+      }
       return { hasError: true };
     }
 

--- a/thirdParty/daily-vcs-main/js/vcs-batch-runner.js
+++ b/thirdParty/daily-vcs-main/js/vcs-batch-runner.js
@@ -272,14 +272,19 @@ function compGetSourceMetadataCb(comp, type, src) {
   return ret;
 }
 
-function compErrorCb(error, info) {
-  const { componentStack } = info;
+let compHasError = false;
 
-  console.error(
-    '** VCS composition error during React render: %s - ',
-    error,
-    componentStack
-  );
+function compErrorCb(error, info) {
+  if (info) {
+    console.error(
+      '** VCS composition error during React render: %s - ',
+      error,
+      info.componentStack
+    );
+  } else {
+    console.error('** VCS composition error during React render: ', error);
+  }
+  compHasError = true;
 }
 
 let cachedOutputJson = {
@@ -288,6 +293,10 @@ let cachedOutputJson = {
 };
 
 function compUpdatedCb(comp) {
+  if (compHasError) {
+    console.error("** Can't continue after React error");
+    process.exit(9);
+  }
   if (!batchState.initialStateApplied) return;
 
   logToHostInfo(


### PR DESCRIPTION
Catch React errors early for VCS batch runner and print out the stack trace.