### PR TITLE
Add unit tests for BfDsCheckbox component

### DIFF
--- a/apps/bfDs/components/BfDsForm/__tests__/BfDsForm.test.tsx
+++ b/apps/bfDs/components/BfDsForm/__tests__/BfDsForm.test.tsx
@@ -1,0 +1,115 @@
+import { render } from "infra/testing/ui-testing.ts";
+import { assertEquals, assertExists } from "@std/assert";
+import { BfDsForm, useBfDsFormContext } from "../BfDsForm.tsx";
+import { BfDsFormTextInput } from "../BfDsFormTextInput.tsx";
+import { BfDsFormNumberInput } from "../BfDsFormNumberInput.tsx";
+import { BfDsFormToggle } from "../BfDsFormToggle.tsx";
+import { BfDsFormTextArea } from "../BfDsFormTextArea.tsx";
+import { BfDsFormSubmitButton } from "../BfDsFormSubmitButton.tsx";
+
+// Helper component to test the form context
+function FormContextDisplay() {
+  const { data } = useBfDsFormContext<{ name: string; age: number }>();
+  return (
+    <div>
+      <span data-testid="form-data">
+        {data ? `${data.name}-${data.age}` : "no-data"}
+      </span>
+    </div>
+  );
+}
+
+Deno.test("BfDsForm renders with initial data", () => {
+  const initialData = { name: "Test User", age: 30 };
+  const { doc } = render(
+    <BfDsForm initialData={initialData}>
+      <FormContextDisplay />
+    </BfDsForm>,
+  );
+
+  const formDataElement = doc?.querySelector("[data-testid='form-data']");
+  assertExists(formDataElement, "Form data element should exist");
+  assertEquals(
+    formDataElement?.textContent,
+    "Test User-30",
+    "Form should display the initial data",
+  );
+});
+
+Deno.test("BfDsForm renders form elements correctly", () => {
+  const initialData = {
+    name: "Test User",
+    age: 30,
+    isActive: true,
+    bio: "Hello",
+  };
+  const { doc } = render(
+    <BfDsForm initialData={initialData}>
+      <BfDsFormTextInput id="name" title="Name" />
+      <BfDsFormNumberInput id="age" title="Age" />
+      <BfDsFormToggle id="isActive" title="Active" />
+      <BfDsFormTextArea id="bio" title="Bio" />
+      <BfDsFormSubmitButton text="Submit" />
+    </BfDsForm>,
+  );
+
+  // Check if form element exists
+  const formElement = doc?.querySelector("form");
+  assertExists(formElement, "Form element should exist");
+
+  // Check if all form inputs are rendered
+  const nameInput = doc?.querySelector("input[name='name']");
+  assertExists(nameInput, "Name input should exist");
+  assertEquals(
+    nameInput?.getAttribute("value"),
+    "Test User",
+    "Name input should have the correct value",
+  );
+
+  const ageInput = doc?.querySelector("input[name='age']");
+  assertExists(ageInput, "Age input should exist");
+  assertEquals(
+    ageInput?.getAttribute("value"),
+    "30",
+    "Age input should have the correct value",
+  );
+
+  const submitButton = doc?.querySelector("button[type='submit']");
+  assertExists(submitButton, "Submit button should exist");
+  assertEquals(
+    submitButton?.textContent,
+    "Submit",
+    "Submit button should have the correct text",
+  );
+});
+
+Deno.test("BfDsForm renders with custom styles", () => {
+  const initialData = { name: "Test User" };
+  const customStyle = { padding: "20px", backgroundColor: "lightgray" };
+  const { doc } = render(
+    <BfDsForm initialData={initialData} xstyle={customStyle}>
+      <div>Form content</div>
+    </BfDsForm>,
+  );
+
+  const formElement = doc?.querySelector("form");
+  assertExists(formElement, "Form element should exist");
+
+  const formStyle = formElement?.getAttribute("style");
+  assertExists(formStyle, "Form should have style attribute");
+
+  // The exact style syntax might vary in the string representation
+  // So we'll check for the presence of the key style properties
+  assertEquals(
+    formStyle?.includes("padding") && formStyle?.includes("20px"),
+    true,
+    "Form should have custom padding style",
+  );
+  assertEquals(
+    (formStyle?.includes("background-color") ||
+      formStyle?.includes("backgroundColor")) &&
+      formStyle?.includes("lightgray"),
+    true,
+    "Form should have custom background color style",
+  );
+});

--- a/apps/bfDs/components/BfDsForm/__tests__/BfDsFormSubmitButton.test.tsx
+++ b/apps/bfDs/components/BfDsForm/__tests__/BfDsFormSubmitButton.test.tsx
@@ -1,0 +1,49 @@
+import { render } from "infra/testing/ui-testing.ts";
+import { assertEquals, assertExists } from "@std/assert";
+import { BfDsForm } from "../BfDsForm.tsx";
+import { BfDsFormSubmitButton } from "../BfDsFormSubmitButton.tsx";
+
+Deno.test("BfDsFormSubmitButton renders with correct text", () => {
+  const { getByText } = render(
+    <BfDsForm initialData={{}}>
+      <BfDsFormSubmitButton text="Save Changes" />
+    </BfDsForm>,
+  );
+
+  const button = getByText("Save Changes");
+  assertExists(button, "Submit button with text should exist");
+});
+
+Deno.test("BfDsFormSubmitButton renders as submit type button", () => {
+  const { doc } = render(
+    <BfDsForm initialData={{}}>
+      <BfDsFormSubmitButton text="Submit" />
+    </BfDsForm>,
+  );
+
+  const button = doc?.querySelector("button[type='submit']");
+  assertExists(button, "Button should have type 'submit'");
+});
+
+Deno.test("BfDsFormSubmitButton passes kind prop to BfDsButton", () => {
+  const { doc } = render(
+    <BfDsForm initialData={{}}>
+      <BfDsFormSubmitButton text="Submit" kind="primary" />
+    </BfDsForm>,
+  );
+
+  const button = doc?.querySelector("button");
+  assertExists(button, "Button should exist");
+
+  // Check for primary button styling
+  // Note: This may need adjustment based on how BfDsButton applies the kind prop
+  // It could be a class or inline style depending on your implementation
+  const buttonStyle = button?.getAttribute("style");
+  assertExists(buttonStyle, "Button should have style attribute");
+  assertEquals(
+    buttonStyle?.includes("var(--primaryButton)") ||
+      button?.classList.contains("primary"),
+    true,
+    "Button should have primary styling",
+  );
+});

