### PR TITLE
Add unit tests for BfDsBreadcrumbs component

### DIFF
--- a/apps/bfDs/components/BfDsForm/__tests__/BfDsForm.test.tsx
+++ b/apps/bfDs/components/BfDsForm/__tests__/BfDsForm.test.tsx
@@ -1,0 +1,115 @@
+import { render } from "infra/testing/ui-testing.ts";
+import { assertEquals, assertExists } from "@std/assert";
+import { BfDsForm, useBfDsFormContext } from "../BfDsForm.tsx";
+import { BfDsFormTextInput } from "../BfDsFormTextInput.tsx";
+import { BfDsFormNumberInput } from "../BfDsFormNumberInput.tsx";
+import { BfDsFormToggle } from "../BfDsFormToggle.tsx";
+import { BfDsFormTextArea } from "../BfDsFormTextArea.tsx";
+import { BfDsFormSubmitButton } from "../BfDsFormSubmitButton.tsx";
+
+// Helper component to test the form context
+function FormContextDisplay() {
+  const { data } = useBfDsFormContext<{ name: string; age: number }>();
+  return (
+    <div>
+      <span data-testid="form-data">
+        {data ? `${data.name}-${data.age}` : "no-data"}
+      </span>
+    </div>
+  );
+}
+
+Deno.test("BfDsForm renders with initial data", () => {
+  const initialData = { name: "Test User", age: 30 };
+  const { doc } = render(
+    <BfDsForm initialData={initialData}>
+      <FormContextDisplay />
+    </BfDsForm>,
+  );
+
+  const formDataElement = doc?.querySelector("[data-testid='form-data']");
+  assertExists(formDataElement, "Form data element should exist");
+  assertEquals(
+    formDataElement?.textContent,
+    "Test User-30",
+    "Form should display the initial data",
+  );
+});
+
+Deno.test("BfDsForm renders form elements correctly", () => {
+  const initialData = {
+    name: "Test User",
+    age: 30,
+    isActive: true,
+    bio: "Hello",
+  };
+  const { doc } = render(
+    <BfDsForm initialData={initialData}>
+      <BfDsFormTextInput id="name" title="Name" />
+      <BfDsFormNumberInput id="age" title="Age" />
+      <BfDsFormToggle id="isActive" title="Active" />
+      <BfDsFormTextArea id="bio" title="Bio" />
+      <BfDsFormSubmitButton text="Submit" />
+    </BfDsForm>,
+  );
+
+  // Check if form element exists
+  const formElement = doc?.querySelector("form");
+  assertExists(formElement, "Form element should exist");
+
+  // Check if all form inputs are rendered
+  const nameInput = doc?.querySelector("input[name='name']");
+  assertExists(nameInput, "Name input should exist");
+  assertEquals(
+    nameInput?.getAttribute("value"),
+    "Test User",
+    "Name input should have the correct value",
+  );
+
+  const ageInput = doc?.querySelector("input[name='age']");
+  assertExists(ageInput, "Age input should exist");
+  assertEquals(
+    ageInput?.getAttribute("value"),
+    "30",
+    "Age input should have the correct value",
+  );
+
+  const submitButton = doc?.querySelector("button[type='submit']");
+  assertExists(submitButton, "Submit button should exist");
+  assertEquals(
+    submitButton?.textContent,
+    "Submit",
+    "Submit button should have the correct text",
+  );
+});
+
+Deno.test("BfDsForm renders with custom styles", () => {
+  const initialData = { name: "Test User" };
+  const customStyle = { padding: "20px", backgroundColor: "lightgray" };
+  const { doc } = render(
+    <BfDsForm initialData={initialData} xstyle={customStyle}>
+      <div>Form content</div>
+    </BfDsForm>,
+  );
+
+  const formElement = doc?.querySelector("form");
+  assertExists(formElement, "Form element should exist");
+
+  const formStyle = formElement?.getAttribute("style");
+  assertExists(formStyle, "Form should have style attribute");
+
+  // The exact style syntax might vary in the string representation
+  // So we'll check for the presence of the key style properties
+  assertEquals(
+    formStyle?.includes("padding") && formStyle?.includes("20px"),
+    true,
+    "Form should have custom padding style",
+  );
+  assertEquals(
+    (formStyle?.includes("background-color") ||
+      formStyle?.includes("backgroundColor")) &&
+      formStyle?.includes("lightgray"),
+    true,
+    "Form should have custom background color style",
+  );
+});

