### PR TITLE
Rename BfModel.create to a __DANGEROUS__ prefix, recommend instead people use bfNode.createTargetNode

### DIFF
--- a/infra/bff/friends/boot.bff.ts
+++ b/infra/bff/friends/boot.bff.ts
@@ -4,7 +4,9 @@ register(
   "boot",
   "initializes the repl with applicable options when the repl boots up",
   async () => {
-    await Deno.remove(`${Deno.env.get("BF_PATH")!}/node_modules`, { recursive: true });
+    await Deno.remove(`${Deno.env.get("BF_PATH")!}/node_modules`, {
+      recursive: true,
+    });
     return 0;
   },
 );

--- a/infra/bff/friends/populate.bff.ts
+++ b/infra/bff/friends/populate.bff.ts
@@ -54,15 +54,18 @@ async function populate(projects = accounting) {
       import.meta,
       "bf_internal_org",
     );
-    const newMedia = await BfMedia.create(currentViewer, {
-      filename: transcript.filename,
-      fileId: transcript.fileId,
-    });
+    const newMedia = await BfMedia.__DANGEROUS__createUnattached(
+      currentViewer,
+      {
+        filename: transcript.filename,
+        fileId: transcript.fileId,
+      },
+    );
     const newTranscript = await BfMediaTranscript.create(currentViewer, {
       words: transcript.words,
       filename: transcript.filename,
     });