--- a/apps/bfDs/components/BfDsForm/__tests__/BfDsFormTextInput.test.tsx
+++ b/apps/bfDs/components/BfDsForm/__tests__/BfDsFormTextInput.test.tsx
@@ -1,0 +1,47 @@
+import { render } from "infra/testing/ui-testing.ts";
+import { assertEquals, assertExists } from "@std/assert";
+import { BfDsForm } from "../BfDsForm.tsx";
+import { BfDsFormTextInput } from "../BfDsFormTextInput.tsx";
+
+Deno.test("BfDsFormTextInput renders with correct label and value", () => {
+  const initialData = { username: "testuser" };
+  const { doc, getByText } = render(
+    <BfDsForm initialData={initialData}>
+      <BfDsFormTextInput id="username" title="Username" />
+    </BfDsForm>,
+  );
+
+  // Check if label is rendered correctly
+  const label = getByText("Username");
+  assertExists(label, "Label should exist");
+
+  // Check if input is rendered with the correct value
+  const input = doc?.querySelector("input[name='username']");
+  assertExists(input, "Input element should exist");
+  assertEquals(
+    input?.getAttribute("value"),
+    "testuser",
+    "Input should have the correct value from initialData",
+  );
+});
+
+Deno.test("BfDsFormTextInput supports placeholder", () => {
+  const initialData = { email: "" };
+  const { doc } = render(
+    <BfDsForm initialData={initialData}>
+      <BfDsFormTextInput
+        id="email"
+        title="Email"
+        placeholder="Enter your email"
+      />
+    </BfDsForm>,
+  );
+
+  const input = doc?.querySelector("input[name='email']");
+  assertExists(input, "Input element should exist");
+  assertEquals(
+    input?.getAttribute("placeholder"),
+    "Enter your email",
+    "Input should have the correct placeholder",
+  );
+});

--- a/apps/bfDs/components/BfDsForm/__tests__/BfDsFormToggle.test.tsx
+++ b/apps/bfDs/components/BfDsForm/__tests__/BfDsFormToggle.test.tsx
@@ -1,0 +1,39 @@
+import { render } from "infra/testing/ui-testing.ts";
+import { assertEquals, assertExists } from "@std/assert";
+import { BfDsForm } from "../BfDsForm.tsx";
+import { BfDsFormToggle } from "../BfDsFormToggle.tsx";
+
+Deno.test("BfDsFormToggle renders with correct label and initial state", () => {
+  const initialData = { subscribed: true };
+  const { doc, getByText } = render(
+    <BfDsForm initialData={initialData}>
+      <BfDsFormToggle id="subscribed" title="Subscribe to newsletter" />
+    </BfDsForm>,
+  );
+
+  // Check if label is rendered correctly
+  const label = getByText("Subscribe to newsletter");
+  assertExists(label, "Label should exist");
+
+  // Check if the toggle has the correct initial state
+  // Note: Since the rendering is to string, we need to check for indicators that
+  // the toggle is in the "on" state in the HTML
+  const inputElement = doc?.querySelector("input[type='checkbox']");
+  assertExists(inputElement, "Toggle input element should exist");
+
+  // The value attribute or checked state should reflect the initial state
+  // Check for toggle element rendered by BfDsToggle by looking for input checkbox
+  const toggleElement = doc?.querySelector("input[type='checkbox']")
+    ?.parentElement;
+  assertExists(toggleElement, "Toggle container should exist");
+
+  // Verify the checked state matches our initial data
+  // We already have inputElement defined above, so we can reuse it
+  assertEquals(
+    inputElement?.hasAttribute("checked") ||
+      inputElement?.getAttribute("aria-checked") === "true" ||
+      inputElement?.getAttribute("value") === "true",
+    true,
+    "Toggle should be checked initially",
+  );
+});

--- a/apps/bfDs/components/__tests__/BfDsBreadcrumbs.test.tsx
+++ b/apps/bfDs/components/__tests__/BfDsBreadcrumbs.test.tsx
@@ -1,0 +1,91 @@
+import { render } from "infra/testing/ui-testing.ts";
+import { assertEquals, assertExists } from "@std/assert";
+import { BfDsBreadcrumbs } from "../BfDsBreadcrumbs.tsx";
+
+Deno.test("BfDsBreadcrumbs renders with crumbs", () => {
+  const crumbs = [
+    { name: "Page One", link: "/page1" },
+    { name: "Page Two", link: "/page2" },
+  ];
+  const { doc } = render(<BfDsBreadcrumbs crumbs={crumbs} />);
+
+  const breadcrumbItems = doc?.querySelectorAll(".breadcrumb-item");
+  assertExists(breadcrumbItems, "Breadcrumb items should exist");
+  assertEquals(breadcrumbItems.length, 2, "Should render two breadcrumb items");
+
+  const links = doc?.querySelectorAll(".breadcrumb-item a");
+  assertEquals(links?.length, 2, "Should render two links");
+  assertEquals(
+    links?.[0].getAttribute("href"),
+    "/page1",
+    "First link should have correct href",
+  );
+  assertEquals(
+    links?.[1].getAttribute("href"),
+    "/page2",
+    "Second link should have correct href",
+  );
+  assertEquals(
+    links?.[0].textContent,
+    "Page One",
+    "First link should have correct text",
+  );
+  assertEquals(
+    links?.[1].textContent,
+    "Page Two",
+    "Second link should have correct text",
+  );
+});
+
+Deno.test("BfDsBreadcrumbs renders with homeLink", () => {
+  const crumbs = [{ name: "Page One", link: "/page1" }];
+  const homeLink = "/home";
+  const { doc } = render(
+    <BfDsBreadcrumbs crumbs={crumbs} homeLink={homeLink} />,
+  );
+
+  const breadcrumbItems = doc?.querySelectorAll(".breadcrumb-item");
+  assertExists(breadcrumbItems, "Breadcrumb items should exist");
+  assertEquals(
+    breadcrumbItems.length,
+    2,
+    "Should render two breadcrumb items including home",
+  );
+
+  const links = doc?.querySelectorAll(".breadcrumb-item a");
+  assertEquals(links?.length, 2, "Should render two links including home");
+  assertEquals(
+    links?.[0].getAttribute("href"),
+    "/home",
+    "Home link should have correct href",
+  );
+});
+
+Deno.test("BfDsBreadcrumbs renders back icon for crumb with back=true", () => {
+  const crumbs = [
+    { name: "Back", link: "/back", back: true },
+    { name: "Current", link: "/current" },
+  ];
+  const { doc } = render(<BfDsBreadcrumbs crumbs={crumbs} />);
+
+  const firstCrumbContent = doc?.querySelector(
+    ".breadcrumb-item:first-child a",
+  );
+  assertExists(firstCrumbContent, "First breadcrumb item should exist");
+
+  const backIcon = firstCrumbContent?.querySelector("svg");
+  assertExists(backIcon, "Back icon should exist in the first breadcrumb");
+});
+
+Deno.test("BfDsBreadcrumbs renders with correct accessibility attributes", () => {
+  const crumbs = [{ name: "Page One", link: "/page1" }];
+  const { doc } = render(<BfDsBreadcrumbs crumbs={crumbs} />);
+
+  const nav = doc?.querySelector("nav");
+  assertExists(nav, "Navigation element should exist");
+  assertEquals(
+    nav?.getAttribute("aria-label"),
+    "Breadcrumbs",
+    "Nav should have correct aria-label",
+  );
+});

