### PR TITLE
rm node_modules on repl boot

### DIFF
--- a/infra/bff/friends/boot.bff.ts
+++ b/infra/bff/friends/boot.bff.ts
@@ -1,11 +1,10 @@
 import { register } from "infra/bff/mod.ts";
-import { runShellCommand } from "infra/bff/shellBase.ts";
 
 register(
   "boot",
   "initializes the repl with applicable options when the repl boots up",
   async () => {
-    await runShellCommand(["bff"]);
-    return await 0;
+    await Deno.remove(`${Deno.env.get("BF_PATH")!}/node_modules`, { recursive: true });
+    return 0;
   },
 );


### PR DESCRIPTION
Summary:

deals with node_modules having absolute symlinks from Deno.

Test Plan:
<!-- GitContextStart -->
- - -
This pull request can be reviewed on [<img src="https://gitcontext.com/logo/GitContextButton.svg" height="32" align="absmiddle" alt="GitContext.com"/>](https://gitcontext.com/app/prs/github/bolt-foundry/bolt-foundry/528)
<!-- GitContextEnd -->