### PR TITLE
fix queryTargetInstances and querySourceInstances

### DIFF
--- a/packages/bfDb/coreModels/BfEdge.ts
+++ b/packages/bfDb/coreModels/BfEdge.ts
@@ -166,6 +166,9 @@ export class BfEdge<
     const sourceEdgeIds = sourceEdges.map((edge) => edge.metadata.bfSid)
       .filter(Boolean) as Array<BfSid>;
     logger.debug("sourceEdgeIds", sourceEdgeIds);
+    if (sourceEdgeIds.length === 0) {
+      return [];
+    }
     const sources = await SourceClass.query(
       currentViewer,
       {},
@@ -213,6 +216,9 @@ export class BfEdge<
     const targetEdgeIds = targetEdges.map((edge) => edge.metadata.bfTid)
       .filter(Boolean) as Array<BfTid>;
     logger.debug("targetEdgeIds", targetEdgeIds);
+    if (targetEdgeIds.length === 0) {
+      return [];
+    }
     const targets = await TargetClass.query(
       currentViewer,
       {},

--- a/packages/bfDb/coreModels/BfNode.ts
+++ b/packages/bfDb/coreModels/BfNode.ts
@@ -16,6 +16,7 @@ import {
   bfQueryItemsForGraphQLConnection,
   bfSubscribeToConnectionChanges,
 } from "packages/bfDb/bfDb.ts";
+import { BfModelErrorClassMismatch } from "packages/bfDb/classes/BfModelError.ts";
 const logger = getLogger(import.meta);
 
 export type BfNodeRequiredProps = Record<string, unknown>;
@@ -58,6 +59,7 @@ export class BfNode<
       bfOid: currentViewerIsAdmin
         ? metadataToQuery.bfOid ?? currentViewer.organizationBfGid
         : currentViewer.organizationBfGid,
+      className: this.name,
     };
     const { edges, ...others } = await bfQueryItemsForGraphQLConnection<
       ChildRequiredProps & Partial<ChildOptionalProps>,
@@ -72,16 +74,23 @@ export class BfNode<
     return {
       ...others,
       // @ts-expect-error edge is anytyped but it shouldn't be... it should be a rowitem.
-      edges: edges.map((edge) => ({
-        cursor: edge.cursor,
-        node: new this(
-          currentViewer,
-          edge.node.props,
-          {},
-          edge.node.metadata,
-          true,
-        ).toGraphql(),
-      })),
+      edges: edges.map((edge) => {
+        if (edge.node.metadata.className != this.name) {
+          throw new BfModelErrorClassMismatch(
+            `Connection class mismatch. Got ${edge.node.metadata.className} but expected ${this.name}`,
+          );
+        }
+        return {
+          cursor: edge.cursor,
+          node: new this(
+            currentViewer,
+            edge.node.props,
+            {},
+            edge.node.metadata,
+            true,
+          ).toGraphql(),
+        };
+      }),
     };
   }
 

--- a/packages/bfDb/models/BfMediaNodeVideo.ts
+++ b/packages/bfDb/models/BfMediaNodeVideo.ts
@@ -1,7 +1,185 @@
-import {
-  BfNode,
-  type BfNodeRequiredProps,
-} from "packages/bfDb/coreModels/BfNode.ts";
+import { BfNode } from "packages/bfDb/coreModels/BfNode.ts";
+import { getLogger } from "deps.ts";
+import { BfError } from "lib/BfError.ts";
 
