### PR TITLE
Make Notion API return blog posts sorted by date

### DIFF
--- a/lib/notionApi.ts
+++ b/lib/notionApi.ts
@@ -133,6 +133,18 @@ export async function getBlogPostsFromNotion(): Promise<[BlogPostData]> {
       };
     },
   );
+  filteredData.sort((a, b) => {
+    const dateA = a.date ? new Date(a.date) : null;
+    const dateB = b.date ? new Date(b.date) : null;
+
+    if (!dateA && !dateB) return 0;
+    if (!dateA) return 1;
+    if (!dateB) return -1;
+
+    if (dateA > dateB) return -1;
+    if (dateA < dateB) return 1;
+    return 0;
+  });
   return filteredData;
 }
 


### PR DESCRIPTION

Summary:

Test Plan:
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/688).
* #694
* #693
* #692
* #691
* #690
* #689
* __->__ #688