### PR TITLE
Add internalbf app with basic server and port configuration

### DIFF
--- a/.replit
+++ b/.replit
@@ -141,6 +141,10 @@ localPort = 3011
 externalPort = 3001
 
 [[ports]]
+localPort = 5000
+externalPort = 5000
+
+[[ports]]
 localPort = 8000
 
 [[ports]]

--- a/apps/internalbf/internalbf.ts
+++ b/apps/internalbf/internalbf.ts
@@ -1,0 +1,23 @@
+#! /usr/bin/env -S deno run --allow-net --allow-env
+
+import { getLogger } from "packages/logger/logger.ts";
+
+const logger = getLogger(import.meta);
+
+// Get port from environment variable or use 5000 as default
+const port = Number(Deno.env.get("PORT") ?? 5000);
+
+// Simple request handler
+function handleRequest(req: Request): Response {
+  logger.info(`[${new Date().toISOString()}] [${req.method}] ${req.url}`);
+  return new Response("Hello World", {
+    status: 200,
+    headers: { "Content-Type": "text/plain" },
+  });
+}
+
+// Start the server
+if (import.meta.main) {
+  logger.info(`Starting internalbf app on port ${port}`);
+  Deno.serve({ port, hostname: "0.0.0.0" }, handleRequest);
+}


### PR DESCRIPTION
## SUMMARY
This commit introduces a new application `internalbf` by adding a new file `internalbf.ts` under `apps/internalbf/`. The application is a simple server written in TypeScript, utilizing Deno. It logs incoming requests and responds with "Hello World". The server defaults to port 5000, configurable via the `PORT` environment variable. Additionally, the `.replit` configuration file has been updated to expose port 5000, enabling external access.

## TEST PLAN
1. Ensure Deno is installed and available in the environment.
2. Run the `internalbf.ts` script using Deno: `deno run --allow-net --allow-env apps/internalbf/internalbf.ts`.
3. Verify the server starts successfully and logs the start message.
4. Send an HTTP request to `http://localhost:5000` and confirm that the response is "Hello World".
5. Check the logs to ensure the request is logged with the correct method and URL.
6. Optionally, set the `PORT` environment variable to a different value and repeat steps 3-5 to verify the server listens on the specified port.

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/514)
<!-- GitContextEnd -->