### PR TITLE
Fix batching so it defaults to smaller batch sizes

### DIFF
--- a/packages/bfDb/bfDb.ts
+++ b/packages/bfDb/bfDb.ts
@@ -428,7 +428,7 @@ export async function bfQueryItemsWithSizeLimit<
   orderBy: keyof Row = "sort_value",
   cursorValue?: number | string,
   maxSizeBytes: number = 10 * 1024 * 1024, // 10MB in bytes
-  batchSize: number = 10,
+  batchSize: number = 4,
 ): Promise<Array<DbItem<TProps, BfBaseModelMetadata>>> {
   logger.setLevel(logger.levels.DEBUG);
   logger.debug({
@@ -517,15 +517,21 @@ export async function bfQueryItemsWithSizeLimit<
 
   const items: Array<DbItem<TProps, BfBaseModelMetadata>> = [];
   let totalSize = 0;
+  let hasUsedCursor = false;
   let currentCursor = cursorValue;
 
   while (true) {
     let cursorCondition = "";
     if (currentCursor !== undefined) {
-      cursorCondition = `${orderBy} ${orderDirection === "ASC" ? ">" : "<"} $${
-        variables.length + 1
-      }`;
-      variables.push(currentCursor);
+      if (hasUsedCursor) {
+        variables[variables.length - 1] = currentCursor;
+      } else {
+        variables.push(currentCursor);
+        hasUsedCursor = true;
+      }
+      cursorCondition = `${orderBy} ${
+        orderDirection === "ASC" ? ">" : "<"
+      } $${variables.length}`;
     }
 
     const allConditions = [


### PR DESCRIPTION

Summary:
Seems like a good idea to let the models control their own batch size... ie BfMediaNodeTranscript will always be pretty huge and doing 4 at a time is appropriate, but others are probably tiny, so they could have much larger batch sizes. Also, retrying with exponential backoff could also be a good idea.

Test Plan:
