### PR TITLE
Make a way of creating a current viewer out of thin air... very dangerous

### DIFF
--- a/packages/bfDb/classes/BfCurrentViewer.ts
+++ b/packages/bfDb/classes/BfCurrentViewer.ts
@@ -14,7 +14,7 @@ import type { BfAccount } from "packages/bfDb/models/BfAccount.ts";
 import { getLogger } from "deps.ts";
 import { BF_INTERNAL_ORG_NAME } from "packages/bfDb/utils.ts";
 
-const _logger = getLogger(import.meta);
+const logger = getLogger(import.meta);
 
 export class BfCurrentViewerCreationError extends Error {
   constructor(reason: string) {
@@ -111,6 +111,22 @@ export class BfCurrentViewerFromAccount extends BfCurrentViewer {
   }
 }
 
+export class __DANGEROUS__BfCurrentViewerFromThinAir extends BfCurrentViewer {
+  static __DANGEROUS__create(
+    importMeta: ImportMeta,
+    props: { organizationBfGid: BfGid; role: ACCOUNT_ROLE; personBfGid: BfGid },
+  ) {
+    logger.warn(`Creating a CV from thin air, this is dangerous.`, props);
+    return new this(
+      props.organizationBfGid,
+      props.role,
+      props.personBfGid,
+      props.personBfGid,
+      importMeta.url,
+    );
+  }
+}
+
 export class IBfCurrentViewerInternalAdmin extends BfCurrentViewerAccessToken {
   static async create(
     importMeta: ImportMeta,
@@ -143,6 +159,7 @@ export class IBfCurrentViewerInternalAdmin extends BfCurrentViewerAccessToken {
 export class IBfCurrentViewerInternalAdminOmni
   extends IBfCurrentViewerInternalAdmin {
   static __DANGEROUS__create(importMeta: ImportMeta, orgId = "omni_person") {
+    logger.warn("Creating omni cv, tread carefully. Created for: ", orgId);
     return new this(
       toBfOid(orgId),
       ACCOUNT_ROLE.OMNI,


### PR DESCRIPTION




Summary:

When creating people / accounts, it's reasonable to need to construct a cv before it's quite ready.

Test Plan:
Stacked notebook
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/571).
* #574
* #573
* #572
* __->__ #571