### PR TITLE
add find ancestor by class, add findVideo to BfMedia

### DIFF
--- a/packages/bfDb/bfDb.ts
+++ b/packages/bfDb/bfDb.ts
@@ -404,6 +404,59 @@ const VALID_METADATA_COLUMN_NAMES = [
 
 const defaultClause = "1=1";
 
+export async function bfQueryAncestorsByClassName<
+  TProps = Record<string, unknown>,
+  TMetadata extends BfBaseModelMetadata = BfBaseModelMetadata,
+>(
+  bfOid: string,
+  targetBfGid: string,
+  sourceBfClassName: string,
+  depth: number = 10,
+): Promise<Array<DbItem<TProps, TMetadata>>> {
+  try {
+    const rows = await sql`
+      WITH RECURSIVE AncestorTree AS (
+        SELECT bf_sid, bf_s_class_name, 1 AS depth
+        FROM bfDb
+        WHERE bf_tid = ${targetBfGid} AND bf_oid = ${bfOid}
+        UNION ALL
+        SELECT b.bf_sid, b.bf_s_class_name, at.depth + 1
+        FROM bfDb AS b
+        INNER JOIN AncestorTree AS at ON b.bf_tid = at.bf_sid
+        WHERE at.depth < ${depth}
+      )
+      SELECT *
+      FROM bfDb
+      WHERE bf_gid = (
+        SELECT bf_sid
+        FROM AncestorTree
+        WHERE bf_s_class_name = ${sourceBfClassName}
+        LIMIT 1
+      );
+    `;
+    const items = rows.map((row) => ({
+      props: row.props,
+      metadata: {
+        bfGid: row.bf_gid,
+        bfSid: row.bf_sid,
+        bfOid: row.bf_oid,
+        bfTid: row.bf_tid,
+        bfCid: row.bf_cid,
+        bfTClassName: row.bf_t_class_name,
+        bfSClassName: row.bf_s_class_name,
+        className: row.class_name,
+        createdAt: new Date(row.created_at),
+        lastUpdated: new Date(row.last_updated),
+        sortValue: row.sort_value,
+      },
+    } as DbItem<TProps, TMetadata>));
+    return items;
+  } catch (error) {
+    logger.error("Error finding ancestor by class name:", error);
+    throw error;
+  }
+}
+
 export async function bfQueryItemsUnified<
   TProps = Props,
   TMetadata extends BfBaseModelMetadata = BfBaseModelMetadata,

--- a/packages/bfDb/coreModels/BfNode.ts
+++ b/packages/bfDb/coreModels/BfNode.ts
@@ -13,6 +13,7 @@ import {
 } from "packages/bfDb/classes/BfCurrentViewer.ts";
 import type { BfAnyid } from "packages/bfDb/classes/BfBaseModelIdTypes.ts";
 import {
+  bfQueryAncestorsByClassName,
   bfQueryItemsForGraphQLConnection,
   bfSubscribeToConnectionChanges,
 } from "packages/bfDb/bfDb.ts";
@@ -133,6 +134,32 @@ export class BfNode<
       role,
     });
     return targetModel as InstanceType<TTargetClass>;
+  }
+
+  public async queryAncestorsByClassName<
+    // an actual good use of any.
+    // deno-lint-ignore no-explicit-any
+    TSourceClass extends abstract new (...args: any) => any,
+  >(
+    BfNodeClass: TSourceClass,
+    limit: number = 10,
+  ) {
+    const ancestors = await bfQueryAncestorsByClassName(
+      this.currentViewer.organizationBfGid,
+      this.metadata.bfGid,
+      BfNodeClass.name,
+      limit,
+    );
+    logger.debug("BfNode ancestors", ancestors);
+    return ancestors.map(({ props, metadata }) => {
+      return new (BfNodeClass as unknown as typeof BfNode)(
+        this.currentViewer,
+        props,
+        {},
+        metadata,
+        false,
+      );
+    }) as Array<InstanceType<TSourceClass>>;
   }
 
   public querySourceInstances<

--- a/packages/bfDb/models/BfMedia.ts
+++ b/packages/bfDb/models/BfMedia.ts
@@ -85,6 +85,27 @@ export class BfMedia extends BfNode<BfMediaProps> {
      */
   }
 
+  async findVideo(
+    role: BfMediaNodeVideoRole = BfMediaNodeVideoRole.PREVIEW,
+  ) {
+    const targets = await this.queryTargetInstances(
+      BfMediaNodeVideoGoogleDriveResource,
+    );
+    logger.info("FIND VIDEO targets", targets);
+    const resource = targets[0];
+
+    const video = await resource.queryTargetInstances(
+      BfMediaNodeVideo,
+      {
+        status: BfMediaNodeVideoStatus.COMPLETED,
+      },
+      {
+        role,
+      },
+    );
+    return video[0];
+  }
+
   async createTranscripts() {
     const targets = await this.queryTargetInstances(
       BfMediaNodeVideoGoogleDriveResource,

--- a/packages/bfDb/models/BfMediaNodeVideo.ts
+++ b/packages/bfDb/models/BfMediaNodeVideo.ts
@@ -23,16 +23,17 @@ export enum BfMediaNodeVideoRole {
   BEST = "BEST",
 }
 
-export type BfMediaNodeVideoProps = {
+export type BfMediaNodeVideoProps<T> = {
   status: BfMediaNodeVideoStatus;
   processingPct: number;
   role: BfMediaNodeVideoRole;
-};
+} & T;
 
-export class BfMediaNodeVideo extends BfNode<BfMediaNodeVideoProps> {
+export class BfMediaNodeVideo<T = {}> extends BfNode<BfMediaNodeVideoProps<T>> {
+  private cacheDirectory = getMediaCacheDirectory("bf-media-video-cache");
+
   private getRawFilePath(): string {
-    const cacheDirectory = getMediaCacheDirectory("bf-media-video-cache");
-    return `${cacheDirectory}/${this.metadata.bfGid}.mp4`;
+    return `${this.cacheDirectory}/${this.metadata.bfGid}.mp4`;
   }
 
   async getFilePath(): Promise<string | null> {
@@ -77,15 +78,15 @@ export class BfMediaNodeVideo extends BfNode<BfMediaNodeVideoProps> {
     );
     logger.debug("Input file:", filePath, fileExists);
     if (
-      !await Deno.stat(BF_MEDIA_VIDEO_CACHE_DIRECTORY).then(() => true).catch(
+      !await Deno.stat(this.cacheDirectory).then(() => true).catch(
         () => false,
       )
     ) {
       logger.error(
         "Directory doesn't exist, creating",
-        BF_MEDIA_VIDEO_CACHE_DIRECTORY,
+        this.cacheDirectory,
       );
-      await Deno.mkdir(BF_MEDIA_VIDEO_CACHE_DIRECTORY, { recursive: true });
+      await Deno.mkdir(this.cacheDirectory, { recursive: true });
     }
     const outputFilePath = this.getRawFilePath();
 


### PR DESCRIPTION

Summary: query the db for ancestors of a model

Test Plan:
example, to find BfMedia from BfSavedSearchResult:
```
const ssr = await BfSavedSearchResult.findX(cv, id);
const bfMediaAncestors = await ssr.queryAncestorsByClassName(
  BfMedia,
)
const bfMedia = bfMediaAncestors[0];
```


Summary: find a video by role (default "PREVIEW")

Test Plan:
```
const video = await bfMedia.findVideo("PREVIEW")
```


Summary:

Test Plan:
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/855).
* #859
* #858
* #857
* #856
* __->__ #855