### PR TITLE
fixed edge query for graphql and count (wip)

### DIFF
--- a/packages/bfDb/bfDb.ts
+++ b/packages/bfDb/bfDb.ts
@@ -404,7 +404,7 @@ const VALID_METADATA_COLUMN_NAMES = [
 
 const defaultClause = "1=1";
 
-async function bfQueryItemsUnified<
+export async function bfQueryItemsUnified<
   TProps = Props,
   TMetadata extends BfBaseModelMetadata = BfBaseModelMetadata,
 >(

--- a/packages/bfDb/coreModels/BfEdge.ts
+++ b/packages/bfDb/coreModels/BfEdge.ts
@@ -10,7 +10,11 @@ import type {
 } from "packages/bfDb/classes/BfBaseModelIdTypes.ts";
 import type { ConnectionArguments } from "packages/graphql/deps.ts";
 import { BfModel } from "packages/bfDb/classes/BfModel.ts";
-import { bfGetItemsByBfGid } from "packages/bfDb/bfDb.ts";
+import {
+  bfGetItemsByBfGid,
+  bfQueryItemsForGraphQLConnection,
+  bfQueryItemsUnified,
+} from "packages/bfDb/bfDb.ts";
 import type { ConnectionInterface } from "relay";
 import type { BfCurrentViewer } from "packages/bfDb/classes/BfCurrentViewer.ts";
 import { getLogger } from "deps.ts";
@@ -101,21 +105,26 @@ export class BfEdge<
     sourceBfGid: BfGid | BfSid,
     propsToQuery: Partial<TRequiredProps & TOptionalProps> = {},
     connectionArgs: ConnectionArguments,
+    edgePropsToQuery?: Partial<BfEdgeOptionalProps>,
   ): Promise<
     ConnectionInterface<
       InstanceType<TThis> & EdgeCreationMetadata
     > & { count: number }
   > {
-    logger.debug("queryTargetsConnectionForGraphQL", TargetClass, sourceBfGid);
-    const TargetClassAsBfNode = TargetClass as unknown as typeof BfNode;
-    const connection = await TargetClassAsBfNode
-      .queryConnectionForGraphQL(
-        currentViewer,
-        { bfSid: sourceBfGid, bfTClassName: TargetClass.name },
-        propsToQuery,
-        connectionArgs,
-      );
-    logger.debug("connection", connection);
+    const edgeMetadataForQuery = {
+      bfTClassName: TargetClass.name,
+      bfSid: sourceBfGid,
+      bfOid: currentViewer.organizationBfGid,
+      className: this.name,
+    };
+    logger.info("edgePropsToQuery", edgePropsToQuery);
+    const connection = await bfQueryItemsForGraphQLConnection(
+      edgeMetadataForQuery,
+      edgePropsToQuery,
+      connectionArgs,
+      [],
+    );
+
     if (connection.edges.length === 0) {
       return connection;
     }
@@ -128,17 +137,27 @@ export class BfEdge<
       Boolean,
     ) as Array<BfTid>;
     logger.debug("targetIds", targetIds);
+    const count = await bfQueryItemsUnified(
+      { className: TargetClass.name },
+      propsToQuery,
+      targetIds,
+      undefined,
+      undefined,
+      {
+        countOnly: true,
+      },
+    );
+    const TargetClassAsBfNode = TargetClass as unknown as typeof BfNode;
     const targetConnection = await TargetClassAsBfNode
       .queryConnectionForGraphQL(
         currentViewer,
         {},
-        {},
+        propsToQuery,
         connectionArgs,
         targetIds,
       );
     logger.debug("targetConnection", targetConnection);
-    // TODO Total hack.
-    return { ...targetConnection, count: connection.count };
+    return { ...targetConnection, count };
   }
 
   static async querySourceInstances<

--- a/packages/bfDb/coreModels/BfNode.ts
+++ b/packages/bfDb/coreModels/BfNode.ts
@@ -185,6 +185,7 @@ export class BfNode<
       this.metadata.bfGid,
       props,
       args,
+      edgeProps,
     );
   }
 

--- a/packages/graphql/types/BfGraphQLMedia.ts
+++ b/packages/graphql/types/BfGraphQLMedia.ts
@@ -27,14 +27,14 @@ export const BfGraphQLMediaQuery = extendType({
     t.connectionField("media", {
       type: "BfMedia",
       resolve: (_, args, { bfCurrentViewer }) => {
-        logger.debug("Fetching all transcripts");
+        logger.debug("Fetching all media");
         const media = BfMedia.queryConnectionForGraphQL(
           bfCurrentViewer,
           { bfOid: bfCurrentViewer.bfOid },
           {},
           args,
         );
-        logger.debug("Fetched all transcripts successfully");
+        logger.debug("Fetched all media successfully");
         return media;
       },
     });


### PR DESCRIPTION

Summary: You can now filter edges by metadata target connection props correctly. And it returns the correct count.

Test Plan:
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/848).
* #852
* #851
* #849
* __->__ #848