--- a/apps/bfDs/components/BfDsForm/__tests__/BfDsFormSubmitButton.test.tsx
+++ b/apps/bfDs/components/BfDsForm/__tests__/BfDsFormSubmitButton.test.tsx
@@ -1,0 +1,49 @@
+import { render } from "infra/testing/ui-testing.ts";
+import { assertEquals, assertExists } from "@std/assert";
+import { BfDsForm } from "../BfDsForm.tsx";
+import { BfDsFormSubmitButton } from "../BfDsFormSubmitButton.tsx";
+
+Deno.test("BfDsFormSubmitButton renders with correct text", () => {
+  const { getByText } = render(
+    <BfDsForm initialData={{}}>
+      <BfDsFormSubmitButton text="Save Changes" />
+    </BfDsForm>,
+  );
+
+  const button = getByText("Save Changes");
+  assertExists(button, "Submit button with text should exist");
+});
+
+Deno.test("BfDsFormSubmitButton renders as submit type button", () => {
+  const { doc } = render(
+    <BfDsForm initialData={{}}>
+      <BfDsFormSubmitButton text="Submit" />
+    </BfDsForm>,
+  );
+
+  const button = doc?.querySelector("button[type='submit']");
+  assertExists(button, "Button should have type 'submit'");
+});
+
+Deno.test("BfDsFormSubmitButton passes kind prop to BfDsButton", () => {
+  const { doc } = render(
+    <BfDsForm initialData={{}}>
+      <BfDsFormSubmitButton text="Submit" kind="primary" />
+    </BfDsForm>,
+  );
+
+  const button = doc?.querySelector("button");
+  assertExists(button, "Button should exist");
+
+  // Check for primary button styling
+  // Note: This may need adjustment based on how BfDsButton applies the kind prop
+  // It could be a class or inline style depending on your implementation
+  const buttonStyle = button?.getAttribute("style");
+  assertExists(buttonStyle, "Button should have style attribute");
+  assertEquals(
+    buttonStyle?.includes("var(--primaryButton)") ||
+      button?.classList.contains("primary"),
+    true,
+    "Button should have primary styling",
+  );
+});

--- a/apps/bfDs/components/BfDsForm/__tests__/BfDsFormTextInput.test.tsx
+++ b/apps/bfDs/components/BfDsForm/__tests__/BfDsFormTextInput.test.tsx
@@ -1,0 +1,47 @@
+import { render } from "infra/testing/ui-testing.ts";
+import { assertEquals, assertExists } from "@std/assert";
+import { BfDsForm } from "../BfDsForm.tsx";
+import { BfDsFormTextInput } from "../BfDsFormTextInput.tsx";
+
+Deno.test("BfDsFormTextInput renders with correct label and value", () => {
+  const initialData = { username: "testuser" };
+  const { doc, getByText } = render(
+    <BfDsForm initialData={initialData}>
+      <BfDsFormTextInput id="username" title="Username" />
+    </BfDsForm>,
+  );
+
+  // Check if label is rendered correctly
+  const label = getByText("Username");
+  assertExists(label, "Label should exist");
+
+  // Check if input is rendered with the correct value
+  const input = doc?.querySelector("input[name='username']");
+  assertExists(input, "Input element should exist");
+  assertEquals(
+    input?.getAttribute("value"),
+    "testuser",
+    "Input should have the correct value from initialData",
+  );
+});
+
+Deno.test("BfDsFormTextInput supports placeholder", () => {
+  const initialData = { email: "" };
+  const { doc } = render(
+    <BfDsForm initialData={initialData}>
+      <BfDsFormTextInput
+        id="email"
+        title="Email"
+        placeholder="Enter your email"
+      />
+    </BfDsForm>,
+  );
+
+  const input = doc?.querySelector("input[name='email']");
+  assertExists(input, "Input element should exist");
+  assertEquals(
+    input?.getAttribute("placeholder"),
+    "Enter your email",
+    "Input should have the correct placeholder",
+  );
+});

