### PR TITLE
Adds ability to query multiple items at once by bfgid

### DIFF
--- a/infra/lib/jupyterUtils.ts
+++ b/infra/lib/jupyterUtils.ts
@@ -23,8 +23,7 @@ export async function getJupyterCurrentViewer(
     BfAccount.name,
   );
   if (!accountRow) {
-    logger.error("No account row for JUPYTER_BFACCOUNT_BFGID", userId);
-    return null;
+    throw new Error("No account row for JUPYTER_BFACCOUNT_BFGID");
   }
 
   const omniCv = IBfCurrentViewerInternalAdminOmni.__DANGEROUS__create(import.meta);

--- a/packages/bfDb/classes/BfModel.ts
+++ b/packages/bfDb/classes/BfModel.ts
@@ -160,16 +160,19 @@ export abstract class BfBaseModel<
     currentViewer: BfCurrentViewer,
     metadataToQuery: Partial<BfBaseModelMetadata<TCreationMetadata>>,
     propsToQuery: Partial<TRequiredProps & TOptionalProps> = {},
+    bfGids: Array<BfAnyid> = [],
   ): Promise<
     Array<InstanceType<TThis> & BfBaseModelMetadata<TCreationMetadata>>
   > {
     const currentViewerIsAdmin = currentViewer instanceof
       IBfCurrentViewerInternalAdmin;
+    logger.debug("Current viewer is admin:", currentViewerIsAdmin)
 
     const queryableMetadata = {
       ...metadataToQuery,
       className: this.name,
     };
+    
     if (currentViewerIsAdmin) {
       if (metadataToQuery.bfOid != null) {
         queryableMetadata.bfOid = metadataToQuery.bfOid;
@@ -177,13 +180,16 @@ export abstract class BfBaseModel<
     } else {
       queryableMetadata.bfOid = currentViewer.organizationBfGid;
     }
+    logger.debug("Queryable metadata:", queryableMetadata);
     const items = await bfQueryItems<
       TRequiredProps & Partial<TOptionalProps>,
       BfBaseModelMetadata<TCreationMetadata>
     >(
       queryableMetadata,
       propsToQuery,
+      bfGids,
     );
+    logger.debug("Items:", items);
 
     return items.map(({ props, metadata }) => {
       const model = new this(currentViewer, props, {}, metadata, true);
@@ -206,7 +212,7 @@ export abstract class BfBaseModel<
     metadataToQuery: Partial<BfBaseModelMetadata<TCreationMetadata>>,
     propsToQuery: Partial<TRequiredProps & TOptionalProps> = {},
     connectionArgs: ConnectionArguments,
-    bfGids = [],
+    bfGids: Array<BfAnyid> = [],
   ): Promise<
     ConnectionInterface<
       InstanceType<TThis> & BfBaseModelMetadata<TCreationMetadata>


### PR DESCRIPTION
Summary:

Lets users query directly by multiple IDs instead of having to use other things.

Test Plan:

stacked notebook
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/381).
* #383
* #382
* __->__ #381
* #380
* #379
<!-- GitContextStart -->
- - -
This pull request can be reviewed on [<img src="https://gitcontext.com/logo/GitContextButton.svg" height="32" align="absmiddle" alt="GitContext.com"/>](https://gitcontext.com/app/prs/github/bolt-foundry/bolt-foundry/381)
<!-- GitContextEnd -->