### PR TITLE
Add GitHub authentication check and login prompt

### DIFF
--- a/infra/bff/friends/ai.bff.ts
+++ b/infra/bff/friends/ai.bff.ts
@@ -113,6 +113,31 @@ export async function aiCommit(_args: string[]): Promise<number> {
     return 1;
   }
 
+  // Check if user is logged into GitHub
+  logger.info("Checking GitHub authentication status...");
+  const { code: authCode } = await runShellCommandWithOutput(
+    ["gh", "auth", "status"],
+    {},
+    true,
+    false,
+  );
+
+  if (authCode !== 0) {
+    logger.info("Not logged into GitHub. Starting GitHub authentication...");
+    logger.info("Please follow the prompts to authenticate with GitHub.");
+
+    const loginResult = await runShellCommand(["gh", "auth", "login"]);
+
+    if (loginResult !== 0) {
+      logger.error("GitHub authentication failed");
+      return 1;
+    }
+
+    logger.info("Successfully authenticated with GitHub");
+  } else {
+    logger.info("GitHub authentication verified");
+  }
+
   // Configure GitHub user
   await configureGitHubUser();
 
@@ -281,6 +306,31 @@ export async function aiAmend(_args: string[]): Promise<number> {
   if (!openaiApiKey) {
     logger.error("OPENAI_API_KEY environment variable is not set");
     return 1;
+  }
+
+  // Check if user is logged into GitHub
+  logger.info("Checking GitHub authentication status...");
+  const { code: authCode } = await runShellCommandWithOutput(
+    ["gh", "auth", "status"],
+    {},
+    true,
+    false,
+  );
+
+  if (authCode !== 0) {
+    logger.info("Not logged into GitHub. Starting GitHub authentication...");
+    logger.info("Please follow the prompts to authenticate with GitHub.");
+
+    const loginResult = await runShellCommand(["gh", "auth", "login"]);
+
+    if (loginResult !== 0) {
+      logger.error("GitHub authentication failed");
+      return 1;
+    }
+
+    logger.info("Successfully authenticated with GitHub");
+  } else {
+    logger.info("GitHub authentication verified");
   }
 
   // Configure GitHub user


### PR DESCRIPTION

SUMMARY:
This commit introduces a check for GitHub authentication status within the `ai.bff.ts` script. If the user is not logged into GitHub, the script will prompt them to authenticate by running the `gh auth login` command. This ensures that the user is properly authenticated before proceeding with the script's operations. The new logic checks the authentication status using `gh auth status`, and if the authentication fails, it prompts the user to log in and verifies the success of the authentication process. This enhancement improves the script's robustness by preventing unauthorized operations due to lack of authentication.

TEST PLAN:
1. Run the script without being logged into GitHub and verify that it prompts for authentication.
2. Follow the prompts and ensure successful login.
3. Re-run the script while logged into GitHub to confirm it skips the authentication prompt.
4. Test both successful and failed login scenarios to ensure proper logging and error handling.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/512).
* #513
* __->__ #512