### PR TITLE
If a connection doesn't have any results, immediately return

### DIFF
--- a/packages/bfDb/coreModels/BfEdge.ts
+++ b/packages/bfDb/coreModels/BfEdge.ts
@@ -116,6 +116,9 @@ export class BfEdge<
         connectionArgs,
       );
     logger.debug("connection", connection);
+    if (connection.edges.length === 0) {
+      return connection;
+    }
     const targetEdgeIds = connection.edges.map((
       edge: { node: { id: string } },
     ) => edge.node.id);


### PR DESCRIPTION




Summary:

Before this change, it would inadvertantly return all results

Test Plan:
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/765).
* #770
* #767
* #766
* __->__ #765