-    await BfEdge.create(currentViewer, {}, {
+    await BfEdge.__DANGEROUS__createUnattached(currentViewer, {}, {
       // @ts-expect-error idk why the metadata types are messed up for bf edges.
       bfTClassName: "BfMediaTranscript",
       bfTid: newTranscript.metadata.bfGid,

--- a/infra/bff/friends/transcribe.bff.ts
+++ b/infra/bff/friends/transcribe.bff.ts
@@ -63,7 +63,7 @@ export async function createTranscript(
     bfMedia = await BfMedia.find(currentViewer, mediaId as BfAnyid);
     logger.info("Media found");
   } else {
-    bfMedia = await BfMedia.create(currentViewer, {
+    bfMedia = await BfMedia.__DANGEROUS__createUnattached(currentViewer, {
       filename: "New media",
     });
     logger.info("Media created", bfMedia.metadata.bfGid);

--- a/infra/bff/friends/transcribe.bff.ts
+++ b/infra/bff/friends/transcribe.bff.ts
@@ -10,7 +10,6 @@ import { BfMediaTranscript } from "packages/bfDb/models/BfMediaTranscript.ts";
 import { BfMedia } from "packages/bfDb/models/BfMedia.ts";
 import { BfAnyid } from "packages/bfDb/classes/BfBaseModelIdTypes.ts";
 import { BfError } from "lib/BfError.ts";
-import { BfNode } from "packages/bfDb/coreModels/BfNode.ts";
 
 const logger = getLogger(import.meta);
 
@@ -77,8 +76,7 @@ export async function createTranscript(
   // create transcript
   logger.info("Creating Transcript");
   const bfTranscript = await bfMedia.createTargetNode(
-    currentViewer,
-    BfMediaTranscript as typeof BfNode,
+    BfMediaTranscript,
     {
       words: JSON.stringify(transcript.words),
       filename: inputAudio,

--- a/packages/bfDb/classes/BfModel.ts
+++ b/packages/bfDb/classes/BfModel.ts
@@ -356,6 +356,33 @@ instance methods at the bottom alphabetized. This is to make it easier to find t
       & Partial<TOptionalProps>;
   }
 
+  protected async beforeCreate() {}
+  protected async afterCreate() {}
+  protected async beforeLoad() {}
+  protected async beforeSave() {}
+  protected async afterSave() {}
+
+  protected toString() {
+    return `${this.constructor.name}#${this.metadata.bfGid}`;
+  }
+
+  protected validateSave(): Promise<boolean> | boolean {
+    return true;
+  }
+  protected validatePermissions(
+    action: ACCOUNT_ACTIONS,
+  ): Promise<boolean> | boolean {
+    const availableActions = getAvailableActionsForRole(
+      this.currentViewer.role,
+    );
+    if (availableActions.includes(action)) {
+      return true;
+    }
+    throw new BfModelErrorPermission(
+      `Your role (${this.currentViewer.role}) does not have permission to ${action} on ${this.constructor.name}.`,
+    );
+  }
+
   toGraphql() {
     return {
       ...this.props,
@@ -365,12 +392,6 @@ instance methods at the bottom alphabetized. This is to make it easier to find t
         this.constructor.name,
     };
   }
-
-  beforeLoad(): Promise<void> | void {}
-
-  beforeCreate(): Promise<void> | void {}
-
-  afterCreate(): Promise<void> | void {}
 
   async load() {
     await this.beforeLoad();
@@ -428,9 +449,6 @@ instance methods at the bottom alphabetized. This is to make it easier to find t
     }
   }
 
-  async beforeSave() {}
-  async afterSave() {}
-
   async save() {
     await this.beforeSave();
     await Promise.all([
@@ -445,23 +463,7 @@ instance methods at the bottom alphabetized. This is to make it easier to find t
     await this.afterSave();
   }
 
-  validatePermissions(action: ACCOUNT_ACTIONS): Promise<boolean> | boolean {
-    const availableActions = getAvailableActionsForRole(
-      this.currentViewer.role,
-    );
-    if (availableActions.includes(action)) {
-      return true;
-    }
-    throw new BfModelErrorPermission(
-      `Your role (${this.currentViewer.role}) does not have permission to ${action} on ${this.constructor.name}.`,
-    );
-  }
-
-  validateSave(): Promise<boolean> {
-    return Promise.resolve(true);
-  }
-
-  public async delete() {
+  async delete() {
     await this.validatePermissions(ACCOUNT_ACTIONS.DELETE);
     try {
       await bfDeleteItem(this.metadata.bfOid, this.metadata.bfGid);
@@ -482,10 +484,6 @@ instance methods at the bottom alphabetized. This is to make it easier to find t
   }
   public async transactionRollback() {
     await transactionRollback();
-  }
-
-  toString() {
-    return `${this.constructor.name}#${this.metadata.bfGid}`;
   }
 }
 

--- a/packages/bfDb/classes/BfModel.ts
+++ b/packages/bfDb/classes/BfModel.ts
@@ -54,7 +54,15 @@ export abstract class BfBaseModel<
   protected static isSorted = false;
   protected static isSelfOwned = false;
 
-  public static async create<
+  /**
+   * Dangerous, because using this create function lets you create a node not
+   * attached to anything by default. That's pretty dangerous, because it could
+   * result in something never getting deleted.
+   *
+   * Usually, you'll want to use BfNode's createTargetNode function, which would
+   * necessarily tie a node from a source to a target.
+   */
+  public static async __DANGEROUS__createUnattached<
     TThis extends Constructor<
       BfModel<TRequiredProps, TOptionalProps, TCreationMetadata>
     >,

--- a/packages/bfDb/coreModels/BfEdge.ts
+++ b/packages/bfDb/coreModels/BfEdge.ts
@@ -66,7 +66,9 @@ export class BfEdge<
       bfSid: sourceNode.metadata.bfGid,
     } as EdgeCreationMetadata;
 
-    const newEdge = await BfEdge.create(currentViewer, { role }, metadata);
+    const newEdge = await BfEdge.__DANGEROUS__createUnattached(currentViewer, {
+      role,
+    }, metadata);
     return newEdge;
   }
 

--- a/packages/bfDb/coreModels/BfEdge.ts
+++ b/packages/bfDb/coreModels/BfEdge.ts
@@ -19,7 +19,7 @@ const logger = getLogger(import.meta);
 export type BfEdgeRequiredProps = Record<string, never>;
 
 export type BfEdgeOptionalProps = {
-  action?: string;
+  role?: string;
 };
 
 export type EdgeCreationMetadata = {
@@ -57,6 +57,7 @@ export class BfEdge<
     currentViewer: BfCurrentViewer,
     sourceNode: BfNode,
     targetNode: BfNode,
+    role?: string,
   ): Promise<BfEdge> {
     const metadata = {
       bfTClassName: targetNode.constructor.name,
@@ -65,7 +66,7 @@ export class BfEdge<
       bfSid: sourceNode.metadata.bfGid,
     } as EdgeCreationMetadata;
 
-    const newEdge = await BfEdge.create(currentViewer, {}, metadata);
+    const newEdge = await BfEdge.create(currentViewer, { role }, metadata);
     return newEdge;
   }
 
@@ -155,7 +156,7 @@ export class BfEdge<
     const sourceEdgeIds = sourceEdges.map((edge: BfNode) => edge.metadata.bfSid)
       .filter(Boolean) as Array<BfSid>;
     logger.debug("sourceEdgeIds", sourceEdgeIds);
-    const sources = await SourceClass.query(
+    const sources = await (SourceClass as typeof BfNode).query(
       currentViewer,
       {},
       propsToQuery,

--- a/packages/bfDb/coreModels/BfNode.ts
+++ b/packages/bfDb/coreModels/BfNode.ts
@@ -40,11 +40,12 @@ export class BfNode<
       targetCreationMetadata,
     });
 
-    const targetModel = await (TargetClass as unknown as typeof BfNode).create(
-      this.currentViewer,
-      targetProps,
-      targetCreationMetadata,
-    );
+    const targetModel = await (TargetClass as unknown as typeof BfNode)
+      .__DANGEROUS__createUnattached(
+        this.currentViewer,
+        targetProps,
+        targetCreationMetadata,
+      );
     await BfEdge.createEdgeBetweenNodes(
       this.currentViewer,
       this,

--- a/packages/bfDb/coreModels/BfNode.ts
+++ b/packages/bfDb/coreModels/BfNode.ts
@@ -4,7 +4,6 @@ import {
   Constructor,
   CreationMetadata,
 } from "packages/bfDb/classes/BfBaseModelMetadata.ts";
-import { BfCurrentViewer } from "packages/bfDb/classes/BfCurrentViewer.ts";
 import { BfEdge } from "packages/bfDb/coreModels/BfEdge.ts";
 import { getLogger } from "deps.ts";
 const logger = getLogger(import.meta);
@@ -23,43 +22,42 @@ export class BfNode<
   ChildCreationMetadata
 > {
   public async createTargetNode<
-    TThis extends Constructor<
-      BfModel<TRequiredProps, TOptionalProps, TCreationMetadata>
+    TTargetClass extends Constructor<
+      BfModel<TProps, Record<string, unknown>, TCreationMetadata>
     >,
-    TRequiredProps,
-    TOptionalProps,
-    TCreationMetadata extends CreationMetadata,
+    TProps extends Record<string, unknown>,
+    TCreationMetadata extends BfBaseModelMetadata<CreationMetadata> =
+      BfBaseModelMetadata<CreationMetadata>,
   >(
-    this: BfNode,
-    currentViewer: BfCurrentViewer,
-    TargetClass: typeof BfNode,
-    targetProps: TRequiredProps & Partial<TOptionalProps>,
-    targetCreationMetadata: TCreationMetadata,
-  ): Promise<
-    InstanceType<TThis> & BfBaseModelMetadata<TCreationMetadata>
-  > {
+    TargetClass: TTargetClass,
+    targetProps: TProps,
+    role?: string,
+    targetCreationMetadata?: TCreationMetadata,
+  ) {
     logger.debug("createTargetNode", {
-      currentViewer,
       TargetClass,
       targetProps,
       targetCreationMetadata,
     });
-    const targetModel = await TargetClass.create(
-      currentViewer,
+
+    const targetModel = await (TargetClass as unknown as typeof BfNode).create(
+      this.currentViewer,
       targetProps,
       targetCreationMetadata,
     );
     await BfEdge.createEdgeBetweenNodes(
-      currentViewer,
+      this.currentViewer,
       this,
       targetModel,
+      role,
     );
     logger.debug("created edge", {
       sourceId: this.metadata.bfGid,
+      sourceClass: this.constructor.name,
       targetId: targetModel.metadata.bfGid,
+      targetClass: targetModel.constructor.name,
+      role,
     });
-    return targetModel as unknown as
-      & InstanceType<TThis>
-      & BfBaseModelMetadata<TCreationMetadata>;
+    return targetModel as InstanceType<TTargetClass>;
   }
 }

--- a/packages/bfDb/models/BfClip.ts
+++ b/packages/bfDb/models/BfClip.ts
@@ -16,11 +16,14 @@ type BfClipProps = {
 export class BfClip extends BfNode<BfClipProps> {
   async createNewClipReview(videoFile: File) {
     const priorReviews = await this.queryClipReviewEdges();
-    const clipReview = await BfClipReview.create(this.currentViewer, {
-      title: `${this.props.title} (V${priorReviews.length + 1})`,
-    });
+    const clipReview = await BfClipReview.__DANGEROUS__createUnattached(
+      this.currentViewer,
+      {
+        title: `${this.props.title} (V${priorReviews.length + 1})`,
+      },
+    );
     clipReview.addFile(videoFile);
-    await BfEdge.create(this.currentViewer, {}, {
+    await BfEdge.__DANGEROUS__createUnattached(this.currentViewer, {}, {
       bfSid: toBfSid(this.metadata.bfGid),
       bfTid: toBfTid(clipReview.metadata.bfGid),
     });

--- a/packages/bfDb/models/BfGoogleAuth.ts
+++ b/packages/bfDb/models/BfGoogleAuth.ts
@@ -8,7 +8,7 @@ type BfGoogleAuthProps = {
 
 export class BfGoogleAuth extends BfNode<BfGoogleAuthProps> {
   async afterCreate() {
-    await BfEdge.create(this.currentViewer, {}, {
+    await BfEdge.__DANGEROUS__createUnattached(this.currentViewer, {}, {
       // @ts-expect-error idk why the metadata types are messed up for bf edges.
       bfTClassName: this.metadata.className,
       bfTid: this.metadata.bfGid,

--- a/packages/bfDb/models/BfGoogleDriveResource.ts
+++ b/packages/bfDb/models/BfGoogleDriveResource.ts
@@ -57,13 +57,17 @@ export class BfGoogleDriveResource
       throw new Error("no google auth");
     }
 
-    const googleAuthEdgePromise = BfEdge.create(this.currentViewer, {}, {
-      // @ts-expect-error typing is bad on bfEdge
-      bfSid: googleAuth.metadata.bfGid,
-      bfSClassName: "BfGoogleAuth",
-      bfTid: this.metadata.bfGid,
-      bfTClassName: this.constructor.name,
-    });
+    const googleAuthEdgePromise = BfEdge.__DANGEROUS__createUnattached(
+      this.currentViewer,
+      {},
+      {
+        // @ts-expect-error typing is bad on bfEdge
+        bfSid: googleAuth.metadata.bfGid,
+        bfSClassName: "BfGoogleAuth",
+        bfTid: this.metadata.bfGid,
+        bfTClassName: this.constructor.name,
+      },
+    );
 
     const jobPromise = BfJob.createJobForNode(
       this,
@@ -142,7 +146,7 @@ export class BfGoogleDriveResource
     try {
       await this.transactionStart();
       const child = await (this.constructor as typeof BfGoogleDriveResource)
-        .create(this.currentViewer, childProps);
+        .__DANGEROUS__createUnattached(this.currentViewer, childProps);
       const edge = await BfEdge.createEdgeBetweenNodes(
         this.currentViewer,
         this,

--- a/packages/bfDb/models/BfJob.ts
+++ b/packages/bfDb/models/BfJob.ts
@@ -55,7 +55,10 @@ export class BfJob extends BfNode<BfJobRequiredProps, Record<string, never>> {
       method: method as string,
       args,
     };
-    const job = await this.create(currentViewer, jobProps);
+    const job = await this.__DANGEROUS__createUnattached(
+      currentViewer,
+      jobProps,
+    );
     const _jobEdge = await BfEdge.createEdgeBetweenNodes(
       currentViewer,
       bfNode,

--- a/packages/bfDb/models/BfOrganization.ts
+++ b/packages/bfDb/models/BfOrganization.ts
@@ -33,9 +33,13 @@ export class BfOrganization extends BfNode<BfOrganizationRequiredProps> {
       role: ACCOUNT_ROLE.OWNER,
       displayName: this.props.name,
     };
-    const newAccount = await BfAccount.create(currentViewer, props, {
-      bfOid: this.metadata.bfOid,
-    });
+    const newAccount = await BfAccount.__DANGEROUS__createUnattached(
+      currentViewer,
+      props,
+      {
+        bfOid: this.metadata.bfOid,
+      },
+    );
     return newAccount;
   }
 }

--- a/packages/bfDb/models/BfPerson.ts
+++ b/packages/bfDb/models/BfPerson.ts
@@ -48,7 +48,10 @@ export class BfPerson extends BfNode<BfPersonRequiredProps> {
         import.meta,
         credential,
       );
-    const newPerson = await this.create(currentViewer, { email, name }, {
+    const newPerson = await this.__DANGEROUS__createUnattached(currentViewer, {
+      email,
+      name,
+    }, {
       bfGid: currentViewer.personBfGid,
       bfOid: toBfOid(currentViewer.personBfGid),
     });

--- a/packages/bfDb/utils.ts
+++ b/packages/bfDb/utils.ts
@@ -56,14 +56,14 @@ export async function upsertBfDb() {
   logger.info("Checking for omni account");
   if (!(await BfPerson.find(omniCv, toBfGid("omni_person")))) {
     logger.info("Creating omni person");
-    await BfPerson.create(omniCv, {
+    await BfPerson.__DANGEROUS__createUnattached(omniCv, {
       name: "Omni user",
     }, { bfGid: toBfGid("omni_person"), bfOid: toBfOid("omni_person") });
   }
   logger.info("Checking for internal org");
   if (!(await BfOrganization.find(omniCv, toBfOid(BF_INTERNAL_ORG_NAME)))) {
     logger.info("Creating internal org");
-    await BfOrganization.create(omniCv, {
+    await BfOrganization.__DANGEROUS__createUnattached(omniCv, {
       name: "Bolt Foundry internal",
       domainName: "boltfoundry.com",
     }, {

--- a/packages/graphql/types/BfGraphQLClip.ts
+++ b/packages/graphql/types/BfGraphQLClip.ts
@@ -40,7 +40,7 @@ export const BfGraphQLClipCreateMutation = mutationField("upsertClip", {
     let clip = await BfClip.find(bfCurrentViewer, originalClipId);
     if (!clip) {
       logger.debug("Couldn't find clip, creating");
-      clip = await BfClip.create(bfCurrentViewer, {
+      clip = await BfClip.__DANGEROUS__createUnattached(bfCurrentViewer, {
         title,
       }, {
         bfGid: toBfGid(originalClipId),

--- a/packages/graphql/types/BfGraphQLGoogleAuth.ts
+++ b/packages/graphql/types/BfGraphQLGoogleAuth.ts
@@ -25,9 +25,12 @@ export const LinkGoogleAccountMutation = mutationField(
       if (!refreshToken) {
         throw new Error("No refresh token found");
       }
-      const _googleAuth = await BfGoogleAuth.create(bfCurrentViewer, {
-        refreshToken,
-      });
+      const _googleAuth = await BfGoogleAuth.__DANGEROUS__createUnattached(
+        bfCurrentViewer,
+        {
+          refreshToken,
+        },
+      );
       return bfCurrentViewer;
     },
   },

--- a/packages/graphql/types/BfGraphQLGoogleDriveResource.ts
+++ b/packages/graphql/types/BfGraphQLGoogleDriveResource.ts
@@ -47,10 +47,13 @@ export const BfGraphQLPickGoogleDriveFolderMutation = mutationField(
       { resourceId, name },
       { bfCurrentViewer }: GraphQLContext,
     ) => {
-      const folder = await BfGoogleDriveResource.create(bfCurrentViewer, {
-        resourceId,
-        name,
-      });
+      const folder = await BfGoogleDriveResource.__DANGEROUS__createUnattached(
+        bfCurrentViewer,
+        {
+          resourceId,
+          name,
+        },
+      );
       const organization = await BfOrganization.findX(
         bfCurrentViewer,
         bfCurrentViewer.organizationBfGid,


### PR DESCRIPTION

- Summary:
    - `BfNode` is the recommended way to interact with everything inside of `BfDb`. Every part of the graph should be a `BfNode` and not a `BfModel`. Relatedly, with few exceptions every Node should be created from a source BfNode. That means, the primary method for creating models should now be `bfNodeInstance.createTargetNode`, **NOT** `BfModel.create`.
    - This also has some other upsides, notably it's impossible to mess up current viewer. Since every node will already have a current viewer, it seems reasonable that instead of having to specify one every time you create a new node, it'll just inherit the current viewer that loaded the original source node.
    - Deep deletes will likely happen automatically whenever a target node has no source nodes, which would cascade down a tree until all content is deleted. That means should we delete an organization, the entire tree beneath it would automatically delete without us having to do any corner cases for "oh well if you're deleting an organization, delete everything owned by that organization." `BfOrganization` will be the top of the tree in the majority of cases, and it will probably have a large number of first level connections.
    - `BfPerson` would also be a top level construct, which should connect to organizations through `accounts`. Accounts probably are "dual targets" in that they have "person" and "organization" as the source edges, wherein if either part of the chain deletes, the account deletes, but the underlying other side of the account does not delete.
    - `BfModel` methods should generally be avoided by outside callers. `BfEdge` has methods for querying and connecting `BfNode` instances together. `BfNode` has the right creation methods.
    - Classes which extend `BfNode` will probably reach into `BfModel` only for hooks like `beforeCreate` etc. But most of those hooks could be moved as explicit declarations in `BfNode` to help authors not be confused.
- Test plan:
    - Briefly tested app and everything worked
- Future work:
    - `BfAccount` needs to be upgraded to use this structure.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/532).
* __->__ #532
* #531
* #530
* #529