--- a/apps/bfDs/components/__tests__/BfDsButton.test.tsx
+++ b/apps/bfDs/components/__tests__/BfDsButton.test.tsx
@@ -1,0 +1,39 @@
+import { render } from "infra/testing/ui-testing.ts";
+import { assertEquals, assertExists } from "@std/assert";
+import { BfDsButton } from "../BfDsButton.tsx";
+
+Deno.test("BfDsButton renders with text", () => {
+  const buttonText = "Click Me";
+  const { getByText } = render(<BfDsButton text={buttonText} />);
+
+  const button = getByText(buttonText);
+  assertExists(button, `Button with text "${buttonText}" should exist`);
+});
+
+Deno.test("BfDsButton renders with correct variant style", () => {
+  const { doc } = render(<BfDsButton text="Primary Button" kind="primary" />);
+  const button = doc?.querySelector("button");
+
+  assertExists(button, "Button element should exist");
+
+  // BfDsButton uses inline styles rather than classes for variants
+  const buttonStyle = button?.getAttribute("style");
+  assertExists(buttonStyle, "Button should have style attribute");
+  assertEquals(
+    buttonStyle?.includes("var(--primaryButton)"),
+    true,
+    "Button should have primary button style",
+  );
+});
+
+Deno.test("BfDsButton renders as disabled when disabled prop is true", () => {
+  const { doc } = render(<BfDsButton text="Disabled Button" disabled />);
+  const button = doc?.querySelector("button");
+
+  assertExists(button, "Button element should exist");
+  assertEquals(
+    button?.hasAttribute("disabled"),
+    true,
+    "Button should have disabled attribute",
+  );
+});

--- a/apps/bfDs/components/__tests__/BfDsCallout.test.tsx
+++ b/apps/bfDs/components/__tests__/BfDsCallout.test.tsx
@@ -1,0 +1,100 @@
+import { render } from "infra/testing/ui-testing.ts";
+import { assertEquals, assertExists } from "@std/assert";
+import { BfDsCallout } from "../BfDsCallout.tsx";
+import { BfDsButton } from "../BfDsButton.tsx";
+
+Deno.test("BfDsCallout renders with header and body text", () => {
+  const headerText = "Information Header";
+  const bodyText = "This is important information for the user.";
+  const { getByText } = render(
+    <BfDsCallout kind="info" header={headerText} body={bodyText} />,
+  );
+
+  const header = getByText(headerText);
+  const body = getByText(bodyText);
+
+  assertExists(header, `Header with text "${headerText}" should exist`);
+  assertExists(body, `Body with text "${bodyText}" should exist`);
+});
+
+Deno.test("BfDsCallout renders with correct kind (info)", () => {
+  const { doc } = render(
+    <BfDsCallout kind="info" header="Info Header" body="Info message" />,
+  );
+
+  const calloutElement = doc?.querySelector(".callout");
+  assertExists(calloutElement, "Callout element should exist");
+  assertEquals(
+    calloutElement?.classList.contains("info"),
+    true,
+    "Callout should have 'info' class",
+  );
+});
+
+Deno.test("BfDsCallout renders with correct kind (warning)", () => {
+  const { doc } = render(
+    <BfDsCallout
+      kind="warning"
+      header="Warning Header"
+      body="Warning message"
+    />,
+  );
+
+  const calloutElement = doc?.querySelector(".callout");
+  assertExists(calloutElement, "Callout element should exist");
+  assertEquals(
+    calloutElement?.classList.contains("warning"),
+    true,
+    "Callout should have 'warning' class",
+  );
+});
+
+Deno.test("BfDsCallout renders with correct kind (error)", () => {
+  const { doc } = render(
+    <BfDsCallout kind="error" header="Error Header" body="Error message" />,
+  );
+
+  const calloutElement = doc?.querySelector(".callout");
+  assertExists(calloutElement, "Callout element should exist");
+  assertEquals(
+    calloutElement?.classList.contains("error"),
+    true,
+    "Callout should have 'error' class",
+  );
+});
+
+Deno.test("BfDsCallout renders with correct kind (success)", () => {
+  const { doc } = render(
+    <BfDsCallout
+      kind="success"
+      header="Success Header"
+      body="Success message"
+    />,
+  );
+
+  const calloutElement = doc?.querySelector(".callout");
+  assertExists(calloutElement, "Callout element should exist");
+  assertEquals(
+    calloutElement?.classList.contains("success"),
+    true,
+    "Callout should have 'success' class",
+  );
+});
+
+Deno.test("BfDsCallout renders with action element", () => {
+  const actionText = "Click Me";
+  const { getByText } = render(
+    <BfDsCallout
+      kind="info"
+      header="Header"
+      body="Message"
+      action={<BfDsButton text={actionText} />}
+    />,
+  );
+
+  const actionButton = getByText(actionText);
+  assertExists(
+    actionButton,
+    `Action button with text "${actionText}" should exist`,
+  );
+});

