### PR TITLE
Set up server vcs builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 .git
 .sl
 .env.local
+.DS_Store

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1717530100,
-        "narHash": "sha256-b4Dn+PnrZoVZ/BoR9JN2fTxXxplJrAsdSUIePf4Cacs=",
+        "lastModified": 1722869614,
+        "narHash": "sha256-7ojM1KSk3mzutD7SkrdSflHXEujPvW1u7QuqWoTLXQU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a2e1d0414259a144ebdc048408a807e69e0565af",
+        "rev": "883180e6550c1723395a3a342f830bfc5c371f6b",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "type": "indirect"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
-    nixpkgs.url = "nixpkgs/nixos-23.11";
+    nixpkgs.url = "nixpkgs/nixos-24.05";
     nixpkgs-unstable.url = "nixpkgs/nixos-unstable";
   };
 
@@ -51,7 +51,21 @@
         # these packages show up with "direnv allow"
         devShellPackages = with pkgs; [
           jq
-        ];
+          nodejs_22
+          rustc
+          zlib
+          libpng
+          pkg-config
+          freetype
+          meson
+          argp-standalone
+          ninja
+        ] ++ (if pkgs.stdenv.isDarwin then
+          with pkgs.darwin.apple_sdk.frameworks; [
+            CoreGraphics
+            CoreText
+          ]
+        else []);
 
         deployPackages = with pkgs; [
         ];

--- a/packages/vcs/cli-render/bf-vcscut-tools/install_and_build_vcsrender.sh
+++ b/packages/vcs/cli-render/bf-vcscut-tools/install_and_build_vcsrender.sh
@@ -5,7 +5,7 @@ echo "This script will install dependencies needed by vcsrender and build the to
 if [[ "$OSTYPE" == "darwin"* ]]; then
   echo "Installing Mac dependencies..."
   # install package if not already available
-  brew install argp-standalone meson 2>/dev/null && true
+  brew install webp jpeg-turbo argp-standalone meson 2>/dev/null && true
 fi
 
 set -e


### PR DESCRIPTION
Set up server vcs builds

Summary:

Will work on a mac probably™. Requires brew. Needs to be nixified if we want it to be easier to use on replit.

Test Plan:

```sh
cd packages/vcs/cli-render/bf-vcscut-tools
./install_and_build_vcsrenderer.sh
npm run render ../example-data/short_clip.mp4
```
<!-- GitContextStart -->
- - -
This pull request can be reviewed on [<img src="https://gitcontext.com/logo/GitContextButton.svg" height="32" align="absmiddle" alt="GitContext.com"/>](https://gitcontext.com/app/prs/github/bolt-foundry/bolt-foundry/330)
<!-- GitContextEnd -->