### PR TITLE
fix querying items

### DIFF
--- a/packages/bfDb/coreModels/BfNode.ts
+++ b/packages/bfDb/coreModels/BfNode.ts
@@ -16,6 +16,7 @@ import {
   bfQueryItemsForGraphQLConnection,
   bfSubscribeToConnectionChanges,
 } from "packages/bfDb/bfDb.ts";
+import { BfModelErrorClassMismatch } from "packages/bfDb/classes/BfModelError.ts";
 const logger = getLogger(import.meta);
 
 export type BfNodeRequiredProps = Record<string, unknown>;
@@ -58,6 +59,7 @@ export class BfNode<
       bfOid: currentViewerIsAdmin
         ? metadataToQuery.bfOid ?? currentViewer.organizationBfGid
         : currentViewer.organizationBfGid,
+      className: this.name,
     };
     const { edges, ...others } = await bfQueryItemsForGraphQLConnection<
       ChildRequiredProps & Partial<ChildOptionalProps>,
@@ -72,16 +74,23 @@ export class BfNode<
     return {
       ...others,
       // @ts-expect-error edge is anytyped but it shouldn't be... it should be a rowitem.
-      edges: edges.map((edge) => ({
-        cursor: edge.cursor,
-        node: new this(
-          currentViewer,
-          edge.node.props,
-          {},
-          edge.node.metadata,
-          true,
-        ).toGraphql(),
-      })),
+      edges: edges.map((edge) => {
+        if (edge.node.metadata.className != this.name) {
+          throw new BfModelErrorClassMismatch(
+            `Connection class mismatch. Got ${edge.node.metadata.className} but expected ${this.name}`,
+          );
+        }
+        return {
+          cursor: edge.cursor,
+          node: new this(
+            currentViewer,
+            edge.node.props,
+            {},
+            edge.node.metadata,
+            true,
+          ).toGraphql(),
+        };
+      }),
     };
   }
 


### PR DESCRIPTION




Summary: add className so it only returns those classes you are looking for. add class mismatch error handling.

Test Plan:
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/841).
* #843
* #846
* #845
* #842
* __->__ #841