### PR TITLE
Fix camel case keys like BfSClassName to properly query

### DIFF
--- a/infra/lib/jupyterUtils.ts
+++ b/infra/lib/jupyterUtils.ts
@@ -23,8 +23,7 @@ export async function getJupyterCurrentViewer(
     BfAccount.name,
   );
   if (!accountRow) {
-    logger.error("No account row for JUPYTER_BFACCOUNT_BFGID", userId);
-    return null;
+    throw new Error("No account row for JUPYTER_BFACCOUNT_BFGID");
   }
 
   const omniCv = IBfCurrentViewerInternalAdminOmni.__DANGEROUS__create(import.meta);


### PR DESCRIPTION
Summary:

Before, when trying to query keys with consecutive caps, we wouldn't underscore them, which is the expected db behavior.

This fixes that.

Also adds some convenience logging

Test Plan:

Notebook in stacked diff
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/380).
* #383
* #382
* #381
* __->__ #380
* #379
<!-- GitContextStart -->
- - -
This pull request can be reviewed on [<img src="https://gitcontext.com/logo/GitContextButton.svg" height="32" align="absmiddle" alt="GitContext.com"/>](https://gitcontext.com/app/prs/github/bolt-foundry/bolt-foundry/380)
<!-- GitContextEnd -->