--- a/apps/bfDs/components/BfDsForm/__tests__/BfDsFormToggle.test.tsx
+++ b/apps/bfDs/components/BfDsForm/__tests__/BfDsFormToggle.test.tsx
@@ -1,0 +1,39 @@
+import { render } from "infra/testing/ui-testing.ts";
+import { assertEquals, assertExists } from "@std/assert";
+import { BfDsForm } from "../BfDsForm.tsx";
+import { BfDsFormToggle } from "../BfDsFormToggle.tsx";
+
+Deno.test("BfDsFormToggle renders with correct label and initial state", () => {
+  const initialData = { subscribed: true };
+  const { doc, getByText } = render(
+    <BfDsForm initialData={initialData}>
+      <BfDsFormToggle id="subscribed" title="Subscribe to newsletter" />
+    </BfDsForm>,
+  );
+
+  // Check if label is rendered correctly
+  const label = getByText("Subscribe to newsletter");
+  assertExists(label, "Label should exist");
+
+  // Check if the toggle has the correct initial state
+  // Note: Since the rendering is to string, we need to check for indicators that
+  // the toggle is in the "on" state in the HTML
+  const inputElement = doc?.querySelector("input[type='checkbox']");
+  assertExists(inputElement, "Toggle input element should exist");
+
+  // The value attribute or checked state should reflect the initial state
+  // Check for toggle element rendered by BfDsToggle by looking for input checkbox
+  const toggleElement = doc?.querySelector("input[type='checkbox']")
+    ?.parentElement;
+  assertExists(toggleElement, "Toggle container should exist");
+
+  // Verify the checked state matches our initial data
+  // We already have inputElement defined above, so we can reuse it
+  assertEquals(
+    inputElement?.hasAttribute("checked") ||
+      inputElement?.getAttribute("aria-checked") === "true" ||
+      inputElement?.getAttribute("value") === "true",
+    true,
+    "Toggle should be checked initially",
+  );
+});

