### PR TITLE
Update BfNode's new createTargetNode to have stronger typing

### DIFF
--- a/infra/bff/friends/boot.bff.ts
+++ b/infra/bff/friends/boot.bff.ts
@@ -4,7 +4,9 @@ register(
   "boot",
   "initializes the repl with applicable options when the repl boots up",
   async () => {
-    await Deno.remove(`${Deno.env.get("BF_PATH")!}/node_modules`, { recursive: true });
+    await Deno.remove(`${Deno.env.get("BF_PATH")!}/node_modules`, {
+      recursive: true,
+    });
     return 0;
   },
 );

--- a/infra/bff/friends/transcribe.bff.ts
+++ b/infra/bff/friends/transcribe.bff.ts
@@ -10,7 +10,6 @@ import { BfMediaTranscript } from "packages/bfDb/models/BfMediaTranscript.ts";
 import { BfMedia } from "packages/bfDb/models/BfMedia.ts";
 import { BfAnyid } from "packages/bfDb/classes/BfBaseModelIdTypes.ts";
 import { BfError } from "lib/BfError.ts";
-import { BfNode } from "packages/bfDb/coreModels/BfNode.ts";
 
 const logger = getLogger(import.meta);
 
@@ -77,8 +76,7 @@ export async function createTranscript(
   // create transcript
   logger.info("Creating Transcript");
   const bfTranscript = await bfMedia.createTargetNode(
-    currentViewer,
-    BfMediaTranscript as typeof BfNode,
+    BfMediaTranscript,
     {
       words: JSON.stringify(transcript.words),
       filename: inputAudio,

--- a/packages/bfDb/classes/BfModel.ts
+++ b/packages/bfDb/classes/BfModel.ts
@@ -356,6 +356,33 @@ instance methods at the bottom alphabetized. This is to make it easier to find t
       & Partial<TOptionalProps>;
   }
 
+  protected async beforeCreate() {}
+  protected async afterCreate() {}
+  protected async beforeLoad() {}
+  protected async beforeSave() {}
+  protected async afterSave() {}
+
+  protected toString() {
+    return `${this.constructor.name}#${this.metadata.bfGid}`;
+  }
+
+  protected validateSave(): Promise<boolean> | boolean {
+    return true;
+  }
+  protected validatePermissions(
+    action: ACCOUNT_ACTIONS,
+  ): Promise<boolean> | boolean {
+    const availableActions = getAvailableActionsForRole(
+      this.currentViewer.role,
+    );
+    if (availableActions.includes(action)) {
+      return true;
+    }
+    throw new BfModelErrorPermission(
+      `Your role (${this.currentViewer.role}) does not have permission to ${action} on ${this.constructor.name}.`,
+    );
+  }
+
   toGraphql() {
     return {
       ...this.props,
@@ -365,12 +392,6 @@ instance methods at the bottom alphabetized. This is to make it easier to find t
         this.constructor.name,
     };
   }
-
-  beforeLoad(): Promise<void> | void {}
-
-  beforeCreate(): Promise<void> | void {}
-
-  afterCreate(): Promise<void> | void {}
 
   async load() {
     await this.beforeLoad();
@@ -428,9 +449,6 @@ instance methods at the bottom alphabetized. This is to make it easier to find t
     }
   }
 
-  async beforeSave() {}
-  async afterSave() {}
-
   async save() {
     await this.beforeSave();
     await Promise.all([
@@ -445,23 +463,7 @@ instance methods at the bottom alphabetized. This is to make it easier to find t
     await this.afterSave();
   }
 
-  validatePermissions(action: ACCOUNT_ACTIONS): Promise<boolean> | boolean {
-    const availableActions = getAvailableActionsForRole(
-      this.currentViewer.role,
-    );
-    if (availableActions.includes(action)) {
-      return true;
-    }
-    throw new BfModelErrorPermission(
-      `Your role (${this.currentViewer.role}) does not have permission to ${action} on ${this.constructor.name}.`,
-    );
-  }
-
-  validateSave(): Promise<boolean> {
-    return Promise.resolve(true);
-  }
-
-  public async delete() {
+  async delete() {
     await this.validatePermissions(ACCOUNT_ACTIONS.DELETE);
     try {
       await bfDeleteItem(this.metadata.bfOid, this.metadata.bfGid);
@@ -482,10 +484,6 @@ instance methods at the bottom alphabetized. This is to make it easier to find t
   }
   public async transactionRollback() {
     await transactionRollback();
-  }
-
-  toString() {
-    return `${this.constructor.name}#${this.metadata.bfGid}`;
   }
 }
 

--- a/packages/bfDb/coreModels/BfEdge.ts
+++ b/packages/bfDb/coreModels/BfEdge.ts
@@ -19,7 +19,7 @@ const logger = getLogger(import.meta);
 export type BfEdgeRequiredProps = Record<string, never>;
 
 export type BfEdgeOptionalProps = {
-  action?: string;
+  role?: string;
 };
 
 export type EdgeCreationMetadata = {
@@ -57,6 +57,7 @@ export class BfEdge<
     currentViewer: BfCurrentViewer,
     sourceNode: BfNode,
     targetNode: BfNode,
+    role?: string,
   ): Promise<BfEdge> {
     const metadata = {
       bfTClassName: targetNode.constructor.name,
@@ -65,7 +66,7 @@ export class BfEdge<
       bfSid: sourceNode.metadata.bfGid,
     } as EdgeCreationMetadata;
 
-    const newEdge = await BfEdge.create(currentViewer, {}, metadata);
+    const newEdge = await BfEdge.create(currentViewer, { role }, metadata);
     return newEdge;
   }
 
@@ -155,7 +156,7 @@ export class BfEdge<
     const sourceEdgeIds = sourceEdges.map((edge: BfNode) => edge.metadata.bfSid)
       .filter(Boolean) as Array<BfSid>;
     logger.debug("sourceEdgeIds", sourceEdgeIds);
-    const sources = await SourceClass.query(
+    const sources = await (SourceClass as typeof BfNode).query(
       currentViewer,
       {},
       propsToQuery,

--- a/packages/bfDb/coreModels/BfNode.ts
+++ b/packages/bfDb/coreModels/BfNode.ts
@@ -4,7 +4,6 @@ import {
   Constructor,
   CreationMetadata,
 } from "packages/bfDb/classes/BfBaseModelMetadata.ts";
-import { BfCurrentViewer } from "packages/bfDb/classes/BfCurrentViewer.ts";
 import { BfEdge } from "packages/bfDb/coreModels/BfEdge.ts";
 import { getLogger } from "deps.ts";
 const logger = getLogger(import.meta);
@@ -23,43 +22,42 @@ export class BfNode<
   ChildCreationMetadata
 > {
   public async createTargetNode<
-    TThis extends Constructor<
-      BfModel<TRequiredProps, TOptionalProps, TCreationMetadata>
+    TTargetClass extends Constructor<
+      BfModel<TProps, Record<string, unknown>, TCreationMetadata>
     >,
-    TRequiredProps,
-    TOptionalProps,
-    TCreationMetadata extends CreationMetadata,
+    TProps extends Record<string, unknown>,
+    TCreationMetadata extends BfBaseModelMetadata<CreationMetadata> =
+      BfBaseModelMetadata<CreationMetadata>,
   >(
-    this: BfNode,
-    currentViewer: BfCurrentViewer,
-    TargetClass: typeof BfNode,
-    targetProps: TRequiredProps & Partial<TOptionalProps>,
-    targetCreationMetadata: TCreationMetadata,
-  ): Promise<
-    InstanceType<TThis> & BfBaseModelMetadata<TCreationMetadata>
-  > {
+    TargetClass: TTargetClass,
+    targetProps: TProps,
+    role?: string,
+    targetCreationMetadata?: TCreationMetadata,
+  ) {
     logger.debug("createTargetNode", {
-      currentViewer,
       TargetClass,
       targetProps,
       targetCreationMetadata,
     });
-    const targetModel = await TargetClass.create(
-      currentViewer,
+
+    const targetModel = await (TargetClass as unknown as typeof BfNode).create(
+      this.currentViewer,
       targetProps,
       targetCreationMetadata,
     );
     await BfEdge.createEdgeBetweenNodes(
-      currentViewer,
+      this.currentViewer,
       this,
       targetModel,
+      role,
     );
     logger.debug("created edge", {
       sourceId: this.metadata.bfGid,
+      sourceClass: this.constructor.name,
       targetId: targetModel.metadata.bfGid,
+      targetClass: targetModel.constructor.name,
+      role,
     });
-    return targetModel as unknown as
-      & InstanceType<TThis>
-      & BfBaseModelMetadata<TCreationMetadata>;
+    return targetModel as InstanceType<TTargetClass>;
   }
 }


### PR DESCRIPTION

Summary:

Makes the types resilliant to issues when creating target nodes. Pretty cool!

Also changing edges so they have a "role" prop


Test Plan:
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/531).
* #532
* __->__ #531
* #530
* #529