### PR TITLE
Make a way to delete specific models without deleting the entire db

### DIFF
--- a/packages/bfDb/coreModels/BfEdge.ts
+++ b/packages/bfDb/coreModels/BfEdge.ts
@@ -116,6 +116,9 @@ export class BfEdge<
         connectionArgs,
       );
     logger.debug("connection", connection);
+    if (connection.edges.length === 0) {
+      return connection;
+    }
     const targetEdgeIds = connection.edges.map((
       edge: { node: { id: string } },
     ) => edge.node.id);

--- a/packages/bfDb/utils.ts
+++ b/packages/bfDb/utils.ts
@@ -110,3 +110,42 @@ export async function __DANGEROUSLY_DESTROY_THE_DATABASE__(
   await sql`DROP TABLE IF EXISTS bfDb`;
   logger.warn("Database destroyed");
 }
+
+export async function cleanModels(modelNames: Array<string>, dryRun = true) {
+  if (dryRun) {
+    logger.warn("Dry run of cleaning models.");
+  }
+  const classNames = modelNames.map((name) => `'${name}'`).join(", ");
+  const [{ count }] = await sql`
+  WITH class_names AS (
+    SELECT unnest(ARRAY[${classNames}]) AS name
+  )
+  SELECT COUNT(*) FROM bfdb
+  WHERE class_name IN (SELECT name FROM class_names)
+   OR bf_s_class_name IN (SELECT name FROM class_names)
+   OR bf_t_class_name IN (SELECT name FROM class_names);
+   `;
+
+  logger.warn(
+    `Removing ${
+      modelNames.join(", ")
+    } model classes from ${count} nodes and edges`,
+  );
+  if (dryRun) {
+    logger.warn("Skipping remove, dry run only.");
+    return;
+  }
+  await sql`
+  WITH class_names AS (
+    SELECT unnest(ARRAY[${classNames}]) AS name
+  )
+  DELETE FROM bfdb
+  WHERE class_name IN (SELECT name FROM class_names)
+   OR bf_s_class_name IN (SELECT name FROM class_names)
+   OR bf_t_class_name IN (SELECT name FROM class_names);
+  `;
+
+  logger.warn(
+    `Removed ${modelNames.join(", ")} model classes from nodes and edges`,
+  );
+}


### PR DESCRIPTION

Summary:

This can be used to nuke models without using bff db:reset. Used in notebooks mostly.

Test Plan:
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/766).
* #770
* #767
* __->__ #766
* #765