--- a/apps/bfDs/components/__tests__/BfDsBreadcrumbs.test.tsx
+++ b/apps/bfDs/components/__tests__/BfDsBreadcrumbs.test.tsx
@@ -1,0 +1,91 @@
+import { render } from "infra/testing/ui-testing.ts";
+import { assertEquals, assertExists } from "@std/assert";
+import { BfDsBreadcrumbs } from "../BfDsBreadcrumbs.tsx";
+
+Deno.test("BfDsBreadcrumbs renders with crumbs", () => {
+  const crumbs = [
+    { name: "Page One", link: "/page1" },
+    { name: "Page Two", link: "/page2" },
+  ];
+  const { doc } = render(<BfDsBreadcrumbs crumbs={crumbs} />);
+
+  const breadcrumbItems = doc?.querySelectorAll(".breadcrumb-item");
+  assertExists(breadcrumbItems, "Breadcrumb items should exist");
+  assertEquals(breadcrumbItems.length, 2, "Should render two breadcrumb items");
+
+  const links = doc?.querySelectorAll(".breadcrumb-item a");
+  assertEquals(links?.length, 2, "Should render two links");
+  assertEquals(
+    links?.[0].getAttribute("href"),
+    "/page1",
+    "First link should have correct href",
+  );
+  assertEquals(
+    links?.[1].getAttribute("href"),
+    "/page2",
+    "Second link should have correct href",
+  );
+  assertEquals(
+    links?.[0].textContent,
+    "Page One",
+    "First link should have correct text",
+  );
+  assertEquals(
+    links?.[1].textContent,
+    "Page Two",
+    "Second link should have correct text",
+  );
+});
+
+Deno.test("BfDsBreadcrumbs renders with homeLink", () => {
+  const crumbs = [{ name: "Page One", link: "/page1" }];
+  const homeLink = "/home";
+  const { doc } = render(
+    <BfDsBreadcrumbs crumbs={crumbs} homeLink={homeLink} />,
+  );
+
+  const breadcrumbItems = doc?.querySelectorAll(".breadcrumb-item");
+  assertExists(breadcrumbItems, "Breadcrumb items should exist");
+  assertEquals(
+    breadcrumbItems.length,
+    2,
+    "Should render two breadcrumb items including home",
+  );
+
+  const links = doc?.querySelectorAll(".breadcrumb-item a");
+  assertEquals(links?.length, 2, "Should render two links including home");
+  assertEquals(
+    links?.[0].getAttribute("href"),
+    "/home",
+    "Home link should have correct href",
+  );
+});
+
+Deno.test("BfDsBreadcrumbs renders back icon for crumb with back=true", () => {
+  const crumbs = [
+    { name: "Back", link: "/back", back: true },
+    { name: "Current", link: "/current" },
+  ];
+  const { doc } = render(<BfDsBreadcrumbs crumbs={crumbs} />);
+
+  const firstCrumbContent = doc?.querySelector(
+    ".breadcrumb-item:first-child a",
+  );
+  assertExists(firstCrumbContent, "First breadcrumb item should exist");
+
+  const backIcon = firstCrumbContent?.querySelector("svg");
+  assertExists(backIcon, "Back icon should exist in the first breadcrumb");
+});
+
+Deno.test("BfDsBreadcrumbs renders with correct accessibility attributes", () => {
+  const crumbs = [{ name: "Page One", link: "/page1" }];
+  const { doc } = render(<BfDsBreadcrumbs crumbs={crumbs} />);
+
+  const nav = doc?.querySelector("nav");
+  assertExists(nav, "Navigation element should exist");
+  assertEquals(
+    nav?.getAttribute("aria-label"),
+    "Breadcrumbs",
+    "Nav should have correct aria-label",
+  );
+});

--- a/apps/bfDs/components/__tests__/BfDsButton.test.tsx
+++ b/apps/bfDs/components/__tests__/BfDsButton.test.tsx
@@ -1,0 +1,39 @@
+import { render } from "infra/testing/ui-testing.ts";
+import { assertEquals, assertExists } from "@std/assert";
+import { BfDsButton } from "../BfDsButton.tsx";
+
+Deno.test("BfDsButton renders with text", () => {
+  const buttonText = "Click Me";
+  const { getByText } = render(<BfDsButton text={buttonText} />);
+
+  const button = getByText(buttonText);
+  assertExists(button, `Button with text "${buttonText}" should exist`);
+});
+
+Deno.test("BfDsButton renders with correct variant style", () => {
+  const { doc } = render(<BfDsButton text="Primary Button" kind="primary" />);
+  const button = doc?.querySelector("button");
+
+  assertExists(button, "Button element should exist");
+
+  // BfDsButton uses inline styles rather than classes for variants
+  const buttonStyle = button?.getAttribute("style");
+  assertExists(buttonStyle, "Button should have style attribute");
+  assertEquals(
+    buttonStyle?.includes("var(--primaryButton)"),
+    true,
+    "Button should have primary button style",
+  );
+});
+
+Deno.test("BfDsButton renders as disabled when disabled prop is true", () => {
+  const { doc } = render(<BfDsButton text="Disabled Button" disabled />);
+  const button = doc?.querySelector("button");
+
+  assertExists(button, "Button element should exist");
+  assertEquals(
+    button?.hasAttribute("disabled"),
+    true,
+    "Button should have disabled attribute",
+  );
+});

