### PR TITLE
Set up accounts with proper linking

### DIFF
--- a/packages/bfDb/models/BfOrganization.ts
+++ b/packages/bfDb/models/BfOrganization.ts
@@ -89,6 +89,8 @@ export class BfOrganization extends BfNode<BfOrganizationRequiredProps> {
     });
     const DANGEROUSLY_CREATED_ACCOUNT = org.createTargetNode(BfAccount, {
       role: ACCOUNT_ROLE.MEMBER,
+      organizationBfGid: orgId,
+      personBfGid: currentViewer.personBfGid,
     }, ACCOUNT_ROLE.MEMBER);
     logger.warn("Created dangerous account successfully.");
     return DANGEROUSLY_CREATED_ACCOUNT;

--- a/packages/bfDb/utils.ts
+++ b/packages/bfDb/utils.ts
@@ -19,17 +19,17 @@ const sql = neon(databaseUrl);
 export async function upsertBfDb() {
   await sql`
   CREATE TABLE IF NOT EXISTS bfDb (
+    class_name VARCHAR(255),
     bf_gid VARCHAR(255) PRIMARY KEY,
+    last_updated TIMESTAMP WITHOUT TIME ZONE,
+    props JSONB NOT NULL,
+    created_at TIMESTAMP WITHOUT TIME ZONE,
     bf_oid VARCHAR(255) NOT NULL,
     bf_cid VARCHAR(255) NOT NULL,
     bf_s_class_name VARCHAR(255),
     bf_sid VARCHAR(255),
     bf_t_class_name VARCHAR(255),
     bf_tid VARCHAR(255),
-    class_name VARCHAR(255),
-    last_updated TIMESTAMP WITHOUT TIME ZONE,
-    created_at TIMESTAMP WITHOUT TIME ZONE,
-    props JSONB NOT NULL,
     sort_value BIGINT NOT NULL
   );
   `;


### PR DESCRIPTION




Summary:

I don't really love that accounts have these props, but it does make it simpler to traverse between orgs, accounts, and people.

Test Plan:
![Screenshot 2024-09-05 at 11 24 50 AM](https://github.com/user-attachments/assets/68fd605b-ee0b-4e8a-87f2-f665170eb5d0)
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/565).
* #566
* __->__ #565
* #564