### PR TITLE
Add google auth lib

### DIFF
--- a/aws/client/components/FontPreload.tsx
+++ b/aws/client/components/FontPreload.tsx
@@ -1,16 +1,16 @@
 import { React } from "aws/client/deps.ts";
-import { fontBoldWeights } from "packages/vcs/params.js";
+// import { fontBoldWeights } from "packages/vcs/params.js";
 
 export default function FontPreload({ fontFamily }) {
-  if (!fontFamily) return null;
-  const fontWeight = fontBoldWeights[fontFamily];
+  // if (!fontFamily) return null;
+  // const fontWeight = fontBoldWeights[fontFamily];
 
-  return (
-    <div
-      className="fontPreload"
-      style={{ fontFamily: `"${fontFamily}", "Papyrus"`, fontWeight }}
-    >
-      {fontFamily}
-    </div>
-  );
+  // return (
+  //   <div
+  //     className="fontPreload"
+  //     style={{ fontFamily: `"${fontFamily}", "Papyrus"`, fontWeight }}
+  //   >
+  //     {fontFamily}
+  //   </div>
+  // );
 }

--- a/aws/client/components/SettingsForm.tsx
+++ b/aws/client/components/SettingsForm.tsx
@@ -9,7 +9,7 @@ import Input from "aws/client/ui_components/Input.tsx";
 import RatioSelector from "aws/client/components/RatioSelector.tsx";
 import Toggle from "aws/client/ui_components/Toggle.tsx";
 import DropdownSelector from "aws/client/ui_components/DropdownSelector.tsx";
-import { fontFamilies } from "packages/vcs/params.js";
+// import { fontFamilies } from "packages/vcs/compositions/params.js";
 import {
   useFeatureFlag,
   useFeatureVariant,
@@ -17,7 +17,7 @@ import {
 import { SettingsFormQuery_settings$key } from "aws/__generated__/SettingsFormQuery_settings.graphql.ts";
 import { WatermarkLogoType } from "aws/types/settings.ts";
 import { hexToRgb, rgbToHex } from "aws/client/lib/color.ts";
-import { imagePreloads } from "packages/vcs/preloads.js";
+import { imagePreloads } from "packages/vcs/compositions/preloads.js";
 import classnames from "aws/client/lib/classnames.ts";
 import Button from "aws/client/ui_components/Button.tsx";
 import TextArea from "aws/client/ui_components/TextArea.tsx";
@@ -365,7 +365,7 @@ export default function SettingsForm(
             />
           }
         />
-        {enableCaptionFonts && (
+        {/* {enableCaptionFonts && (
           <RowTemplate
             changed={changedSettings != null &&
               changedSettings.indexOf("font") > -1}
@@ -390,7 +390,7 @@ export default function SettingsForm(
               />
             }
           />
-        )}
+        )} */}
         {enableCaptionTemplates && (
           <>
             <RowTemplate

--- a/import_map.json
+++ b/import_map.json
@@ -40,7 +40,8 @@
     "graphql": "npm:graphql@16.6.0",
     "nexus": "npm:nexus@1.3.0",
     "@neon/serverless": "jsr:@neon/serverless@0.9.2",
-    "@replit/object-storage": "npm:@replit/object-storage@1.0.0"
+    "@replit/object-storage": "npm:@replit/object-storage@1.0.0",
+    "google-auth-library": "npm:google-auth-library@9.2.0"
   },
   "scopes": {}
 }

--- a/infra/internalbf.com/client/deps.ts
+++ b/infra/internalbf.com/client/deps.ts
@@ -1,3 +1,7 @@
+/// <reference path="https://esm.sh/v135/@types/google.accounts@0.0.14/index.d.ts" />
+/// <reference path="https://esm.sh/v135/@types/google.picker@0.0.42/index.d.ts" />
+/// <reference path="https://esm.sh/v135/@types/gapi.drive@0.0.9/index.d.ts" />
+/// <reference path="https://esm.sh/v135/@types/gapi@0.0.47/index.d.ts" />
 export * as ReactDOMClient from "react-dom/client";
 export * as GraphqlWs from "https://esm.sh/graphql-ws@5.14.0";
 import "infra/__generated__/_graphql_imports.ts";

--- a/lib/googleOauth.ts
+++ b/lib/googleOauth.ts
@@ -1,4 +1,4 @@
-import { OAuth2Client } from "npm:google-auth-library@9.2.0";
+import { OAuth2Client } from "google-auth-library";
 import { BfError } from "lib/BfError.ts";
 const GOOGLE_OAUTH_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth";
 const GOOGLE_OAUTH_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";


### PR DESCRIPTION
Summary:

This brings in google's gapi library so we can use google auth extended for google drive, as well as open the official google drive file picker

Test Plan:
<!-- GitContextStart -->
- - -
This pull request can be reviewed on [<img src="https://gitcontext.com/logo/GitContextButton.svg" height="32" align="absmiddle" alt="GitContext.com"/>](https://gitcontext.com/app/prs/github/bolt-foundry/bolt-foundry/333)
<!-- GitContextEnd -->