--- a/apps/bfDs/components/__tests__/BfDsInput.test.tsx
+++ b/apps/bfDs/components/__tests__/BfDsInput.test.tsx
@@ -1,0 +1,40 @@
+import { render } from "infra/testing/ui-testing.ts";
+import { assertEquals, assertExists } from "@std/assert";
+import { BfDsInput } from "../BfDsInput.tsx";
+
+Deno.test("BfDsInput renders with label", () => {
+  const labelText = "Name";
+  const { getByText } = render(
+    <BfDsInput label={labelText} onChange={() => {}} />,
+  );
+
+  const label = getByText(labelText);
+  assertExists(label, `Label with text "${labelText}" should exist`);
+});
+
+Deno.test("BfDsInput renders with placeholder", () => {
+  const placeholderText = "Enter your name";
+  const { doc } = render(
+    <BfDsInput placeholder={placeholderText} onChange={() => {}} />,
+  );
+  const input = doc?.querySelector("input");
+
+  assertExists(input, "Input element should exist");
+  assertEquals(
+    input?.getAttribute("placeholder"),
+    placeholderText,
+    "Input should have the correct placeholder",
+  );
+});
+
+Deno.test("BfDsInput renders as disabled when disabled prop is true", () => {
+  const { doc } = render(<BfDsInput disabled onChange={() => {}} />);
+  const input = doc?.querySelector("input");
+
+  assertExists(input, "Input element should exist");
+  assertEquals(
+    input?.hasAttribute("disabled"),
+    true,
+    "Input should have disabled attribute",
+  );
+});

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,6 +1,7 @@
 {
   "unstable": ["temporal", "webgpu"],
   "imports": {
+    "@b-fuze/deno-dom": "jsr:@b-fuze/deno-dom@^0.1.49",
     "@deno/dnt": "jsr:@deno/dnt@^0.41.3",
     "@denosaurs/python": "jsr:@denosaurs/python@^0.4.4",
     "@iso": "./apps/boltFoundry/__generated__/__isograph/iso.ts",

--- a/deno.lock
+++ b/deno.lock
@@ -1,6 +1,7 @@
 {
   "version": "4",
   "specifiers": {
+    "jsr:@b-fuze/deno-dom@~0.1.49": "0.1.49",
     "jsr:@bolt-foundry/get-configuration-var@0.0.0-dev.0": "0.0.0-dev.0",
     "jsr:@bolt-foundry/logger@^0.0.0-dev.0": "0.0.0-dev.0",
     "jsr:@david/code-block-writer@^13.0.2": "13.0.3",
@@ -126,6 +127,9 @@
     "npm:zod@^3.24.1": "3.24.1"
   },
   "jsr": {
+    "@b-fuze/deno-dom@0.1.49": {
+      "integrity": "45c40175fdd1e74ab2d4b54c4fdaabbad6e5b76ee28df12a48e076b3fa7901a9"
+    },
     "@bolt-foundry/get-configuration-var@0.0.0-dev.0": {
       "integrity": "04ec312462ae6f0f6ed85e82fb444d18a8782754ecd2d920a4947fffb0435a58"
     },
@@ -5821,6 +5825,7 @@
   },
   "workspace": {
     "dependencies": [
+      "jsr:@b-fuze/deno-dom@~0.1.49",
       "jsr:@deno/dnt@~0.41.3",
       "jsr:@denosaurs/python@~0.4.4",
       "jsr:@luca/esbuild-deno-loader@~0.11.1",

--- a/infra/docs/ui-testing/backlog.md
+++ b/infra/docs/ui-testing/backlog.md
@@ -1,0 +1,133 @@
+# UI Component Testing Backlog
+
+This document tracks features, enhancements, and technical improvements that are
+being considered for future versions of the UI Component Testing framework.
+
+## Integration Features (From Version 0.2)
+
+**Priority**: Medium **Type**: Feature **Complexity**: Moderate **Target
+Version**: Future
+
+**Description**: Integration with BFF CLI tooling, visual comparison
+capabilities, and comprehensive test coverage for BfDs components.
+
+**Justification**: These features enhance the testing framework with better
+tooling integration and visual testing capabilities.
+
+**Dependencies**: Core testing foundation must be stable.
+
+**Acceptance Criteria**:
+
+- Integration with CI/CD pipeline
+- Visual comparison testing implemented
+- BFF CLI integration complete
+- Full test coverage for BfDs components
+
+**Why aren't we working on this yet?** Focusing on establishing the core testing
+infrastructure first before adding more advanced features.
+
+### Components and Implementation Details
+
+#### 1. Enhanced Test Utilities
+
+```typescript
+// infra/testing/ui-testing.ts additions
+
+export function fireEvent(element: Element, eventName: string, options = {}) {
+  // Implement event simulation
+}
+
+export function createSnapshot(component: JSX.Element) {
+  // Create snapshot for comparison
+}
+```
+
+#### 2. Visual Comparison
+
+```typescript
+// infra/testing/visual-comparison.ts
+
+export async function compareVisual(componentName: string, html: string) {
+  // Create a visual fingerprint of the component
+  // Compare against baseline
+}
+```
+
+#### 3. Interaction Tests
+
+```typescript
+// Example interaction test
+Deno.test("BfDsButton triggers onClick when clicked", () => {
+  let clicked = false;
+  const { doc } = render(
+    <BfDsButton
+      text="Click Me"
+      onClick={() => {
+        clicked = true;
+      }}
+    />,
+  );
+  const button = doc?.querySelector("button");
+  assertExists(button);
+
+  fireEvent(button, "click");
+  assertEquals(clicked, true);
+});
+```
+
+## Enhancement Features (From Version 0.3)
+
+**Priority**: Low **Type**: Enhancement **Complexity**: Complex **Target
+Version**: Future
+
+**Description**: Snapshot testing capabilities, accessibility testing, and
+comprehensive test reporting.
+
+**Justification**: These features provide more advanced testing capabilities and
+better reporting for UI components.
+
+**Dependencies**: Core testing foundation and integration features must be
+stable.
+
+**Acceptance Criteria**:
+
+- Snapshot testing implemented
+- Accessibility testing integrated
+- Comprehensive test reporting working
+
+**Why aren't we working on this yet?** Focusing on establishing the core testing
+infrastructure first before adding more advanced features.
+
+### Components and Implementation Details
+
+#### 1. Snapshot Testing
+
+```typescript
+// infra/testing/snapshot.ts
+
+export async function matchSnapshot(componentName: string, html: string) {
+  // Read existing snapshot or create new one
+  // Compare against current output
+}
+```
+
+#### 2. Accessibility Testing
+
+```typescript
+// infra/testing/a11y.ts
+
+export function checkAccessibility(html: string) {
+  // Perform basic accessibility checks
+  // Verify ARIA attributes, etc.
+}
+```
+
+#### 3. Test Reporting
+
+```typescript
+// infra/reporting/test-report.ts
+
+export function generateReport(testResults: TestResult[]) {
+  // Generate HTML report with component previews
+}
+```

--- a/infra/docs/ui-testing/project-plan.md
+++ b/infra/docs/ui-testing/project-plan.md
@@ -1,0 +1,193 @@
+# UI Component Testing Project Plan
+
+## Project Purpose
+
+To implement a comprehensive UI component testing strategy that aligns with Bolt
+Foundry's Test-Driven Development principles and "Worse is Better" philosophy,
+focusing on practical solutions using Deno's native testing capabilities.
+
+## Project Versions Overview
+
+1. **Version 0.1: Foundation**
+   - Set up basic testing infrastructure using Deno's web testing approach
+   - Establish component testing patterns
+   - Create initial examples for core components
+
+Note: Version 0.2 (Integration) and Version 0.3 (Enhancement) features have been
+moved to the backlog for future consideration. See `backlog.md` for details.
+
+## User Personas
+
+- **Component Developers**: Need to test UI components in isolation
+- **Integration Developers**: Need to test component interactions
+- **QA Engineers**: Need to verify UI behavior across components
+
+## Success Metrics
+
+- 90%+ test coverage for UI components
+- All BfDs components have comprehensive tests
+- Test suite runs in under 2 minutes
+
+## Version 0.1: Foundation Implementation Plan
+
+### Technical Goals
+
+- Create a simple, reliable testing infrastructure for UI components
+- Establish patterns for testing React components in Deno
+- Implement basic rendering tests for core components
+
+### Components and Implementation
+
+#### 1. Testing Library Setup
+
+Following Deno's recommended approach for web testing:
+
+```typescript
+// infra/testing/ui-testing.ts
+
+import { DOMParser, Element } from "jsr:@b-fuze/deno-dom";
+import { assertEquals, assertExists } from "jsr:@std/assert";
+import { renderToString } from "https://esm.sh/preact-render-to-string@6.0.0";
+
+export function render(component: JSX.Element) {
+  const html = renderToString(component);
+  const doc = new DOMParser().parseFromString(html, "text/html");
+
+  return {
+    getByText: (text: string) => {
+      const elements = Array.from(doc?.querySelectorAll("*") || []);
+      return elements.find((el) => el.textContent?.includes(text));
+    },
+    getByRole: (role: string, options?: { name?: string }) => {
+      const elements = Array.from(
+        doc?.querySelectorAll(`[role="${role}"]`) || [],
+      );
+      if (options?.name) {
+        return elements.find((el) =>
+          el.getAttribute("aria-label") === options.name
+        );
+      }
+      return elements[0];
+    },
+    queryByTestId: (testId: string) => {
+      return doc?.querySelector(`[data-testid="${testId}"]`);
+    },
+    // Add more query helpers as needed
+    html,
+    doc,
+  };
+}
+
+// Helper for simulating events
+export function fireEvent(element: Element, eventName: string, options = {}) {
+  const event = new Event(eventName, { bubbles: true, ...options });
+  element.dispatchEvent(event);
+  return event;
+}
+```
+
+#### 2. Test Patterns for Different Component Types
+
+Create test patterns for:
+
+- Simple Display Components
+- Interactive Components
+- Complex Components with Steps
+
+#### 4. BFF Integration
+
+```typescript
+// infra/bff/friends/ui-test.bff.ts
+
+import { register } from "infra/bff/bff.ts";
+import { runShellCommand } from "infra/bff/shellBase.ts";
+import { getLogger } from "packages/logger/logger.ts";
+
+const logger = getLogger(import.meta);
+
+export async function uiTest(args: string[]): Promise<number> {
+  const watchFlag = args.includes("--watch");
+  // Remove --watch from args if present
+  const filteredArgs = args.filter((arg) => arg !== "--watch");
+  const componentPath = filteredArgs[0] || ".";
+  const testPattern = `${componentPath}/**/__tests__/*.test.{ts,tsx}`;
+
+  logger.info(
+    `Running UI tests${watchFlag ? " in watch mode" : ""} for: ${testPattern}`,
+  );
+
+  const testArgs = ["deno", "test", "--allow-net", "--allow-read"];
+
+  if (watchFlag) {
+    testArgs.push("--watch");
+  }
+
+  testArgs.push(testPattern);
+
+  const result = await runShellCommand(testArgs, undefined, {}, true, true);
+
+  if (!watchFlag && result === 0) {
+    logger.info("✨ All UI tests passed!");
+  } else if (!watchFlag) {
+    logger.error("❌ UI tests failed");
+  }
+
+  return result;
+}
+
+register(
+  "ui-test",
+  "Run UI component tests (use --watch flag for watch mode)",
+  uiTest,
+);
+```
+
+### Integration Points
+
+- Integrate with existing BFF test command
+- Create a testing library compatible with Deno's test runner
+- Ensure tests can be run alongside other unit tests
+
+### Testing Strategy
+
+1. **Component Rendering**: Test that components render correctly with various
+   props
+2. **Event Handling**: Test that events like clicks are properly handled
+3. **Accessibility**: Verify that components meet basic accessibility standards
+4. **State Changes**: Test that components update correctly when state changes
+
+## Practical Implementation Steps
+
+1. **Start with Deno's native web testing approach**:
+   - Use `deno-dom` for DOM manipulation and testing
+   - Leverage Deno's built-in testing and assertion utilities
+   - Follow patterns from the Deno web testing documentation
+
+2. **Target highest-value components first**:
+   - Button, Input, List, Modal
+   - These components are used frequently across the application
+
+3. **Follow the Red-Green-Refactor cycle**:
+   - Write a failing test for expected component behavior
+   - Implement or fix the component to make the test pass
+   - Refactor the component and tests while maintaining passing tests
+
+4. **Document testing patterns**:
+   - Create a new behavior card for UI component testing
+   - Establish conventions for test file organization and naming
+
+5. **Extend BFF CLI commands**:
+   - Add `bff ui-test` for running UI component tests
+   - Add `bff ui-test --watch` for TDD workflow
+
+## Future Enhancements
+
+See `backlog.md` for details on planned future enhancements that were previously
+in Versions 0.2 and 0.3. These include:
+
+- Integration with BFF CLI tooling
+- Visual comparison testing
+- More sophisticated interaction testing
+- Snapshot testing
+- Accessibility testing
+- Test reporting

--- a/infra/testing/ui-testing.ts
+++ b/infra/testing/ui-testing.ts
@@ -1,0 +1,52 @@
+import { DOMParser } from "@b-fuze/deno-dom";
+import { renderToString } from "react-dom/server";
+import type React from "react";
+
+/**
+ * Renders a JSX component to HTML and provides utilities for testing
+ *
+ * @param component - The React/JSX component to render
+ * @returns Testing utilities for querying and asserting on the rendered output
+ */
+export function render(node: React.ReactNode) {
+  const html = renderToString(node);
+  const doc = new DOMParser().parseFromString(html, "text/html");
+
+  return {
+    getByText: (text: string) => {
+      const elements = Array.from(doc?.querySelectorAll("*") || []);
+      return elements.find((el) => el.textContent?.includes(text));
+    },
+    getByRole: (role: string, options?: { name?: string }) => {
+      const elements = Array.from(
+        doc?.querySelectorAll(`[role="${role}"]`) || [],
+      );
+      if (options?.name) {
+        return elements.find((el) =>
+          el.getAttribute("aria-label") === options.name
+        );
+      }
+      return elements[0];
+    },
+    queryByTestId: (testId: string) => {
+      return doc?.querySelector(`[data-testid="${testId}"]`);
+    },
+    // Add more query helpers as needed
+    html,
+    doc,
+  };
+}
+
+/**
+ * Helper for simulating events on DOM elements
+ *
+ * @param element - The DOM element to dispatch the event on
+ * @param eventName - The name of the event to dispatch
+ * @param options - Optional event configuration
+ * @returns The dispatched event
+ */
+export function fireEvent(element: Element, eventName: string, options = {}) {
+  const event = new Event(eventName, { bubbles: true, ...options });
+  element.dispatchEvent(event);
+  return event;
+}


### PR DESCRIPTION

## SUMMARY
This commit introduces a new test file, `BfDsBreadcrumbs.test.tsx`, which contains a suite of unit tests for the `BfDsBreadcrumbs` component. The tests cover the following scenarios:
- Rendering of breadcrumb items with correct labels and links.
- Inclusion of a home link when the `homeLink` prop is provided.
- Rendering of a back icon when a breadcrumb item has the `back` attribute set to true.
- Correct application of accessibility attributes such as `aria-label` on the navigation element.

These tests are implemented using the `Deno.test` framework and utilize assertions from `@std/assert` to ensure the component behaves as expected.

## TEST PLAN
1. Run the test suite using the Deno runtime to verify that all tests pass:
   ```
   deno test apps/bfDs/components/__tests__/BfDsBreadcrumbs.test.tsx
   ```
2. Ensure that the console output shows all tests passing without any errors or failures.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/549).
* #550
* #554
* #553
* #552
* __->__ #549
* #548
* #547
* #546