### PR TITLE
Remove redundant CI checks before committing

### DIFF
--- a/infra/bff/friends/land.bff.ts
+++ b/infra/bff/friends/land.bff.ts
@@ -129,18 +129,7 @@ export async function land(): Promise<number> {
     return addResult;
   }
 
-  // Run CI checks before committing
-  logger.info("Running CI checks before committing...");
-  const ciResult = await runShellCommand([
-    "bff",
-    "ci",
-  ]);
-
-  if (ciResult !== 0) {
-    logger.error("CI checks failed, aborting commit");
-    return ciResult;
-  }
-  logger.info("CI checks passed, proceeding with commit");
+  logger.info("Proceeding with commit");
 
   // Create git commit with sapling commits and hash
   logger.info("Creating git commit...");


### PR DESCRIPTION
## SUMMARY
This commit removes the code that runs CI checks before proceeding with a commit in the `land.bff.ts` file. The previous implementation included a sequence where CI checks were executed, and their result would determine whether the commit process would continue. This mechanism is now deemed redundant or unnecessary for the current workflow, hence its removal. Instead, the process now logs a straightforward message indicating that it is proceeding with the commit without executing the CI checks.

## TEST PLAN
1. Ensure that the code compiles without errors after the removal of the CI check logic.
2. Verify the logging output to confirm that the message "Proceeding with commit" appears as expected.
3. Conduct a mock commit to ensure that the removal of CI checks does not affect the commit process negatively.
4. Review if any downstream processes relying on the CI check have been affected, and validate their continued functionality.

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/542)
<!-- GitContextEnd -->