--- a/apps/bfDs/components/__tests__/BfDsCheckbox.test.tsx
+++ b/apps/bfDs/components/__tests__/BfDsCheckbox.test.tsx
@@ -1,0 +1,116 @@
+import { render } from "infra/testing/ui-testing.ts";
+import { assertEquals, assertExists } from "@std/assert";
+import { BfDsCheckbox } from "../BfDsCheckbox.tsx";
+
+Deno.test("BfDsCheckbox renders with label", () => {
+  const labelText = "Accept terms";
+  const { getByText } = render(
+    <BfDsCheckbox label={labelText} onChange={() => {}} />,
+  );
+
+  const label = getByText(labelText);
+  assertExists(label, `Label with text "${labelText}" should exist`);
+});
+
+Deno.test("BfDsCheckbox renders as checked when value is true", () => {
+  const { doc } = render(
+    <BfDsCheckbox value onChange={() => {}} />,
+  );
+
+  // The component uses icon to show checked state
+  const icon = doc?.querySelector(".icon") || doc?.querySelector("svg");
+  assertExists(icon, "Icon element should exist");
+
+  // Check for an input with checked attribute
+  const input = doc?.querySelector("input[type='checkbox']");
+  assertExists(input, "Checkbox input element should exist");
+  assertEquals(
+    input?.hasAttribute("checked") || input?.getAttribute("checked") === "",
+    true,
+    "Input should be checked",
+  );
+});
+
+Deno.test("BfDsCheckbox renders as unchecked when value is false", () => {
+  const { doc } = render(
+    <BfDsCheckbox value={false} onChange={() => {}} />,
+  );
+
+  // Check that the input is not checked
+  const input = doc?.querySelector("input[type='checkbox']");
+  assertExists(input, "Checkbox input element should exist");
+  assertEquals(
+    input?.hasAttribute("checked") || input?.getAttribute("checked") === "",
+    false,
+    "Input should not be checked",
+  );
+});
+
+Deno.test("BfDsCheckbox renders as disabled when disabled prop is true", () => {
+  const { doc } = render(
+    <BfDsCheckbox disabled onChange={() => {}} />,
+  );
+
+  const input = doc?.querySelector("input[type='checkbox']");
+  assertExists(input, "Checkbox input element should exist");
+  assertEquals(
+    input?.hasAttribute("disabled"),
+    true,
+    "Input should have disabled attribute",
+  );
+});
+
+Deno.test("BfDsCheckbox renders with different sizes", () => {
+  const { doc } = render(
+    <BfDsCheckbox
+      label="Size Test"
+      value
+      onChange={() => {}}
+      size="large"
+    />,
+  );
+
+  // Look for the checkbox input
+  const checkbox = doc?.querySelector("input[type='checkbox']");
+  assertExists(checkbox, "Checkbox input should exist");
+
+  // The main checkbox container
+  const checkboxContainer = doc?.querySelector("div[data-bf-testid]") ||
+    doc?.querySelector("input[type='checkbox']").parentElement;
+  assertExists(checkboxContainer, "Checkbox container should exist");
+
+  // Look for the icon - BfDsIcon is rendered with the appropriate size
+  const icon = doc?.querySelector("svg");
+  assertExists(icon, "Icon element should exist");
+
+  // Verify the checkbox label contains the text
+  const labelElement = doc?.querySelector("label");
+  assertExists(labelElement, "Label element should exist");
+
+  const labelText = labelElement?.textContent;
+  assertEquals(
+    labelText?.includes("Size Test"),
+    true,
+    "Label should contain 'Size Test'",
+  );
+});
+
+Deno.test("BfDsCheckbox renders with meta information", () => {
+  const metaText = "Additional information";
+  const { getByText } = render(
+    <BfDsCheckbox meta={metaText} onChange={() => {}} />,
+  );
+
+  const meta = getByText(metaText);
+  assertExists(meta, `Meta text "${metaText}" should exist`);
+});
+
+Deno.test("BfDsCheckbox renders with test ID when provided", () => {
+  const testId = "test-checkbox";
+  const { doc } = render(
+    <BfDsCheckbox testId={testId} value={false} onChange={() => {}} />,
+  );
+
+  const checkbox = doc?.querySelector(`[data-bf-testid="${testId}-true"]`);
+  assertExists(checkbox, "Checkbox with test ID should exist");
+});

