### PR TITLE
Set up first draft of ingestion

### DIFF
--- a/experimental/randallb/drive-ingest.ipynb
+++ b/experimental/randallb/drive-ingest.ipynb
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "a9ace635-a08a-440d-a20e-e8f8a05dd61e",
    "metadata": {},
    "outputs": [],
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "6ede9c22-5c12-4976-8fd9-cfc17ac84b22",
    "metadata": {},
    "outputs": [],
@@ -60,20 +60,74 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "4e3b6afa-fdd3-4153-8168-a2537c460584",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "import { BfMedia } from \"packages/bfDb/models/BfMedia.ts\""
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "cd818cfd-593c-4ca3-a192-cc5737bdd1f7",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/runner/randallb-08-22/packages/bfDb/models/BfMediaAudio.ts - \u001b[34mINFO\u001b[39m:  Writing to /tmp/bfMediaAudioCache/1e790d1cbfe64bc2a3de64b5e534a34b.aac\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/runner/randallb-08-22/packages/bfDb/models/BfMediaTranscript.ts - \u001b[31mERROR\u001b[39m:  Need to send to assembly ai probably\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "BfMedia {\n",
+       "  currentViewer: BfCurrentViewerFromAccount {\n",
+       "    organizationBfGid: \u001b[32m\"bf_internal_org\"\u001b[39m,\n",
+       "    role: \u001b[32m\"OWNER\"\u001b[39m,\n",
+       "    personBfGid: \u001b[32m\"google:108810509077746991108\"\u001b[39m,\n",
+       "    accountBfGid: \u001b[32m\"06a63679d1af4956804fe30ada9254ca\"\u001b[39m,\n",
+       "    creator: \u001b[32m\"file:///home/runner/randallb-08-22/infra/lib/jupyterUtils.ts\"\u001b[39m,\n",
+       "    jwtPayload: \u001b[1mnull\u001b[22m,\n",
+       "    __typename: \u001b[32m\"BfCurrentViewerFromAccount\"\u001b[39m\n",
+       "  },\n",
+       "  serverProps: {},\n",
+       "  clientProps: {},\n",
+       "  metadata: {\n",
+       "    bfGid: \u001b[32m\"f37fef2b5078467abaae3089a7a49a47\"\u001b[39m,\n",
+       "    bfSid: \u001b[1mnull\u001b[22m,\n",
+       "    bfTid: \u001b[1mnull\u001b[22m,\n",
+       "    bfOid: \u001b[32m\"bf_internal_org\"\u001b[39m,\n",
+       "    bfCid: \u001b[32m\"06a63679d1af4956804fe30ada9254ca\"\u001b[39m,\n",
+       "    bfTClassName: \u001b[1mnull\u001b[22m,\n",
+       "    bfSClassName: \u001b[1mnull\u001b[22m,\n",
+       "    className: \u001b[32m\"BfMedia\"\u001b[39m,\n",
+       "    createdAt: \u001b[35m2024-08-23T14:25:20.408Z\u001b[39m,\n",
+       "    lastUpdated: \u001b[35m2024-08-23T14:25:20.408Z\u001b[39m\n",
+       "  },\n",
+       "  _cachedProps: {}\n",
+       "}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "\n"
+    "async function downloadFile() {\n",
+    "    return await BfMedia.createFromGoogleDriveResource(file)\n",
+    "}"
    ]
   },
   {

--- a/experimental/randallb/drive-ingest.ipynb
+++ b/experimental/randallb/drive-ingest.ipynb
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "a9ace635-a08a-440d-a20e-e8f8a05dd61e",
    "metadata": {},
    "outputs": [],
@@ -49,7 +49,14 @@
    "id": "6ede9c22-5c12-4976-8fd9-cfc17ac84b22",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "async function createFile() {\n",
+    "    await BfGoogleDriveResource.create(cv, {resourceId: fileId})\n",
+    "}\n",
+    "async function createFolder() {\n",
+    "    await BfGoogleDriveResource.create(cv, {resourceId: folderId})\n",
+    "}    "
+   ]
   },
   {
    "cell_type": "code",

--- a/infra/jobRunner/jobRunner.ts
+++ b/infra/jobRunner/jobRunner.ts
@@ -21,34 +21,40 @@ const currentViewer = IBfCurrentViewerInternalAdminOmni.__DANGEROUS__create(
   import.meta,
 );
 export async function checkForWork(shouldClose = true) {
-  logger.info("Checking for work");
+  logger.debug("Checking for work");
   const jobs = await BfJob.findAvailableJobs(currentViewer);
-  logger.info(`Found ${jobs.length} jobs`);
+  logger.debug(`Found ${jobs.length} jobs`);
   if (jobs.length > 0) {
     const job = jobs[0];
-    logger.info(`Peeling off ${job?.metadata.bfGid}`);
+    logger.info(`Peeling off ${job}`);
     await job.executeJob();
   }
 
   if (shouldCheckForWork) {
-    logger.info(`Setting up next work check in ${WORKER_INTERVAL}ms`);
+    logger.debug(`Setting up next work check in ${WORKER_INTERVAL}ms`);
     setTimeout(checkForWork, WORKER_INTERVAL);
     return;
   }
   logger.info("No work to do, timeout hit.");
   if (shouldClose) {
-    globalThis.close();
+    close();
   }
 }
 export function disableCheckForWork() {
   shouldCheckForWork = false;
 }
 export function close() {
+  disableCheckForWork();
   logger.info("Closing");
   globalThis.close();
 }
 if (import.meta.main) {
   logger.info("Worker is main, starting to check for work");
   checkForWork();
-  setTimeout(disableCheckForWork, WORKER_TIMEOUT);
+  if (WORKER_TIMEOUT > 0) {
+    logger.info(`Worker timeout set to ${WORKER_TIMEOUT}ms`);
+    setTimeout(disableCheckForWork, WORKER_TIMEOUT);
+  } else {
+    logger.info("Worker timeout not set, no timeout");
+  }
 }

--- a/packages/bfDb/classes/BfCurrentViewer.ts
+++ b/packages/bfDb/classes/BfCurrentViewer.ts
@@ -35,6 +35,10 @@ export abstract class BfCurrentViewer {
   ) {
     this.__typename = this.constructor.name;
   }
+
+  toString() {
+    return `${this.constructor.name}(BfAccount#${this.accountBfGid}, role: ${this.role})`;
+  }
 }
 
 export class BfCurrentViewerAnon extends BfCurrentViewer {

--- a/packages/bfDb/models/BfGoogleDriveResource.ts
+++ b/packages/bfDb/models/BfGoogleDriveResource.ts
@@ -12,9 +12,12 @@ import {
 import { BfError } from "lib/BfError.ts";
 import { toBfGid } from "packages/bfDb/classes/BfBaseModelIdTypes.ts";
 import { BfJob } from "packages/bfDb/models/BfJob.ts";
+import { BfMedia } from "packages/bfDb/models/BfMedia.ts";
+
+const GOOGLE_DRIVE_CACHE_DIRECTORY =
+  Deno.env.get("GOOGLE_DRIVE_CACHE_DIRECTORY") ?? "/tmp/google-drive-cache";
 
 const logger = getLogger(import.meta);
-logger.setLevel(logger.levels.TRACE);
 
 type BfGoogleDriveResourceRequiredProps = {
   resourceId: string;
@@ -68,6 +71,12 @@ export class BfGoogleDriveResource
       [],
     );
 
+    const _ingestPromise = BfJob.createJobForNode(
+      this,
+      "__JOB_ONLY__ingest",
+      [],
+    );
+
     await Promise.all([
       googleAuthEdgePromise,
       googleDriveMetadataPromise,
@@ -102,11 +111,7 @@ export class BfGoogleDriveResource
     return this.crawlChildren();
   }
   private async crawlChildren() {
-    logger.debug(
-      "getting folder contents for folder",
-      this.props.resourceId,
-      this.metadata.bfGid,
-    );
+    logger.debug(`getting folder contents for folder ${this}`);
     const token = await this.getAccessToken();
     const response = await fetchFolderContents(token, this.props.resourceId);
     logger.debug("folder contents", response);
@@ -145,10 +150,6 @@ export class BfGoogleDriveResource
       logger.debug("created child and edge", child, edge);
       await this.transactionCommit();
       logger.debug("committed transaction");
-      if (this.props.mimeType.startsWith("video")) {
-        await this.download();
-      }
-      await this.reportProgress(1);
     } catch (e) {
       logger.debug("failed to create child and edge", e);
       await this.transactionRollback();
@@ -157,11 +158,43 @@ export class BfGoogleDriveResource
     }
   }
 
-  async download() {
-    await BfJob.createJobForNode(this, "__JOB_ONLY__download", []);
+  __JOB_ONLY__ingest() {
+    return this.ingest();
   }
-  async __JOB_ONLY__download(targetPath?: string) {
-    const path = targetPath ?? await Deno.makeTempFile();
+
+  private async ingest() {
+    if (this.props.mimeType.startsWith("video")) {
+      await BfMedia.createFromGoogleDriveResource(this);
+    }
+    return this;
+  }
+
+  getFilePath() {
+    return `${GOOGLE_DRIVE_CACHE_DIRECTORY}/${this.metadata.bfGid}`;
+  }
+
+  /**
+   * Retrieves a file handle for the resource.
+   *
+   * We recommend the {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/using using} keyword ensures that system resources are disposed of correctly.
+   * Otherwise you'll need to dispose of the file handle yourself.
+   *
+   * @example
+   * const fileHandle = await bfGoogleDriveResource.getFileHandle();
+   *
+   * @example
+   * const fileHandle = await bfGoogleDriveResource.getFileHandle();
+   * fileHandle.close();
+   */
+  async getFileHandle(): Promise<Deno.FsFile> {
+    const existsOnDisk = await Deno.stat(this.getFilePath()).then(() => true)
+      .catch(() => false);
+    return existsOnDisk ? Deno.open(this.getFilePath()) : this.download();
+  }
+
+  private async download(targetPath = this.getFilePath()) {
+    await Deno.mkdir(GOOGLE_DRIVE_CACHE_DIRECTORY, { recursive: true });
+    const path = targetPath;
     const token = await this.getAccessToken();
     const response = await fetchFile(token, this.props.resourceId);
     logger.debug("downloading", this.props.resourceId, path);
@@ -186,6 +219,7 @@ export class BfGoogleDriveResource
       logger.debug("downloaded", this.props.resourceId, path);
       this.reportProgress(1);
     }
+    return file;
   }
 
   private async reportProgress(progress: number) {

--- a/packages/bfDb/models/BfGoogleDriveResource.ts
+++ b/packages/bfDb/models/BfGoogleDriveResource.ts
@@ -145,14 +145,22 @@ export class BfGoogleDriveResource
       logger.debug("created child and edge", child, edge);
       await this.transactionCommit();
       logger.debug("committed transaction");
+      if (this.props.mimeType.startsWith("video")) {
+        await this.download();
+      }
+      await this.reportProgress(1);
     } catch (e) {
       logger.debug("failed to create child and edge", e);
       await this.transactionRollback();
       logger.debug("rolled back transaction");
-      throw new BfError("Error creating child", e);
+      throw e;
     }
   }
-  async download(targetPath?: string) {
+
+  async download() {
+    await BfJob.createJobForNode(this, "__JOB_ONLY__download", []);
+  }
+  async __JOB_ONLY__download(targetPath?: string) {
     const path = targetPath ?? await Deno.makeTempFile();
     const token = await this.getAccessToken();
     const response = await fetchFile(token, this.props.resourceId);
@@ -176,15 +184,12 @@ export class BfGoogleDriveResource
         }
       }
       logger.debug("downloaded", this.props.resourceId, path);
-      await this.reportProgress(1);
+      this.reportProgress(1);
     }
   }
 
   private async reportProgress(progress: number) {
     logger.debug("reporting progress", progress, this.metadata.bfGid);
-    if (this.props == undefined) {
-      logger.debug("props is undefined", this.metadata.bfGid, this);
-    }
     this.props.ingestionProgress = progress;
     await this.save();
     return this;

--- a/packages/bfDb/models/BfJob.ts
+++ b/packages/bfDb/models/BfJob.ts
@@ -63,12 +63,12 @@ export class BfJob extends BfNode<BfJobRequiredProps, Record<string, never>> {
     );
     if (runInForeground) {
       logger.warn(
-        "Job running in foreground. It's not super reflective of actual behavior running a job in the foreground, probably only best to do for debugging sake.",
+        `${job} running in foreground (likely of current web request.) It's not reflective of actual behavior, best only to do for debugging sake.`,
       );
       await job.executeJob();
     } else if (runImmediately) {
       logger.warn(
-        "Job executing immediately in background. Production runs should execute as an asynchronous job.",
+        `${job} executing in next tick in background. Production runs should execute as an asynchronous job.`,
       );
       job.executeJob();
     }
@@ -90,7 +90,7 @@ export class BfJob extends BfNode<BfJobRequiredProps, Record<string, never>> {
   }
 
   async executeJob() {
-    logger.debug("Executing job");
+    logger.debug(`Executing job ${this}`);
     this.props.status = BfJobType.RUNNING;
     await this.save();
     const edges = await BfEdge.queryAllSourceEdgesForNode(this);

--- a/packages/bfDb/models/BfMedia.ts
+++ b/packages/bfDb/models/BfMedia.ts
@@ -6,6 +6,10 @@ import { render } from "infra/bff/friends/render.bff.ts";
 import { fetchFile } from "lib/googleDriveApi.ts";
 import { BfPerson } from "packages/bfDb/models/BfPerson.ts";
 import { sanitizeFilename } from "packages/lib/textUtils.ts";
+import { BfGoogleDriveResource } from "packages/bfDb/models/BfGoogleDriveResource.ts";
+import { BfEdge } from "packages/bfDb/coreModels/BfEdge.ts";
+import { BfMediaAudio } from "packages/bfDb/models/BfMediaAudio.ts";
+import { BfMediaTranscript } from "packages/bfDb/models/BfMediaTranscript.ts";
 
 const logger = getLogger(import.meta);
 
@@ -35,8 +39,35 @@ export class BfMedia extends BfNode<BfMediaProps> {
     return media;
   }
 
-  example(args: unknown) {
-    logger.info("this is an example job", this.currentViewer, args);
+  static async createFromGoogleDriveResource(
+    driveResource: BfGoogleDriveResource,
+  ) {
+    const bfMediaAudioPromise = BfMediaAudio.createFromGoogleDriveResource(
+      driveResource,
+    );
+    const bfMedia = await this.create(driveResource.currentViewer, {});
+    await BfEdge.createEdgeBetweenNodes(
+      bfMedia.currentViewer,
+      bfMedia,
+      driveResource,
+    );
+
+    const bfMediaAudio = await bfMediaAudioPromise;
+    await BfEdge.createEdgeBetweenNodes(
+      bfMedia.currentViewer,
+      bfMedia,
+      bfMediaAudio,
+    );
+    const bfMediaTranscript = await BfMediaTranscript.createFromBfMediaAudio(
+      bfMediaAudio,
+    );
+    await BfEdge.createEdgeBetweenNodes(
+      bfMedia.currentViewer,
+      bfMedia,
+      bfMediaTranscript,
+    );
+
+    return bfMedia;
   }
 
   async downloadClip(args: DownloadClipArgs) {

--- a/packages/bfDb/models/BfMediaAudio.ts
+++ b/packages/bfDb/models/BfMediaAudio.ts
@@ -1,0 +1,72 @@
+import { BfNode } from "packages/bfDb/coreModels/BfNode.ts";
+import { BfGoogleDriveResource } from "packages/bfDb/models/BfGoogleDriveResource.ts";
+import { getLogger } from "deps.ts";
+
+const BF_MEDIA_AUDIO_CACHE_LOCATION = "/tmp/bfMediaAudioCache";
+
+const logger = getLogger(import.meta);
+export class BfMediaAudio extends BfNode {
+  static async createFromGoogleDriveResource(
+    googleDriveResource: BfGoogleDriveResource,
+  ) {
+    await Deno.mkdir(BF_MEDIA_AUDIO_CACHE_LOCATION, { recursive: true });
+    logger.setLevel(logger.levels.DEBUG);
+    const fileHandlePromise = googleDriveResource.getFileHandle();
+    const bfMediaAudio = await this.create(
+      googleDriveResource.currentViewer,
+      {},
+    );
+    const outputPath = bfMediaAudio.getFilePath();
+    logger.info(`Writing to ${outputPath}`);
+
+    const args = [
+      "-i",
+      "-",
+      "-codec:a",
+      "aac",
+      "-b:a",
+      "256k",
+      "-y",
+      "-progress",
+      "pipe:2",
+      "-stats_period",
+      "0.2", // seconds
+      "-v",
+      "quiet",
+      outputPath,
+    ];
+
+    const ffmpegProcess = new Deno.Command("ffmpeg", {
+      args,
+      stdin: "piped",
+      stderr: "piped",
+    });
+
+    const { stdin, stderr } = ffmpegProcess.spawn();
+    using fileHandle = await fileHandlePromise;
+    const fileLoadingPromise = fileHandle.readable.pipeTo(stdin);
+
+    const stderrReader = stderr.pipeThrough(new TextDecoderStream())
+      .getReader();
+
+    while (true) {
+      const { done, value } = await stderrReader.read();
+
+      if (done) break;
+
+      const _stats = value.split("\n").reduce((acc, line) => {
+        const [key, value] = line.split("=");
+        if (key) {
+          acc[key] = value?.trim();
+        }
+        return acc;
+      }, {} as Record<string, string>);
+    }
+    await fileLoadingPromise;
+    return bfMediaAudio;
+  }
+
+  getFilePath() {
+    return `${BF_MEDIA_AUDIO_CACHE_LOCATION}/${this.metadata.bfGid}.aac`;
+  }
+}

--- a/packages/bfDb/models/BfMediaTranscript.ts
+++ b/packages/bfDb/models/BfMediaTranscript.ts
@@ -1,17 +1,42 @@
 import { BfNode } from "packages/bfDb/coreModels/BfNode.ts";
 import { BfCurrentViewer } from "packages/bfDb/classes/BfCurrentViewer.ts";
+import { BfMediaAudio } from "packages/bfDb/models/BfMediaAudio.ts";
+import { getLogger } from "deps.ts";
 
+const logger = getLogger(import.meta);
+
+enum BfMediaTranscriptStatus {
+  CREATED = "CREATED",
+  PROCESSING = "PROCESSING",
+  COMPLETED = "COMPLETED",
+}
 export type BfMediaTranscriptProps = {
   id: string;
   words: string;
   filename: string;
+  status: BfMediaTranscriptStatus;
 };
 
 export class BfMediaTranscript extends BfNode<BfMediaTranscriptProps> {
+  /**
+   * @deprecated don't use this.
+   */
   static async findTranscriptsByViewer(bfCurrentViewer: BfCurrentViewer) {
     const transcripts = await this.query(bfCurrentViewer, {
       bfOid: bfCurrentViewer.organizationBfGid,
     });
     return transcripts;
+  }
+
+  static async createFromBfMediaAudio(bfMediaAudio: BfMediaAudio) {
+    const transcript = await this.create(bfMediaAudio.currentViewer, {
+      status: BfMediaTranscriptStatus.CREATED,
+    });
+    await transcript.populateFromBfMediaAudio(bfMediaAudio);
+    return transcript;
+  }
+
+  async populateFromBfMediaAudio(_bfMediaAudio: BfMediaAudio) {
+    await logger.error("Need to send to assembly ai probably");
   }
 }


### PR DESCRIPTION

Summary:

Videos should theoretically ingest now in a job, and we should be creating audio files.

Test Plan:
NB has the example:

```
await BfMedia.createFromGoogleDriveResource(file)
// returns BfMedia#bfGid
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/512).
* #486
* __->__ #512
* #511
* #510
* #509
* #508