### PR TITLE
fix routing

### DIFF
--- a/packages/client/components/App.tsx
+++ b/packages/client/components/App.tsx
@@ -25,12 +25,9 @@ export const routes = new Map([
   ["/login", { Component: LoginPage, allowLoggedOut: true }],
   ["/ui", { Component: Demo, allowLoggedOut: true }],
   ["/contact-us", { Component: ContactUs, allowLoggedOut: true }],
-  ["/settings", { Component: SettingsPage, allowLoggedOut: false }],
-  ["/settings/", { Component: SettingsPage, allowLoggedOut: false }],
-  ["/settings/:tab", { Component: SettingsPage, allowLoggedOut: false }],
+  ["/settings/:tab?", { Component: SettingsPage, allowLoggedOut: false }],
   ["/search", { Component: ClipSearchPage, allowLoggedOut: false }],
-  ["/blog", { Component: BlogPage, allowLoggedOut: true }],
-  ["/blog/:slug", { Component: BlogPage, allowLoggedOut: true }],
+  ["/blog/:slug?", { Component: BlogPage, allowLoggedOut: true }],
 ]);
 
 export function App() {

--- a/packages/web/web.ts
+++ b/packages/web/web.ts
@@ -278,7 +278,7 @@ Deno.serve(async (req) => {
   if (!matchedHandler) {
     // If no direct match, try matching with optional params
     for (const [routePath, routeHandler] of routes) {
-      const regexPath = routePath.replace(/:\w+\??\+?/g, (match) => {
+      const regexPath = routePath.replace(/\/:\w+\??\+?/g, (match) => {
         if (match.endsWith("+")) {
           return "(.+)";
         } else if (match.endsWith("?")) {


### PR DESCRIPTION

add `\/` (literal "/") to the matching regex so it works with or without the slash

These examples all match `/settings/:tab?`
`/settings`
`/settings/`
`/settings/media`


Summary:

Test Plan:
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/639).
* #642
* #641
* #640
* __->__ #639