--- a/apps/bfDs/components/__tests__/BfDsInput.test.tsx
+++ b/apps/bfDs/components/__tests__/BfDsInput.test.tsx
@@ -1,0 +1,40 @@
+import { render } from "infra/testing/ui-testing.ts";
+import { assertEquals, assertExists } from "@std/assert";
+import { BfDsInput } from "../BfDsInput.tsx";
+
+Deno.test("BfDsInput renders with label", () => {
+  const labelText = "Name";
+  const { getByText } = render(
+    <BfDsInput label={labelText} onChange={() => {}} />,
+  );
+
+  const label = getByText(labelText);
+  assertExists(label, `Label with text "${labelText}" should exist`);
+});
+
+Deno.test("BfDsInput renders with placeholder", () => {
+  const placeholderText = "Enter your name";
+  const { doc } = render(
+    <BfDsInput placeholder={placeholderText} onChange={() => {}} />,
+  );
+  const input = doc?.querySelector("input");
+
+  assertExists(input, "Input element should exist");
+  assertEquals(
+    input?.getAttribute("placeholder"),
+    placeholderText,
+    "Input should have the correct placeholder",
+  );
+});
+
+Deno.test("BfDsInput renders as disabled when disabled prop is true", () => {
+  const { doc } = render(<BfDsInput disabled onChange={() => {}} />);
+  const input = doc?.querySelector("input");
+
+  assertExists(input, "Input element should exist");
+  assertEquals(
+    input?.hasAttribute("disabled"),
+    true,
+    "Input should have disabled attribute",
+  );
+});

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,6 +1,7 @@
 {
   "unstable": ["temporal", "webgpu"],
   "imports": {
+    "@b-fuze/deno-dom": "jsr:@b-fuze/deno-dom@^0.1.49",
     "@deno/dnt": "jsr:@deno/dnt@^0.41.3",
     "@denosaurs/python": "jsr:@denosaurs/python@^0.4.4",
     "@iso": "./apps/boltFoundry/__generated__/__isograph/iso.ts",

--- a/deno.lock
+++ b/deno.lock
@@ -1,6 +1,7 @@
 {
   "version": "4",
   "specifiers": {
+    "jsr:@b-fuze/deno-dom@~0.1.49": "0.1.49",
     "jsr:@bolt-foundry/get-configuration-var@0.0.0-dev.0": "0.0.0-dev.0",
     "jsr:@bolt-foundry/logger@^0.0.0-dev.0": "0.0.0-dev.0",
     "jsr:@david/code-block-writer@^13.0.2": "13.0.3",
@@ -126,6 +127,9 @@
     "npm:zod@^3.24.1": "3.24.1"
   },
   "jsr": {
+    "@b-fuze/deno-dom@0.1.49": {
+      "integrity": "45c40175fdd1e74ab2d4b54c4fdaabbad6e5b76ee28df12a48e076b3fa7901a9"
+    },
     "@bolt-foundry/get-configuration-var@0.0.0-dev.0": {
       "integrity": "04ec312462ae6f0f6ed85e82fb444d18a8782754ecd2d920a4947fffb0435a58"
     },
@@ -5821,6 +5825,7 @@
   },
   "workspace": {
     "dependencies": [
+      "jsr:@b-fuze/deno-dom@~0.1.49",
       "jsr:@deno/dnt@~0.41.3",
       "jsr:@denosaurs/python@~0.4.4",
       "jsr:@luca/esbuild-deno-loader@~0.11.1",

--- a/deno.lock
+++ b/deno.lock
@@ -9,6 +9,7 @@
     "jsr:@deno/dnt@~0.41.3": "0.41.3",
     "jsr:@deno/graph@~0.73.1": "0.73.1",
     "jsr:@denosaurs/plug@1": "1.0.6",
+    "jsr:@denosaurs/plug@1.0.3": "1.0.3",
     "jsr:@denosaurs/python@~0.4.4": "0.4.4",
     "jsr:@luca/esbuild-deno-loader@~0.11.1": "0.11.1",
     "jsr:@openai/openai@^4.78.1": "4.79.1",
@@ -19,19 +20,23 @@
     "jsr:@std/assert@0.226": "0.226.0",
     "jsr:@std/assert@^1.0.10": "1.0.11",
     "jsr:@std/assert@^1.0.11": "1.0.11",
+    "jsr:@std/assert@~0.213.1": "0.213.1",
     "jsr:@std/async@^1.0.9": "1.0.10",
     "jsr:@std/bytes@0.223": "0.223.0",
     "jsr:@std/bytes@^1.0.2": "1.0.4",
     "jsr:@std/cli@^1.0.8": "1.0.10",
     "jsr:@std/collections@^1.0.9": "1.0.10",
     "jsr:@std/data-structures@^1.0.6": "1.0.6",
+    "jsr:@std/encoding@0.213.1": "0.213.1",
     "jsr:@std/encoding@0.221": "0.221.0",
     "jsr:@std/encoding@^1.0.5": "1.0.6",
+    "jsr:@std/fmt@0.213.1": "0.213.1",
     "jsr:@std/fmt@0.221": "0.221.0",
     "jsr:@std/fmt@0.223": "0.223.0",
     "jsr:@std/fmt@1": "1.0.4",
     "jsr:@std/fmt@^1.0.3": "1.0.4",
     "jsr:@std/front-matter@^1.0.5": "1.0.5",
+    "jsr:@std/fs@0.213.1": "0.213.1",
     "jsr:@std/fs@0.221": "0.221.0",
     "jsr:@std/fs@0.223": "0.223.0",
     "jsr:@std/fs@1": "1.0.10",
@@ -44,12 +49,14 @@
     "jsr:@std/io@0.223": "0.223.0",
     "jsr:@std/media-types@^1.1.0": "1.1.0",
     "jsr:@std/net@^1.0.4": "1.0.4",
+    "jsr:@std/path@0.213.1": "0.213.1",
     "jsr:@std/path@0.221": "0.221.0",
     "jsr:@std/path@0.223": "0.223.0",
     "jsr:@std/path@1": "1.0.8",
     "jsr:@std/path@1.0.0-rc.1": "1.0.0-rc.1",
     "jsr:@std/path@^1.0.6": "1.0.8",
     "jsr:@std/path@^1.0.8": "1.0.8",
+    "jsr:@std/path@~0.213.1": "0.213.1",
     "jsr:@std/path@~0.225.2": "0.225.2",
     "jsr:@std/streams@^1.0.8": "1.0.8",
     "jsr:@std/testing@^1.0.9": "1.0.9",
@@ -59,6 +66,7 @@
     "jsr:@ts-morph/common@0.24": "0.24.0",
     "npm:@ai-sdk/openai@^1.3.7": "1.3.7_zod@3.24.1",
     "npm:@anthropic-ai/claude-code@~0.2.18": "0.2.18",
+    "npm:@daily-co/daily-js@0.77": "0.77.0",
     "npm:@hexagon/base64@^1.1.27": "1.1.28",
     "npm:@hyperdx/browser@~0.21.2": "0.21.2_@hyperdx+otel-web@0.16.3__@opentelemetry+api@1.9.0",
     "npm:@hyperdx/deno@^0.0.4": "0.0.4_@opentelemetry+api@1.6.0_@opentelemetry+api-logs@0.43.0",
@@ -128,7 +136,10 @@
   },
   "jsr": {
     "@b-fuze/deno-dom@0.1.49": {
-      "integrity": "45c40175fdd1e74ab2d4b54c4fdaabbad6e5b76ee28df12a48e076b3fa7901a9"
+      "integrity": "45c40175fdd1e74ab2d4b54c4fdaabbad6e5b76ee28df12a48e076b3fa7901a9",
+      "dependencies": [
+        "jsr:@denosaurs/plug@1.0.3"
+      ]
     },
     "@bolt-foundry/get-configuration-var@0.0.0-dev.0": {
       "integrity": "04ec312462ae6f0f6ed85e82fb444d18a8782754ecd2d920a4947fffb0435a58"
@@ -168,6 +179,15 @@
     "@deno/graph@0.73.1": {
       "integrity": "cd69639d2709d479037d5ce191a422eabe8d71bb68b0098344f6b07411c84d41"
     },
+    "@denosaurs/plug@1.0.3": {
+      "integrity": "b010544e386bea0ff3a1d05e0c88f704ea28cbd4d753439c2f1ee021a85d4640",
+      "dependencies": [
+        "jsr:@std/encoding@0.213.1",
+        "jsr:@std/fmt@0.213.1",
+        "jsr:@std/fs@0.213.1",
+        "jsr:@std/path@0.213.1"
+      ]
+    },
     "@denosaurs/plug@1.0.6": {
       "integrity": "6cf5b9daba7799837b9ffbe89f3450510f588fafef8115ddab1ff0be9cb7c1a7",
       "dependencies": [
@@ -180,7 +200,7 @@
     "@denosaurs/python@0.4.4": {
       "integrity": "0eca587ac3a60ed5bce73ac9612126de39d7c26b0a98c03044838fd94aba812f",
       "dependencies": [
-        "jsr:@denosaurs/plug",
+        "jsr:@denosaurs/plug@1",
         "jsr:@std/fmt@1",
         "jsr:@std/fs@1",
         "jsr:@std/path@1"
@@ -211,6 +231,9 @@
         "npm:@peculiar/asn1-schema",
         "npm:@peculiar/asn1-x509"
       ]
+    },
+    "@std/assert@0.213.1": {
+      "integrity": "24c28178b30c8e0782c18e8e94ea72b16282207569cdd10ffb9d1d26f2edebfe"
     },
     "@std/assert@0.221.0": {
       "integrity": "a5f1aa6e7909dbea271754fd4ab3f4e687aeff4873b4cef9a320af813adb489a"
@@ -245,11 +268,17 @@
     "@std/data-structures@1.0.6": {
       "integrity": "76a7fd8080c66604c0496220a791860492ab21a04a63a969c0b9a0609bbbb760"
     },
+    "@std/encoding@0.213.1": {
+      "integrity": "fcbb6928713dde941a18ca5db88ca1544d0755ec8fb20fe61e2dc8144b390c62"
+    },
     "@std/encoding@0.221.0": {
       "integrity": "d1dd76ef0dc5d14088411e6dc1dede53bf8308c95d1537df1214c97137208e45"
     },
     "@std/encoding@1.0.6": {
       "integrity": "ca87122c196e8831737d9547acf001766618e78cd8c33920776c7f5885546069"
+    },
+    "@std/fmt@0.213.1": {
+      "integrity": "a06d31777566d874b9c856c10244ac3e6b660bdec4c82506cd46be052a1082c3"
     },
     "@std/fmt@0.221.0": {
       "integrity": "379fed69bdd9731110f26b9085aeb740606b20428ce6af31ef6bd45ef8efa62a"
@@ -265,6 +294,13 @@
       "dependencies": [
         "jsr:@std/toml",
         "jsr:@std/yaml"
+      ]
+    },
+    "@std/fs@0.213.1": {
+      "integrity": "fbcaf099f8a85c27ab0712b666262cda8fe6d02e9937bf9313ecaea39a22c501",
+      "dependencies": [
+        "jsr:@std/assert@~0.213.1",
+        "jsr:@std/path@~0.213.1"
       ]
     },
     "@std/fs@0.221.0": {
@@ -320,6 +356,12 @@
     },
     "@std/net@1.0.4": {
       "integrity": "2f403b455ebbccf83d8a027d29c5a9e3a2452fea39bb2da7f2c04af09c8bc852"
+    },
+    "@std/path@0.213.1": {
+      "integrity": "f187bf278a172752e02fcbacf6bd78a335ed320d080a7ed3a5a59c3e88abc673",
+      "dependencies": [
+        "jsr:@std/assert@~0.213.1"
+      ]
     },
     "@std/path@0.221.0": {
       "integrity": "0a36f6b17314ef653a3a1649740cc8db51b25a133ecfe838f20b79a56ebe0095",
@@ -498,6 +540,16 @@
     },
     "@csstools/css-tokenizer@3.0.3": {
       "integrity": "sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw=="
+    },
+    "@daily-co/daily-js@0.77.0": {
+      "integrity": "sha512-icNXKieKAkRR/C5dcPjrCkL1jQGFp5C5WtLHy5uHAdTztm+mo9wlPJuehbWaGOM3TV24mgWHZ/+8jOys1G0I4w==",
+      "dependencies": [
+        "@babel/runtime@7.26.0",
+        "@sentry/browser",
+        "bowser",
+        "dequal",
+        "events"
+      ]
     },
     "@discordjs/builders@1.10.1": {
       "integrity": "sha512-OWo1fY4ztL1/M/DUyRPShB4d/EzVfuUvPTRRHRIt/YxBrUYSz0a+JicD5F5zHFoNs2oTuWavxCOVFV1UljHTng==",
@@ -870,7 +922,7 @@
         "@opentelemetry/core@1.30.1_@opentelemetry+api@1.9.0",
         "@opentelemetry/instrumentation",
         "@opentelemetry/semantic-conventions@1.29.0",
-        "@sentry/core",
+        "@sentry/core@8.54.0",
         "@sentry/types",
         "@sentry/utils",
         "json-stringify-safe",
@@ -1738,19 +1790,58 @@
     "@sapphire/snowflake@3.5.3": {
       "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ=="
     },
+    "@sentry-internal/browser-utils@8.55.0": {
+      "integrity": "sha512-ROgqtQfpH/82AQIpESPqPQe0UyWywKJsmVIqi3c5Fh+zkds5LUxnssTj3yNd1x+kxaPDVB023jAP+3ibNgeNDw==",
+      "dependencies": [
+        "@sentry/core@8.55.0"
+      ]
+    },
+    "@sentry-internal/feedback@8.55.0": {
+      "integrity": "sha512-cP3BD/Q6pquVQ+YL+rwCnorKuTXiS9KXW8HNKu4nmmBAyf7urjs+F6Hr1k9MXP5yQ8W3yK7jRWd09Yu6DHWOiw==",
+      "dependencies": [
+        "@sentry/core@8.55.0"
+      ]
+    },
+    "@sentry-internal/replay-canvas@8.55.0": {
+      "integrity": "sha512-nIkfgRWk1091zHdu4NbocQsxZF1rv1f7bbp3tTIlZYbrH62XVZosx5iHAuZG0Zc48AETLE7K4AX9VGjvQj8i9w==",
+      "dependencies": [
+        "@sentry-internal/replay",
+        "@sentry/core@8.55.0"
+      ]
+    },
+    "@sentry-internal/replay@8.55.0": {
+      "integrity": "sha512-roCDEGkORwolxBn8xAKedybY+Jlefq3xYmgN2fr3BTnsXjSYOPC7D1/mYqINBat99nDtvgFvNfRcZPiwwZ1hSw==",
+      "dependencies": [
+        "@sentry-internal/browser-utils",
+        "@sentry/core@8.55.0"
+      ]
+    },
+    "@sentry/browser@8.55.0": {
+      "integrity": "sha512-1A31mCEWCjaMxJt6qGUK+aDnLDcK6AwLAZnqpSchNysGni1pSn1RWSmk9TBF8qyTds5FH8B31H480uxMPUJ7Cw==",
+      "dependencies": [
+        "@sentry-internal/browser-utils",
+        "@sentry-internal/feedback",
+        "@sentry-internal/replay",
+        "@sentry-internal/replay-canvas",
+        "@sentry/core@8.55.0"
+      ]
+    },
     "@sentry/core@8.54.0": {
       "integrity": "sha512-03bWf+D1j28unOocY/5FDB6bUHtYlm6m6ollVejhg45ZmK9iPjdtxNWbrLsjT1WRym0Tjzowu+A3p+eebYEv0Q=="
+    },
+    "@sentry/core@8.55.0": {
+      "integrity": "sha512-6g7jpbefjHYs821Z+EBJ8r4Z7LT5h80YSWRJaylGS4nW5W5Z2KXzpdnyFarv37O7QjauzVC2E+PABmpkw5/JGA=="
     },
     "@sentry/types@8.54.0": {
       "integrity": "sha512-wztdtr7dOXQKi0iRvKc8XJhJ7HaAfOv8lGu0yqFOFwBZucO/SHnu87GOPi8mvrTiy1bentQO5l+zXWAaMvG4uw==",
       "dependencies": [
-        "@sentry/core"
+        "@sentry/core@8.54.0"
       ]
     },
     "@sentry/utils@8.54.0": {
       "integrity": "sha512-JL8UDjrsKxKclTdLXfuHfE7B3KbrAPEYP7tMyN/xiO2vsF6D84fjwYyalO0ZMtuFZE6vpSze8ZOLEh6hLnPYsw==",
       "dependencies": [
-        "@sentry/core"
+        "@sentry/core@8.54.0"
       ]
     },
     "@simplewebauthn/browser@13.1.0": {
@@ -2363,6 +2454,9 @@
     },
     "bignumber.js@9.1.2": {
       "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug=="
+    },
+    "bowser@2.11.0": {
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "brace-expansion@1.1.11": {
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
@@ -3100,6 +3194,9 @@
     },
     "event-target-shim@5.0.1": {
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
+    "events@3.3.0": {
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
     "extend@3.0.2": {
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="

--- a/infra/docs/ui-testing/backlog.md
+++ b/infra/docs/ui-testing/backlog.md
@@ -1,0 +1,133 @@
+# UI Component Testing Backlog
+
+This document tracks features, enhancements, and technical improvements that are
+being considered for future versions of the UI Component Testing framework.
+
+## Integration Features (From Version 0.2)
+
+**Priority**: Medium **Type**: Feature **Complexity**: Moderate **Target
+Version**: Future
+
+**Description**: Integration with BFF CLI tooling, visual comparison
+capabilities, and comprehensive test coverage for BfDs components.
+
+**Justification**: These features enhance the testing framework with better
+tooling integration and visual testing capabilities.
+
+**Dependencies**: Core testing foundation must be stable.
+
+**Acceptance Criteria**:
+
+- Integration with CI/CD pipeline
+- Visual comparison testing implemented
+- BFF CLI integration complete
+- Full test coverage for BfDs components
+
+**Why aren't we working on this yet?** Focusing on establishing the core testing
+infrastructure first before adding more advanced features.
+
+### Components and Implementation Details
+
+#### 1. Enhanced Test Utilities
+
+```typescript
+// infra/testing/ui-testing.ts additions
+
+export function fireEvent(element: Element, eventName: string, options = {}) {
+  // Implement event simulation
+}
+
+export function createSnapshot(component: JSX.Element) {
+  // Create snapshot for comparison
+}
+```
+
+#### 2. Visual Comparison
+
+```typescript
+// infra/testing/visual-comparison.ts
+
+export async function compareVisual(componentName: string, html: string) {
+  // Create a visual fingerprint of the component
+  // Compare against baseline
+}
+```
+
+#### 3. Interaction Tests
+
+```typescript
+// Example interaction test
+Deno.test("BfDsButton triggers onClick when clicked", () => {
+  let clicked = false;
+  const { doc } = render(
+    <BfDsButton
+      text="Click Me"
+      onClick={() => {
+        clicked = true;
+      }}
+    />,
+  );
+  const button = doc?.querySelector("button");
+  assertExists(button);
+
+  fireEvent(button, "click");
+  assertEquals(clicked, true);
+});
+```
+
+## Enhancement Features (From Version 0.3)
+
+**Priority**: Low **Type**: Enhancement **Complexity**: Complex **Target
+Version**: Future
+
+**Description**: Snapshot testing capabilities, accessibility testing, and
+comprehensive test reporting.
+
+**Justification**: These features provide more advanced testing capabilities and
+better reporting for UI components.
+
+**Dependencies**: Core testing foundation and integration features must be
+stable.
+
+**Acceptance Criteria**:
+
+- Snapshot testing implemented
+- Accessibility testing integrated
+- Comprehensive test reporting working
+
+**Why aren't we working on this yet?** Focusing on establishing the core testing
+infrastructure first before adding more advanced features.
+
+### Components and Implementation Details
+
+#### 1. Snapshot Testing
+
+```typescript
+// infra/testing/snapshot.ts
+
+export async function matchSnapshot(componentName: string, html: string) {
+  // Read existing snapshot or create new one
+  // Compare against current output
+}
+```
+
+#### 2. Accessibility Testing
+
+```typescript
+// infra/testing/a11y.ts
+
+export function checkAccessibility(html: string) {
+  // Perform basic accessibility checks
+  // Verify ARIA attributes, etc.
+}
+```
+
+#### 3. Test Reporting
+
+```typescript
+// infra/reporting/test-report.ts
+
+export function generateReport(testResults: TestResult[]) {
+  // Generate HTML report with component previews
+}
+```

--- a/infra/docs/ui-testing/project-plan.md
+++ b/infra/docs/ui-testing/project-plan.md
@@ -1,0 +1,193 @@
+# UI Component Testing Project Plan
+
+## Project Purpose
+
+To implement a comprehensive UI component testing strategy that aligns with Bolt
+Foundry's Test-Driven Development principles and "Worse is Better" philosophy,
+focusing on practical solutions using Deno's native testing capabilities.
+
+## Project Versions Overview
+
+1. **Version 0.1: Foundation**
+   - Set up basic testing infrastructure using Deno's web testing approach
+   - Establish component testing patterns
+   - Create initial examples for core components
+
+Note: Version 0.2 (Integration) and Version 0.3 (Enhancement) features have been
+moved to the backlog for future consideration. See `backlog.md` for details.
+
+## User Personas
+
+- **Component Developers**: Need to test UI components in isolation
+- **Integration Developers**: Need to test component interactions
+- **QA Engineers**: Need to verify UI behavior across components
+
+## Success Metrics
+
+- 90%+ test coverage for UI components
+- All BfDs components have comprehensive tests
+- Test suite runs in under 2 minutes
+
+## Version 0.1: Foundation Implementation Plan
+
+### Technical Goals
+
+- Create a simple, reliable testing infrastructure for UI components
+- Establish patterns for testing React components in Deno
+- Implement basic rendering tests for core components
+
+### Components and Implementation
+
+#### 1. Testing Library Setup
+
+Following Deno's recommended approach for web testing:
+
+```typescript
+// infra/testing/ui-testing.ts
+
+import { DOMParser, Element } from "jsr:@b-fuze/deno-dom";
+import { assertEquals, assertExists } from "jsr:@std/assert";
+import { renderToString } from "https://esm.sh/preact-render-to-string@6.0.0";
+
+export function render(component: JSX.Element) {
+  const html = renderToString(component);
+  const doc = new DOMParser().parseFromString(html, "text/html");
+
+  return {
+    getByText: (text: string) => {
+      const elements = Array.from(doc?.querySelectorAll("*") || []);
+      return elements.find((el) => el.textContent?.includes(text));
+    },
+    getByRole: (role: string, options?: { name?: string }) => {
+      const elements = Array.from(
+        doc?.querySelectorAll(`[role="${role}"]`) || [],
+      );
+      if (options?.name) {
+        return elements.find((el) =>
+          el.getAttribute("aria-label") === options.name
+        );
+      }
+      return elements[0];
+    },
+    queryByTestId: (testId: string) => {
+      return doc?.querySelector(`[data-testid="${testId}"]`);
+    },
+    // Add more query helpers as needed
+    html,
+    doc,
+  };
+}
+
+// Helper for simulating events
+export function fireEvent(element: Element, eventName: string, options = {}) {
+  const event = new Event(eventName, { bubbles: true, ...options });
+  element.dispatchEvent(event);
+  return event;
+}
+```
+
+#### 2. Test Patterns for Different Component Types
+
+Create test patterns for:
+
+- Simple Display Components
+- Interactive Components
+- Complex Components with Steps
+
+#### 4. BFF Integration
+
+```typescript
+// infra/bff/friends/ui-test.bff.ts
+
+import { register } from "infra/bff/bff.ts";
+import { runShellCommand } from "infra/bff/shellBase.ts";
+import { getLogger } from "packages/logger/logger.ts";
+
+const logger = getLogger(import.meta);
+
+export async function uiTest(args: string[]): Promise<number> {
+  const watchFlag = args.includes("--watch");
+  // Remove --watch from args if present
+  const filteredArgs = args.filter((arg) => arg !== "--watch");
+  const componentPath = filteredArgs[0] || ".";
+  const testPattern = `${componentPath}/**/__tests__/*.test.{ts,tsx}`;
+
+  logger.info(
+    `Running UI tests${watchFlag ? " in watch mode" : ""} for: ${testPattern}`,
+  );
+
+  const testArgs = ["deno", "test", "--allow-net", "--allow-read"];
+
+  if (watchFlag) {
+    testArgs.push("--watch");
+  }
+
+  testArgs.push(testPattern);
+
+  const result = await runShellCommand(testArgs, undefined, {}, true, true);
+
+  if (!watchFlag && result === 0) {
+    logger.info("✨ All UI tests passed!");
+  } else if (!watchFlag) {
+    logger.error("❌ UI tests failed");
+  }
+
+  return result;
+}
+
+register(
+  "ui-test",
+  "Run UI component tests (use --watch flag for watch mode)",
+  uiTest,
+);
+```
+
+### Integration Points
+
+- Integrate with existing BFF test command
+- Create a testing library compatible with Deno's test runner
+- Ensure tests can be run alongside other unit tests
+
+### Testing Strategy
+
+1. **Component Rendering**: Test that components render correctly with various
+   props
+2. **Event Handling**: Test that events like clicks are properly handled
+3. **Accessibility**: Verify that components meet basic accessibility standards
+4. **State Changes**: Test that components update correctly when state changes
+
+## Practical Implementation Steps
+
+1. **Start with Deno's native web testing approach**:
+   - Use `deno-dom` for DOM manipulation and testing
+   - Leverage Deno's built-in testing and assertion utilities
+   - Follow patterns from the Deno web testing documentation
+
+2. **Target highest-value components first**:
+   - Button, Input, List, Modal
+   - These components are used frequently across the application
+
+3. **Follow the Red-Green-Refactor cycle**:
+   - Write a failing test for expected component behavior
+   - Implement or fix the component to make the test pass
+   - Refactor the component and tests while maintaining passing tests
+
+4. **Document testing patterns**:
+   - Create a new behavior card for UI component testing
+   - Establish conventions for test file organization and naming
+
+5. **Extend BFF CLI commands**:
+   - Add `bff ui-test` for running UI component tests
+   - Add `bff ui-test --watch` for TDD workflow
+
+## Future Enhancements
+
+See `backlog.md` for details on planned future enhancements that were previously
+in Versions 0.2 and 0.3. These include:
+
+- Integration with BFF CLI tooling
+- Visual comparison testing
+- More sophisticated interaction testing
+- Snapshot testing
+- Accessibility testing
+- Test reporting

--- a/infra/testing/ui-testing.ts
+++ b/infra/testing/ui-testing.ts
@@ -1,0 +1,52 @@
+import { DOMParser } from "@b-fuze/deno-dom";
+import { renderToString } from "react-dom/server";
+import type React from "react";
+
+/**
+ * Renders a JSX component to HTML and provides utilities for testing
+ *
+ * @param component - The React/JSX component to render
+ * @returns Testing utilities for querying and asserting on the rendered output
+ */
+export function render(node: React.ReactNode) {
+  const html = renderToString(node);
+  const doc = new DOMParser().parseFromString(html, "text/html");
+
+  return {
+    getByText: (text: string) => {
+      const elements = Array.from(doc?.querySelectorAll("*") || []);
+      return elements.find((el) => el.textContent?.includes(text));
+    },
+    getByRole: (role: string, options?: { name?: string }) => {
+      const elements = Array.from(
+        doc?.querySelectorAll(`[role="${role}"]`) || [],
+      );
+      if (options?.name) {
+        return elements.find((el) =>
+          el.getAttribute("aria-label") === options.name
+        );
+      }
+      return elements[0];
+    },
+    queryByTestId: (testId: string) => {
+      return doc?.querySelector(`[data-testid="${testId}"]`);
+    },
+    // Add more query helpers as needed
+    html,
+    doc,
+  };
+}
+
+/**
+ * Helper for simulating events on DOM elements
+ *
+ * @param element - The DOM element to dispatch the event on
+ * @param eventName - The name of the event to dispatch
+ * @param options - Optional event configuration
+ * @returns The dispatched event
+ */
+export function fireEvent(element: Element, eventName: string, options = {}) {
+  const event = new Event(eventName, { bubbles: true, ...options });
+  element.dispatchEvent(event);
+  return event;
+}


### PR DESCRIPTION

## SUMMARY
This commit introduces a new test suite for the `BfDsCheckbox` component, located in `BfDsCheckbox.test.tsx`. The tests verify various aspects of the component's behavior, such as rendering with a label, handling checked and unchecked states, responding to the disabled prop, supporting different sizes, displaying meta information, and rendering with a specific test ID. These tests ensure that the component functions correctly across different scenarios and configurations.

## TEST PLAN
1. Run the test suite using the Deno testing framework.
2. Verify that all tests pass without errors, confirming that the `BfDsCheckbox` component behaves as expected in all tested scenarios.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/553).
* #550
* #554
* __->__ #553
* #552
* #549
* #548
* #547
* #546