### PR TITLE
Rework user and account creation to use new CV creation method

### DIFF
--- a/packages/bfDb/classes/BfCurrentViewer.ts
+++ b/packages/bfDb/classes/BfCurrentViewer.ts
@@ -14,7 +14,7 @@ import type { BfAccount } from "packages/bfDb/models/BfAccount.ts";
 import { getLogger } from "deps.ts";
 import { BF_INTERNAL_ORG_NAME } from "packages/bfDb/utils.ts";
 
-const _logger = getLogger(import.meta);
+const logger = getLogger(import.meta);
 
 export class BfCurrentViewerCreationError extends Error {
   constructor(reason: string) {
@@ -111,6 +111,22 @@ export class BfCurrentViewerFromAccount extends BfCurrentViewer {
   }
 }
 
+export class __DANGEROUS__BfCurrentViewerFromThinAir extends BfCurrentViewer {
+  static __DANGEROUS__create(
+    importMeta: ImportMeta,
+    props: { organizationBfGid: BfGid; role: ACCOUNT_ROLE; personBfGid: BfGid },
+  ) {
+    logger.warn(`Creating a CV from thin air, this is dangerous.`, props);
+    return new this(
+      props.organizationBfGid,
+      props.role,
+      props.personBfGid,
+      props.personBfGid,
+      importMeta.url,
+    );
+  }
+}
+
 export class IBfCurrentViewerInternalAdmin extends BfCurrentViewerAccessToken {
   static async create(
     importMeta: ImportMeta,
@@ -143,6 +159,7 @@ export class IBfCurrentViewerInternalAdmin extends BfCurrentViewerAccessToken {
 export class IBfCurrentViewerInternalAdminOmni
   extends IBfCurrentViewerInternalAdmin {
   static __DANGEROUS__create(importMeta: ImportMeta, orgId = "omni_person") {
+    logger.warn("Creating omni cv, tread carefully. Created for: ", orgId);
     return new this(
       toBfOid(orgId),
       ACCOUNT_ROLE.OMNI,

--- a/packages/bfDb/classes/BfModel.ts
+++ b/packages/bfDb/classes/BfModel.ts
@@ -130,21 +130,13 @@ export abstract class BfBaseModel<
     this: TThis,
     currentViewer: BfCurrentViewer,
     bfGid: BfAnyid,
-    dangerousOptions = {
-      I_WANT_TO_LOAD_THIS_DANGEROUSLY_AND_I_KNOW_ITS_PRIVACY_UNSAFE: false,
-    },
   ): Promise<
     InstanceType<TThis> & BfBaseModelMetadata<TCreationMetadata>
   > {
     const model = new this(currentViewer, undefined, undefined, {
       bfGid,
     });
-    if (
-      currentViewer instanceof IBfCurrentViewerInternalAdminOmni ||
-      dangerousOptions
-          .I_WANT_TO_LOAD_THIS_DANGEROUSLY_AND_I_KNOW_ITS_PRIVACY_UNSAFE ===
-        true
-    ) {
+    if (currentViewer instanceof IBfCurrentViewerInternalAdminOmni) {
       await model.load__PRIVACY_UNSAFE();
     } else {
       await model.load();

--- a/packages/bfDb/models/BfOrganization.ts
+++ b/packages/bfDb/models/BfOrganization.ts
@@ -1,4 +1,5 @@
 import {
+  __DANGEROUS__BfCurrentViewerFromThinAir,
   type BfCurrentViewer,
   type BfCurrentViewerAccessToken,
   IBfCurrentViewerInternalAdmin,
@@ -75,7 +76,7 @@ export class BfOrganization extends BfNode<BfOrganizationRequiredProps> {
     domainName: string,
   ) {
     logger.warn(
-      `Creating an account dangerously for ${currentViewer.personBfGid} in ${domainName} from ${importMeta.url}`,
+      `Creating an account for ${currentViewer.personBfGid} in ${domainName} from ${importMeta.url}`,
     );
     const ONLY_USE_THIS_VC_TO_FIND_THE_ORGANIZATION_YOU_WANT_TO_ADD_A_PERSON_TO =
       IBfCurrentViewerInternalAdminOmni.__DANGEROUS__create(import.meta);
@@ -83,16 +84,25 @@ export class BfOrganization extends BfNode<BfOrganizationRequiredProps> {
       ONLY_USE_THIS_VC_TO_FIND_THE_ORGANIZATION_YOU_WANT_TO_ADD_A_PERSON_TO,
       domainName,
     );
-    const orgId = _SCARY_ORG_WITH_OMNI_VC.metadata.bfGid;
-    const org = await this.findX(currentViewer, orgId, {
-      I_WANT_TO_LOAD_THIS_DANGEROUSLY_AND_I_KNOW_ITS_PRIVACY_UNSAFE: true,
-    });
-    const DANGEROUSLY_CREATED_ACCOUNT = org.createTargetNode(BfAccount, {
-      role: ACCOUNT_ROLE.MEMBER,
-      organizationBfGid: orgId,
-      personBfGid: currentViewer.personBfGid,
-    }, ACCOUNT_ROLE.MEMBER);
-    logger.warn("Created dangerous account successfully.");
+    const organizationBfGid = _SCARY_ORG_WITH_OMNI_VC.metadata.bfGid;
+    const personBfGid = currentViewer.personBfGid;
+    const role = ACCOUNT_ROLE.MEMBER;
+    const props = { organizationBfGid, personBfGid, role };
+
+    // we're going to generate a new vc with the org and the person, so the ownership
+    // doesn't get messed up.
+
+    const newViewer = __DANGEROUS__BfCurrentViewerFromThinAir
+      .__DANGEROUS__create(import.meta, props);
+
+    const org = await this.findX(newViewer, organizationBfGid);
+
+    const DANGEROUSLY_CREATED_ACCOUNT = org.createTargetNode(
+      BfAccount,
+      props,
+      ACCOUNT_ROLE.MEMBER,
+    );
+    logger.warn("Created account successfully.");
     return DANGEROUSLY_CREATED_ACCOUNT;
   }
 }

--- a/packages/bfDb/utils.ts
+++ b/packages/bfDb/utils.ts
@@ -22,7 +22,6 @@ export async function upsertBfDb() {
     class_name VARCHAR(255),
     bf_gid VARCHAR(255) PRIMARY KEY,
     last_updated TIMESTAMP WITHOUT TIME ZONE,
-    props JSONB NOT NULL,
     created_at TIMESTAMP WITHOUT TIME ZONE,
     bf_oid VARCHAR(255) NOT NULL,
     bf_cid VARCHAR(255) NOT NULL,
@@ -30,7 +29,8 @@ export async function upsertBfDb() {
     bf_sid VARCHAR(255),
     bf_t_class_name VARCHAR(255),
     bf_tid VARCHAR(255),
-    sort_value BIGINT NOT NULL
+    sort_value BIGINT NOT NULL,
+    props JSONB NOT NULL
   );
   `;
   logger.info("Schema upserted");


### PR DESCRIPTION

Summary:

This prevents us from having to do lots of sketchy loading. (ie bfmodel gets back to not being able to load stuff unless the cv is omni)

Test Plan:
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/573).
* #574
* __->__ #573
* #572
* #571