-export class BfMediaNodeVideo<T extends BfNodeRequiredProps> extends BfNode<T> {
+const logger = getLogger(import.meta);
+
+function getMediaCacheDirectory(dirName: string): string {
+  return Deno.env.get("BF_MEDIA_VIDEO_CACHE_DIRECTORY") ??
+    (Deno.env.get("REPL_HOME")
+      ? `${Deno.env.get("REPL_HOME")}/tmp/${dirName}`
+      : `/tmp/${dirName}`);
+}
+
+export enum BfMediaNodeVideoStatus {
+  NEW = "NEW",
+  PROCESSING = "PROCESSING",
+  COMPLETED = "COMPLETED",
+  FAILED = "FAILED",
+}
+
+export enum BfMediaNodeVideoRole {
+  PREVIEW = "PREVIEW",
+  BEST = "BEST",
+}
+
+export type BfMediaNodeVideoProps = {
+  status: BfMediaNodeVideoStatus;
+  processingPct: number;
+  role: BfMediaNodeVideoRole;
+};
+
+export class BfMediaNodeVideo extends BfNode<BfMediaNodeVideoProps> {
+  private getRawFilePath(): string {
+    const cacheDirectory = getMediaCacheDirectory("bf-media-video-cache");
+    return `${cacheDirectory}/${this.metadata.bfGid}.mp4`;
+  }
+
+  async getFilePath(): Promise<string | null> {
+    const filePath = this.getRawFilePath();
+    logger.debug("getFilePath", filePath);
+
+    return await Deno.stat(filePath).then(() => filePath).catch(() => null);
+  }
+
+  getFile(): Promise<string> {
+    throw new BfError(
+      `Need to implement getFile() for ${this.constructor.name}`,
+    );
+  }
+
+  async createPreview(): Promise<BfMediaNodeVideo> {
+    const videos = await this.queryTargetInstances(BfMediaNodeVideo, {
+      role: BfMediaNodeVideoRole.PREVIEW,
+      status: BfMediaNodeVideoStatus.COMPLETED,
+    });
+    if (videos.length > 0) {
+      logger.info("Found existing video", this);
+      return videos[0];
+    }
+    const bfmnVideo = await this.createTargetNode(BfMediaNodeVideo, {
+      status: BfMediaNodeVideoStatus.NEW,
+      role: BfMediaNodeVideoRole.PREVIEW,
+    });
+    logger.info(`Creating preview video for ${this}`);
+    const filePath = await this.getFile();
+    await bfmnVideo.compressVideo(filePath);
+    logger.info(`Preview video created for ${this}`);
+    logger.info(`Preview video: ${bfmnVideo}`);
+    return bfmnVideo;
+  }
+
+  async compressVideo(filePath: string): Promise<this> {
+    const fileExists = await Deno.stat(filePath).then(() => "EXISTS").catch(
+      () => "DOESN'T EXIST",
+    );
+    logger.debug("Input file:", filePath, fileExists);
+    if (
+      !await Deno.stat(BF_MEDIA_VIDEO_CACHE_DIRECTORY).then(() => true).catch(
+        () => false,
+      )
+    ) {
+      logger.error(
+        "Directory doesn't exist, creating",
+        BF_MEDIA_VIDEO_CACHE_DIRECTORY,
+      );
+      await Deno.mkdir(BF_MEDIA_VIDEO_CACHE_DIRECTORY, { recursive: true });
+    }
+    const outputFilePath = this.getRawFilePath();
+
+    const ffprobeArgs = [
+      "-i",
+      filePath,
+      "-v",
+      "quiet",
+      "-show_format",
+      "-print_format",
+      "json",
+    ];
+    let qualitySettings = [
+      "-b:v",
+      "5000k", // Set video bitrate to approximately 5 mbps
+      "-crf",
+      "28", // lower value for higher quality and vice versa
+    ];
+    if (this.props.role === BfMediaNodeVideoRole.PREVIEW) {
+      qualitySettings = [
+        "-b:v",
+        "500k", // Set video bitrate to approximately 500 kbps
+        "-vf",
+        "scale=-2:480", // Resize video to height 480, maintaining aspect ratio
+        "-crf",
+        "28", // lower value for higher quality and vice versa
+        "-preset",
+        "fast", // Use a faster preset for encoding
+      ];
+    }
+
+    const ffmpegArgs = [
+      "-y", // overwrite file if it exists
+      "-i",
+      filePath,
+      "-vcodec",
+      "libx264",
+      ...qualitySettings,
+      outputFilePath,
+    ];
+
+    logger.info(`Starting video compression for ${this}`);
+    this.props.status = BfMediaNodeVideoStatus.PROCESSING;
+    await this.save();
+    const ffprobeCmd = new Deno.Command("ffprobe", {
+      args: ffprobeArgs,
+      stdout: "piped",
+    });
+    const { stdout } = await ffprobeCmd.output();
+    const ffprobeOutput = JSON.parse(new TextDecoder().decode(stdout));
+    logger.debug(`ffprobe stdout`, ffprobeOutput);
+    const fileDuration = parseFloat(ffprobeOutput.format.duration) * 1000;
+    logger.debug(`fileDuration`, fileDuration);
+
+    const ffmpegCmd = new Deno.Command("ffmpeg", {
+      args: ffmpegArgs,
+      stdout: "null",
+      stderr: "piped",
+    });
+
+    const { stderr } = ffmpegCmd.spawn();
+    const stderrReader = stderr.pipeThrough(new TextDecoderStream())
+      .getReader();
+    while (true) {
+      const { done, value } = await stderrReader.read();
+      if (done) break;
+      const stats = value.split("\n").reduce((acc, line) => {
+        const [key, value] = line.split("=");
+        if (key) {
+          acc[key] = value?.trim();
+        }
+        return acc;
+      }, {} as Record<string, string>);
+      logger.debug("STATS", stats);
+      const outTimeUs = parseInt(stats.out_time_us);
+      const outTimeMs = outTimeUs / 1000;
+      const pctComplete = outTimeMs / fileDuration;
+      this.updateCompressingPct(pctComplete);
+    }
+
+    const outputFileExists = await Deno.stat(outputFilePath).then(() =>
+      "EXISTS"
+    )
+      .catch(() => "DOESN'T EXIST");
+    logger.debug("Output file", outputFilePath, outputFileExists);
+    logger.info(`Video compression complete for ${this}`);
+    this.props.status = BfMediaNodeVideoStatus.COMPLETED;
+    await this.save();
+    return this;
+  }
+
+  private updateCompressingPct(pct: number) {
+    // this.props.processingPct = pct;
+    // await this.save();
+    logger.debug(
+      `${this} Compressing pct updated to ${(pct * 100).toFixed(2)}%`,
+    );
+  }
 }

--- a/packages/bfDb/models/BfMediaNodeVideoGoogleDriveResource.ts
+++ b/packages/bfDb/models/BfMediaNodeVideoGoogleDriveResource.ts
@@ -7,6 +7,8 @@ import {
 } from "packages/bfDb/models/BfMediaNodeTranscript.ts";
 import { BfOrganization } from "packages/bfDb/models/BfOrganization.ts";
 import { BfEdge } from "packages/bfDb/coreModels/BfEdge.ts";
+import { BfGoogleDriveResource } from "packages/bfDb/models/BfGoogleDriveResource.ts";
+import { toBfGid } from "packages/bfDb/classes/BfBaseModelIdTypes.ts";
 
 const logger = getLogger(import.meta);
 
@@ -34,5 +36,21 @@ export class BfMediaNodeVideoGoogleDriveResource
     );
     logger.info(`Transcript created for ${this}`);
     return bfmnTranscript;
+  }
+
+  async getFile() {
+    logger.debug(
+      "getFile",
+      "compressVideoFromGoogleDriveResourceId",
+      this.props.googleDriveResourceId,
+    );
+
+    const bfGoogleDriveResource = await BfGoogleDriveResource.findX(
+      this.currentViewer,
+      toBfGid(this.props.googleDriveResourceId),
+    );
+    logger.debug(`Getting file handle for ${bfGoogleDriveResource}`);
+    using _fileHandle = await bfGoogleDriveResource.download();
+    return bfGoogleDriveResource.getFilePath();
   }
 }


### PR DESCRIPTION




Summary: If no instances exist on a specific model, it would return those instances for every model. Made it return empty array if no instances exist

Test Plan:
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/845).
* #843
* #846
* __->__ #845
* #842
* #841