### PR TITLE
Add E2E test setup with Chromium installation and screenshot support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
 
       # Optional: Collect and upload build outputs
       - name: Cache build outputs
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             result

--- a/.replit
+++ b/.replit
@@ -7,6 +7,7 @@ channel = "stable-24_11"
 
 [deployment]
 deploymentTarget = "cloudrun"
+build = ["sh", "-c", "ls -la build"]
 # build = ["sh", "-c", "bff build"]
 run = ["sh", "-c", "WEB_PORT=9999 ./build/web"]
 
@@ -140,6 +141,15 @@ author = 33272860
 [[workflows.workflow.tasks]]
 task = "shell.exec"
 args = "cd examples/nextjs-sample && npm run dev"
+
+[[workflows.workflow]]
+name = "Run E2E Tests"
+author = 33272860
+mode = "sequential"
+
+[[workflows.workflow.tasks]]
+task = "shell.exec"
+args = "bff e2e --build"
 
 [[ports]]
 localPort = 3000

--- a/.replit
+++ b/.replit
@@ -151,6 +151,15 @@ mode = "sequential"
 task = "shell.exec"
 args = "bff e2e --build"
 
+[[workflows.workflow]]
+name = "Run E2E Tests Only"
+author = 33272860
+mode = "sequential"
+
+[[workflows.workflow.tasks]]
+task = "shell.exec"
+args = "bff e2e"
+
 [[ports]]
 localPort = 3000
 externalPort = 3002

--- a/agents/behaviors/coding.bhc.md
+++ b/agents/behaviors/coding.bhc.md
@@ -99,6 +99,40 @@ Follow these best practices consistently:
 - Type check with `bff check [file_path]`
 - Test with `bff test` or `bff t path/to/test/file.test.ts`
 
+## Process Execution
+
+### Deno.Command (Preferred)
+
+Use `Deno.Command` for process execution in Deno 2+:
+
+```typescript
+// Creating a command
+const command = new Deno.Command("deno", {
+  args: ["test", "--allow-net"],
+  stdout: "piped",
+  stderr: "piped",
+});
+
+// Spawning the process
+const process = command.spawn();
+
+// Waiting for completion and getting status
+const status = await process.status;
+
+// Checking success
+if (status.success) {
+  console.log("Process completed successfully");
+}
+
+// Killing a process if needed
+process.kill();
+
+// For output, you can use:
+const output = await process.output(); // Includes stdout, stderr, and status
+```
+
+Avoid using `Deno.run()` as it's deprecated in Deno 2+.
+
 ## Code Quality
 
 - Avoid inline code comments, preferring logger.debug messages

--- a/apps/bfDs/components/__tests__/BfDsCheckbox.test.tsx
+++ b/apps/bfDs/components/__tests__/BfDsCheckbox.test.tsx
@@ -76,7 +76,7 @@ Deno.test("BfDsCheckbox renders with different sizes", () => {
 
   // The main checkbox container
   const checkboxContainer = doc?.querySelector("div[data-bf-testid]") ||
-    doc?.querySelector("input[type='checkbox']").parentElement;
+    doc?.querySelector("input[type='checkbox']")?.parentElement;
   assertExists(checkboxContainer, "Checkbox container should exist");
 
   // Look for the icon - BfDsIcon is rendered with the appropriate size

--- a/apps/boltFoundry/__tests__/e2e/home.test.e2e.ts
+++ b/apps/boltFoundry/__tests__/e2e/home.test.e2e.ts
@@ -1,5 +1,9 @@
 import { assertEquals } from "@std/assert";
-import { navigateTo, setupE2ETest, teardownE2ETest } from "../setup.ts";
+import {
+  navigateTo,
+  setupE2ETest,
+  teardownE2ETest,
+} from "infra/testing/e2e/setup.ts";
 import { getLogger } from "packages/logger/logger.ts";
 
 const logger = getLogger(import.meta);
@@ -10,6 +14,9 @@ Deno.test("Home page loads successfully", async () => {
   try {
     // Navigate to the home page
     await navigateTo(context, "/");
+
+    // Take screenshot after initial page load
+    await context.takeScreenshot("home-page-initial");
 
     // Wait for content to ensure page loaded
     const title = await context.page.title();
@@ -34,8 +41,13 @@ Deno.test("Home page loads successfully", async () => {
       "Page body should not be empty",
     );
 
+    // Take screenshot after test has completed successfully
+    await context.takeScreenshot("home-page-completed");
+
     logger.info("Home page test completed successfully");
   } catch (error) {
+    // Take screenshot on test failure
+    await context.takeScreenshot("home-page-error");
     logger.error("Test failed:", error);
     throw error;
   } finally {

--- a/deno.lock
+++ b/deno.lock
@@ -126,6 +126,7 @@
     "npm:posthog-js@^1.223.5": "1.223.5_@rrweb+types@2.0.0-alpha.17",
     "npm:posthog-node@^3.1.2": "3.6.3",
     "npm:posthog-node@^4.7.0": "4.7.0",
+    "npm:puppeteer-core@^24.6.0": "24.6.0_devtools-protocol@0.0.1425554",
     "npm:react-dom@19": "19.0.0_react@19.0.0",
     "npm:react-textarea-autosize@^8.5.9": "8.5.9_react@19.0.0",
     "npm:react@*": "19.0.0",
@@ -484,7 +485,7 @@
         "@csstools/css-color-parser",
         "@csstools/css-parser-algorithms",
         "@csstools/css-tokenizer",
-        "lru-cache"
+        "lru-cache@10.4.3"
       ]
     },
     "@asamuzakjp/dom-selector@2.0.2": {
@@ -603,7 +604,7 @@
         "@vladfrangu/async_event_emitter",
         "discord-api-types",
         "tslib",
-        "ws"
+        "ws@8.18.0"
       ]
     },
     "@emnapi/core@1.4.0": {
@@ -1291,7 +1292,7 @@
         "@mdx-js/mdx",
         "@types/unist@3.0.3",
         "esbuild",
-        "source-map",
+        "source-map@0.7.4",
         "vfile",
         "vfile-message"
       ]
@@ -1317,7 +1318,7 @@
         "remark-mdx",
         "remark-parse",
         "remark-rehype",
-        "source-map",
+        "source-map@0.7.4",
         "unified",
         "unist-util-position-from-estree",
         "unist-util-stringify-position",
@@ -1736,6 +1737,18 @@
     "@protobufjs/utf8@1.1.0": {
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
+    "@puppeteer/browsers@2.9.0": {
+      "integrity": "sha512-8+xM+cFydYET4X/5/3yZMHs7sjS6c9I6H5I3xJdb6cinzxWUT/I2QVw4avxCQ8QDndwdHkG/FiSZIrCjAbaKvQ==",
+      "dependencies": [
+        "debug@4.4.0",
+        "extract-zip",
+        "progress",
+        "proxy-agent",
+        "semver@7.7.1",
+        "tar-fs",
+        "yargs"
+      ]
+    },
     "@repeaterjs/repeater@3.0.6": {
       "integrity": "sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA=="
     },
@@ -1858,6 +1871,9 @@
     },
     "@tootallnate/once@2.0.0": {
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
+    },
+    "@tootallnate/quickjs-emscripten@0.23.0": {
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="
     },
     "@tybys/wasm-util@0.9.0": {
       "integrity": "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==",
@@ -2032,6 +2048,12 @@
     },
     "@types/ws@8.18.1": {
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dependencies": [
+        "@types/node@22.10.7"
+      ]
+    },
+    "@types/yauzl@2.10.3": {
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
       "dependencies": [
         "@types/node@22.10.7"
       ]
@@ -2268,6 +2290,9 @@
         "uri-js"
       ]
     },
+    "ansi-regex@5.0.1": {
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+    },
     "ansi-styles@4.3.0": {
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dependencies": [
@@ -2378,11 +2403,17 @@
     "assemblyai@4.9.0": {
       "integrity": "sha512-YUvkVIdMKvMLNQ07zWNma9YWvdSoGZy9RuJ/fB5uceAgDnTL2uo8sAlytkt52hD8DJ61xmZkfO9jkjXl3sZTiw==",
       "dependencies": [
-        "ws"
+        "ws@8.18.0"
       ]
     },
     "ast-types-flow@0.0.8": {
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ=="
+    },
+    "ast-types@0.13.4": {
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dependencies": [
+        "tslib"
+      ]
     },
     "astring@1.9.0": {
       "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg=="
@@ -2419,6 +2450,9 @@
     "axobject-query@4.1.0": {
       "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="
     },
+    "b4a@1.6.7": {
+      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg=="
+    },
     "b64-lite@1.4.0": {
       "integrity": "sha512-aHe97M7DXt+dkpa8fHlCcm1CnskAHrJqEfMI0KN7dwqlzml/aUe1AGt6lk51HzrSfVD67xOso84sOpr+0wIe2w==",
       "dependencies": [
@@ -2437,6 +2471,33 @@
     "balanced-match@1.0.2": {
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "bare-events@2.5.4": {
+      "integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA=="
+    },
+    "bare-fs@4.1.2_bare-events@2.5.4": {
+      "integrity": "sha512-8wSeOia5B7LwD4+h465y73KOdj5QHsbbuoUfPBi+pXgFJIPuG7SsiOdJuijWMyfid49eD+WivpfY7KT8gbAzBA==",
+      "dependencies": [
+        "bare-events",
+        "bare-path",
+        "bare-stream"
+      ]
+    },
+    "bare-os@3.6.1": {
+      "integrity": "sha512-uaIjxokhFidJP+bmmvKSgiMzj2sV5GPHaZVAIktcxcpCyBFFWO+YlikVAdhmUo2vYFvFhOXIAlldqV29L8126g=="
+    },
+    "bare-path@3.0.0": {
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dependencies": [
+        "bare-os"
+      ]
+    },
+    "bare-stream@2.6.5_bare-events@2.5.4": {
+      "integrity": "sha512-jSmxKJNJmHySi6hC42zlZnq00rga4jjxcgNZjY9N5WlOe/iOoGRtdwGsHzQv2RlH2KOYMwGUXhf2zXd32BA9RA==",
+      "dependencies": [
+        "bare-events",
+        "streamx"
+      ]
+    },
     "base-64@0.1.0": {
       "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
     },
@@ -2445,6 +2506,9 @@
     },
     "base64-js@1.5.1": {
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "basic-ftp@5.0.5": {
+      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg=="
     },
     "bidi-js@1.0.3": {
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
@@ -2476,6 +2540,9 @@
       "dependencies": [
         "fill-range"
       ]
+    },
+    "buffer-crc32@0.2.13": {
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="
     },
     "buffer-equal-constant-time@1.0.1": {
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
@@ -2540,11 +2607,27 @@
     "character-reference-invalid@2.0.1": {
       "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="
     },
+    "chromium-bidi@3.0.0_devtools-protocol@0.0.1425554": {
+      "integrity": "sha512-ZOGRDAhBMX1uxL2Cm2TDuhImbrsEz5A/tTcVU6RpXEWaTNUNwsHW6njUXizh51Ir6iqHbKAfhA2XK33uBcLo5A==",
+      "dependencies": [
+        "devtools-protocol",
+        "mitt@3.0.1",
+        "zod"
+      ]
+    },
     "cjs-module-lexer@1.4.3": {
       "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q=="
     },
     "client-only@0.0.1": {
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+    },
+    "cliui@8.0.1": {
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dependencies": [
+        "string-width",
+        "strip-ansi",
+        "wrap-ansi"
+      ]
     },
     "collapse-white-space@2.1.0": {
       "integrity": "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw=="
@@ -2624,6 +2707,9 @@
     "damerau-levenshtein@1.0.8": {
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="
     },
+    "data-uri-to-buffer@6.0.2": {
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="
+    },
     "data-urls@5.0.0": {
       "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
       "dependencies": [
@@ -2695,6 +2781,14 @@
         "object-keys"
       ]
     },
+    "degenerator@5.0.1": {
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dependencies": [
+        "ast-types",
+        "escodegen",
+        "esprima"
+      ]
+    },
     "delayed-stream@1.0.0": {
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
@@ -2709,6 +2803,9 @@
       "dependencies": [
         "dequal"
       ]
+    },
+    "devtools-protocol@0.0.1425554": {
+      "integrity": "sha512-uRfxR6Nlzdzt0ihVIkV+sLztKgs7rgquY/Mhcv1YNCWDh5IZgl5mnn2aeEnW5stYTE0wwiF4RYVz8eMEpV1SEw=="
     },
     "diff-match-patch@1.0.5": {
       "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw=="
@@ -2770,6 +2867,9 @@
       "dependencies": [
         "safe-buffer"
       ]
+    },
+    "emoji-regex@8.0.0": {
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "emoji-regex@9.2.2": {
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
@@ -2943,8 +3043,20 @@
         "@esbuild/win32-x64"
       ]
     },
+    "escalade@3.2.0": {
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="
+    },
     "escape-string-regexp@4.0.0": {
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+    },
+    "escodegen@2.1.0": {
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dependencies": [
+        "esprima",
+        "estraverse",
+        "esutils",
+        "source-map@0.6.1"
+      ]
     },
     "eslint-config-next@15.2.4_eslint@9.23.0_typescript@5.8.2_@typescript-eslint+parser@8.29.0__eslint@9.23.0__typescript@5.8.2_eslint-plugin-import@2.31.0__eslint@9.23.0": {
       "integrity": "sha512-v4gYjd4eYIme8qzaJItpR5MMBXJ0/YV07u7eb50kEnlEmX7yhOjdUdzz70v4fiINYRjLf8X8TbogF0k7wlz6sA==",
@@ -3026,7 +3138,7 @@
         "axe-core",
         "axobject-query",
         "damerau-levenshtein",
-        "emoji-regex",
+        "emoji-regex@9.2.2",
         "eslint",
         "hasown",
         "jsx-ast-utils",
@@ -3128,6 +3240,9 @@
         "eslint-visitor-keys@4.2.0"
       ]
     },
+    "esprima@4.0.1": {
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
     "esquery@1.6.0": {
       "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
       "dependencies": [
@@ -3173,7 +3288,7 @@
       "dependencies": [
         "@types/estree-jsx",
         "astring",
-        "source-map"
+        "source-map@0.7.4"
       ]
     },
     "estree-util-visit@2.0.0": {
@@ -3201,8 +3316,20 @@
     "extend@3.0.2": {
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
+    "extract-zip@2.0.1": {
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dependencies": [
+        "@types/yauzl",
+        "debug@4.4.0",
+        "get-stream",
+        "yauzl"
+      ]
+    },
     "fast-deep-equal@3.1.3": {
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-fifo@1.3.2": {
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
     },
     "fast-glob@3.3.1": {
       "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
@@ -3240,6 +3367,12 @@
       "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
       "dependencies": [
         "reusify"
+      ]
+    },
+    "fd-slicer@1.1.0": {
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dependencies": [
+        "pend"
       ]
     },
     "fdir@6.4.3_picomatch@4.0.2": {
@@ -3355,6 +3488,9 @@
         "json-bigint"
       ]
     },
+    "get-caller-file@2.0.5": {
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+    },
     "get-intrinsic@1.3.0": {
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dependencies": [
@@ -3377,6 +3513,12 @@
         "es-object-atoms"
       ]
     },
+    "get-stream@5.2.0": {
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dependencies": [
+        "pump"
+      ]
+    },
     "get-symbol-description@1.1.0": {
       "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
       "dependencies": [
@@ -3389,6 +3531,14 @@
       "integrity": "sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==",
       "dependencies": [
         "resolve-pkg-maps"
+      ]
+    },
+    "get-uri@6.0.4": {
+      "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
+      "dependencies": [
+        "basic-ftp",
+        "data-uri-to-buffer",
+        "debug@4.4.0"
       ]
     },
     "glob-parent@5.1.2": {
@@ -3458,7 +3608,7 @@
         "@whatwg-node/server",
         "dset",
         "graphql",
-        "lru-cache",
+        "lru-cache@10.4.3",
         "tslib"
       ]
     },
@@ -3638,6 +3788,13 @@
         "side-channel"
       ]
     },
+    "ip-address@9.0.5": {
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "dependencies": [
+        "jsbn",
+        "sprintf-js"
+      ]
+    },
     "is-alphabetical@2.0.1": {
       "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="
     },
@@ -3723,6 +3880,9 @@
       "dependencies": [
         "call-bound"
       ]
+    },
+    "is-fullwidth-code-point@3.0.0": {
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-generator-function@1.1.0": {
       "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
@@ -3851,6 +4011,9 @@
         "argparse"
       ]
     },
+    "jsbn@1.1.0": {
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
+    },
     "jsdom@23.2.0": {
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dependencies": [
@@ -3873,7 +4036,7 @@
         "whatwg-encoding",
         "whatwg-mimetype",
         "whatwg-url@14.1.0",
-        "ws",
+        "ws@8.18.0",
         "xml-name-validator"
       ]
     },
@@ -4056,6 +4219,9 @@
     },
     "lru-cache@10.4.3": {
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+    },
+    "lru-cache@7.18.3": {
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="
     },
     "magic-bytes.js@1.10.0": {
       "integrity": "sha512-/k20Lg2q8LE5xiaaSkMXk4sfvI+9EGEykFS4b0CHHGWqDYU0bGUFSwchNOMA56D7TCs9GwVTkqe9als1/ns8UQ=="
@@ -4483,6 +4649,9 @@
     "mitt@1.2.0": {
       "integrity": "sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw=="
     },
+    "mitt@3.0.1": {
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
+    },
     "module-details-from-path@1.0.3": {
       "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A=="
     },
@@ -4494,6 +4663,9 @@
     },
     "natural-compare@1.4.0": {
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
+    },
+    "netmask@2.0.2": {
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="
     },
     "next@15.2.4_react@19.0.0_react-dom@19.0.0__react@19.0.0": {
       "integrity": "sha512-VwL+LAaPSxEkd3lU2xWbgEOtrM8oedmyhBqaVNmgKB+GvZlCy9rgaEc+y2on0wv+l0oSFqLtYD6dcC1eAedUaQ==",
@@ -4665,6 +4837,26 @@
         "p-limit"
       ]
     },
+    "pac-proxy-agent@7.2.0": {
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dependencies": [
+        "@tootallnate/quickjs-emscripten",
+        "agent-base@7.1.3",
+        "debug@4.4.0",
+        "get-uri",
+        "http-proxy-agent@7.0.2",
+        "https-proxy-agent@7.0.6",
+        "pac-resolver",
+        "socks-proxy-agent"
+      ]
+    },
+    "pac-resolver@7.0.1": {
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dependencies": [
+        "degenerator",
+        "netmask"
+      ]
+    },
     "parent-module@1.0.1": {
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dependencies": [
@@ -4697,6 +4889,9 @@
     },
     "path-parse@1.0.7": {
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "pend@1.2.0": {
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
     },
     "pg-cloudflare@1.1.1": {
       "integrity": "sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q=="
@@ -4854,6 +5049,9 @@
     "prismjs@1.30.0": {
       "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="
     },
+    "progress@2.0.3": {
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
+    },
     "prop-types@15.8.1": {
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "dependencies": [
@@ -4883,6 +5081,19 @@
         "long@4.0.0"
       ]
     },
+    "proxy-agent@6.5.0": {
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dependencies": [
+        "agent-base@7.1.3",
+        "debug@4.4.0",
+        "http-proxy-agent@7.0.2",
+        "https-proxy-agent@7.0.6",
+        "lru-cache@7.18.3",
+        "pac-proxy-agent",
+        "proxy-from-env",
+        "socks-proxy-agent"
+      ]
+    },
     "proxy-from-env@1.1.0": {
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
@@ -4892,8 +5103,26 @@
         "punycode"
       ]
     },
+    "pump@3.0.2": {
+      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "dependencies": [
+        "end-of-stream",
+        "once"
+      ]
+    },
     "punycode@2.3.1": {
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
+    },
+    "puppeteer-core@24.6.0_devtools-protocol@0.0.1425554": {
+      "integrity": "sha512-Cukxysy12m0v350bhl/Gzof0XQYmtON9l2VvGp3D4BOQZVgyf+y5wIpcjDZQ/896Okoi95dKRGRV8E6a7SYAQQ==",
+      "dependencies": [
+        "@puppeteer/browsers",
+        "chromium-bidi",
+        "debug@4.4.0",
+        "devtools-protocol",
+        "typed-query-selector",
+        "ws@8.18.1"
+      ]
     },
     "pvtsutils@1.3.6": {
       "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
@@ -5047,6 +5276,9 @@
         "vfile"
       ]
     },
+    "require-directory@2.1.1": {
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
+    },
     "require-from-string@2.0.2": {
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
@@ -5119,7 +5351,7 @@
         "@xstate/fsm",
         "base64-arraybuffer",
         "fflate@0.4.8",
-        "mitt",
+        "mitt@1.2.0",
         "rrweb-snapshot@1.1.14"
       ]
     },
@@ -5290,8 +5522,29 @@
         "is-arrayish"
       ]
     },
+    "smart-buffer@4.2.0": {
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
+    },
+    "socks-proxy-agent@8.0.5": {
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dependencies": [
+        "agent-base@7.1.3",
+        "debug@4.4.0",
+        "socks"
+      ]
+    },
+    "socks@2.8.4": {
+      "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
+      "dependencies": [
+        "ip-address",
+        "smart-buffer"
+      ]
+    },
     "source-map-js@1.2.1": {
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="
+    },
+    "source-map@0.6.1": {
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map@0.7.4": {
       "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA=="
@@ -5301,6 +5554,9 @@
     },
     "split2@4.2.0": {
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="
+    },
+    "sprintf-js@1.1.3": {
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
     },
     "stable-hash@0.0.5": {
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA=="
@@ -5316,6 +5572,22 @@
     },
     "streamsearch@1.1.0": {
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
+    },
+    "streamx@2.22.0": {
+      "integrity": "sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==",
+      "dependencies": [
+        "bare-events",
+        "fast-fifo",
+        "text-decoder"
+      ]
+    },
+    "string-width@4.2.3": {
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": [
+        "emoji-regex@8.0.0",
+        "is-fullwidth-code-point",
+        "strip-ansi"
+      ]
     },
     "string.prototype.includes@2.0.1": {
       "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
@@ -5392,6 +5664,12 @@
         "character-entities-legacy"
       ]
     },
+    "strip-ansi@6.0.1": {
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": [
+        "ansi-regex"
+      ]
+    },
     "strip-bom@3.0.0": {
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="
     },
@@ -5440,6 +5718,23 @@
     "tailwindcss@4.1.2": {
       "integrity": "sha512-VCsK+fitIbQF7JlxXaibFhxrPq4E2hDcG8apzHUdWFMCQWD8uLdlHg4iSkZ53cgLCCcZ+FZK7vG8VjvLcnBgKw=="
     },
+    "tar-fs@3.0.8": {
+      "integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
+      "dependencies": [
+        "bare-fs",
+        "bare-path",
+        "pump",
+        "tar-stream"
+      ]
+    },
+    "tar-stream@3.1.7": {
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dependencies": [
+        "b4a",
+        "fast-fifo",
+        "streamx"
+      ]
+    },
     "teeny-request@9.0.0": {
       "integrity": "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==",
       "dependencies": [
@@ -5448,6 +5743,12 @@
         "node-fetch",
         "stream-events",
         "uuid@9.0.1"
+      ]
+    },
+    "text-decoder@1.2.3": {
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "dependencies": [
+        "b4a"
       ]
     },
     "throttleit@2.1.0": {
@@ -5560,6 +5861,9 @@
         "possible-typed-array-names",
         "reflect.getprototypeof"
       ]
+    },
+    "typed-query-selector@2.12.0": {
+      "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg=="
     },
     "typescript@5.8.2": {
       "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ=="
@@ -5831,11 +6135,22 @@
     "word-wrap@1.2.5": {
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="
     },
+    "wrap-ansi@7.0.0": {
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": [
+        "ansi-styles",
+        "string-width",
+        "strip-ansi"
+      ]
+    },
     "wrappy@1.0.2": {
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "ws@8.18.0": {
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="
+    },
+    "ws@8.18.1": {
+      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w=="
     },
     "xml-name-validator@5.0.0": {
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="
@@ -5845,6 +6160,31 @@
     },
     "xtend@4.0.2": {
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+    },
+    "y18n@5.0.8": {
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+    },
+    "yargs-parser@21.1.1": {
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
+    },
+    "yargs@17.7.2": {
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dependencies": [
+        "cliui",
+        "escalade",
+        "get-caller-file",
+        "require-directory",
+        "string-width",
+        "y18n",
+        "yargs-parser"
+      ]
+    },
+    "yauzl@2.10.0": {
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dependencies": [
+        "buffer-crc32",
+        "fd-slicer"
+      ]
     },
     "yjs@13.6.24": {
       "integrity": "sha512-xn/pYLTZa3uD1uDG8lpxfLRo5SR/rp0frdASOl2a71aYNvUXdWcLtVL91s2y7j+Q8ppmjZ9H3jsGVgoFMbT2VA==",
@@ -5872,6 +6212,7 @@
     }
   },
   "redirects": {
+    "https://deno.land/std/testing/asserts.ts": "https://deno.land/std@0.224.0/testing/asserts.ts",
     "https://esm.sh/@codemirror/state@^6.2.0?target=denonext": "https://esm.sh/@codemirror/state@6.5.1?target=denonext",
     "https://esm.sh/@marijn/find-cluster-break@^1.0.0?target=denonext": "https://esm.sh/@marijn/find-cluster-break@1.0.2?target=denonext",
     "https://esm.sh/@noble/curves@^1.0.0/abstract/utils?target=denonext": "https://esm.sh/@noble/curves@1.8.1/abstract/utils?target=denonext",
@@ -5885,6 +6226,40 @@
     "https://esm.sh/comlink@^4.3.1?target=denonext": "https://esm.sh/comlink@4.4.2?target=denonext"
   },
   "remote": {
+    "https://deno.land/std@0.224.0/assert/_constants.ts": "a271e8ef5a573f1df8e822a6eb9d09df064ad66a4390f21b3e31f820a38e0975",
+    "https://deno.land/std@0.224.0/assert/assert.ts": "09d30564c09de846855b7b071e62b5974b001bb72a4b797958fe0660e7849834",
+    "https://deno.land/std@0.224.0/assert/assert_almost_equals.ts": "9e416114322012c9a21fa68e187637ce2d7df25bcbdbfd957cd639e65d3cf293",
+    "https://deno.land/std@0.224.0/assert/assert_array_includes.ts": "14c5094471bc8e4a7895fc6aa5a184300d8a1879606574cb1cd715ef36a4a3c7",
+    "https://deno.land/std@0.224.0/assert/assert_equals.ts": "3bbca947d85b9d374a108687b1a8ba3785a7850436b5a8930d81f34a32cb8c74",
+    "https://deno.land/std@0.224.0/assert/assert_exists.ts": "43420cf7f956748ae6ed1230646567b3593cb7a36c5a5327269279c870c5ddfd",
+    "https://deno.land/std@0.224.0/assert/assert_false.ts": "3e9be8e33275db00d952e9acb0cd29481a44fa0a4af6d37239ff58d79e8edeff",
+    "https://deno.land/std@0.224.0/assert/assert_greater.ts": "5e57b201fd51b64ced36c828e3dfd773412c1a6120c1a5a99066c9b261974e46",
+    "https://deno.land/std@0.224.0/assert/assert_greater_or_equal.ts": "9870030f997a08361b6f63400273c2fb1856f5db86c0c3852aab2a002e425c5b",
+    "https://deno.land/std@0.224.0/assert/assert_instance_of.ts": "e22343c1fdcacfaea8f37784ad782683ec1cf599ae9b1b618954e9c22f376f2c",
+    "https://deno.land/std@0.224.0/assert/assert_is_error.ts": "f856b3bc978a7aa6a601f3fec6603491ab6255118afa6baa84b04426dd3cc491",
+    "https://deno.land/std@0.224.0/assert/assert_less.ts": "60b61e13a1982865a72726a5fa86c24fad7eb27c3c08b13883fb68882b307f68",
+    "https://deno.land/std@0.224.0/assert/assert_less_or_equal.ts": "d2c84e17faba4afe085e6c9123a63395accf4f9e00150db899c46e67420e0ec3",
+    "https://deno.land/std@0.224.0/assert/assert_match.ts": "ace1710dd3b2811c391946954234b5da910c5665aed817943d086d4d4871a8b7",
+    "https://deno.land/std@0.224.0/assert/assert_not_equals.ts": "78d45dd46133d76ce624b2c6c09392f6110f0df9b73f911d20208a68dee2ef29",
+    "https://deno.land/std@0.224.0/assert/assert_not_instance_of.ts": "3434a669b4d20cdcc5359779301a0588f941ffdc2ad68803c31eabdb4890cf7a",
+    "https://deno.land/std@0.224.0/assert/assert_not_match.ts": "df30417240aa2d35b1ea44df7e541991348a063d9ee823430e0b58079a72242a",
+    "https://deno.land/std@0.224.0/assert/assert_not_strict_equals.ts": "37f73880bd672709373d6dc2c5f148691119bed161f3020fff3548a0496f71b8",
+    "https://deno.land/std@0.224.0/assert/assert_object_match.ts": "411450fd194fdaabc0089ae68f916b545a49d7b7e6d0026e84a54c9e7eed2693",
+    "https://deno.land/std@0.224.0/assert/assert_rejects.ts": "4bee1d6d565a5b623146a14668da8f9eb1f026a4f338bbf92b37e43e0aa53c31",
+    "https://deno.land/std@0.224.0/assert/assert_strict_equals.ts": "b4f45f0fd2e54d9029171876bd0b42dd9ed0efd8f853ab92a3f50127acfa54f5",
+    "https://deno.land/std@0.224.0/assert/assert_string_includes.ts": "496b9ecad84deab72c8718735373feb6cdaa071eb91a98206f6f3cb4285e71b8",
+    "https://deno.land/std@0.224.0/assert/assert_throws.ts": "c6508b2879d465898dab2798009299867e67c570d7d34c90a2d235e4553906eb",
+    "https://deno.land/std@0.224.0/assert/assertion_error.ts": "ba8752bd27ebc51f723702fac2f54d3e94447598f54264a6653d6413738a8917",
+    "https://deno.land/std@0.224.0/assert/equal.ts": "bddf07bb5fc718e10bb72d5dc2c36c1ce5a8bdd3b647069b6319e07af181ac47",
+    "https://deno.land/std@0.224.0/assert/fail.ts": "0eba674ffb47dff083f02ced76d5130460bff1a9a68c6514ebe0cdea4abadb68",
+    "https://deno.land/std@0.224.0/assert/mod.ts": "48b8cb8a619ea0b7958ad7ee9376500fe902284bb36f0e32c598c3dc34cbd6f3",
+    "https://deno.land/std@0.224.0/assert/unimplemented.ts": "8c55a5793e9147b4f1ef68cd66496b7d5ba7a9e7ca30c6da070c1a58da723d73",
+    "https://deno.land/std@0.224.0/assert/unreachable.ts": "5ae3dbf63ef988615b93eb08d395dda771c96546565f9e521ed86f6510c29e19",
+    "https://deno.land/std@0.224.0/fmt/colors.ts": "508563c0659dd7198ba4bbf87e97f654af3c34eb56ba790260f252ad8012e1c5",
+    "https://deno.land/std@0.224.0/internal/diff.ts": "6234a4b493ebe65dc67a18a0eb97ef683626a1166a1906232ce186ae9f65f4e6",
+    "https://deno.land/std@0.224.0/internal/format.ts": "0a98ee226fd3d43450245b1844b47003419d34d210fa989900861c79820d21c2",
+    "https://deno.land/std@0.224.0/internal/mod.ts": "534125398c8e7426183e12dc255bb635d94e06d0f93c60a297723abe69d3b22e",
+    "https://deno.land/std@0.224.0/testing/asserts.ts": "d0cdbabadc49cc4247a50732ee0df1403fdcd0f95360294ad448ae8c240f3f5c",
     "https://esm.sh/@codemirror/state@6.5.1/denonext/state.mjs": "2547fab4ecaed30592ecb7ea398b7a8081b3b7e9797ebd6b2a696e69b25a3816",
     "https://esm.sh/@codemirror/state@6.5.1?target=denonext": "3473608c32947dfd4186a76b11a50df5c90c4111f0a9092290c5114914e7b12a",
     "https://esm.sh/@hyperdx/browser@0.19.3": "0184d801303c295e405144508feda8254ab67f7f2ed2c027b6a43e8e2367e428",
@@ -5982,6 +6357,7 @@
         "npm:pg@^8.13.3",
         "npm:posthog-js@^1.223.5",
         "npm:posthog-node@^4.7.0",
+        "npm:puppeteer-core@^24.6.0",
         "npm:react-dom@19",
         "npm:react@19",
         "npm:zod@^3.24.1"

--- a/infra/bff/friends/ci.bff.ts
+++ b/infra/bff/friends/ci.bff.ts
@@ -273,13 +273,39 @@ async function runBuildStep(useGithub: boolean): Promise<number> {
 // 4. Test step
 // ----------------------------------------------------------------------------
 
-async function runTestStep(useGithub: boolean): Promise<number> {
-  logger.info("Running deno test -A");
+async function runTestStep(_useGithub: boolean): Promise<number> {
+  logger.info("Running tests...");
+  const testArgs = [
+    "bff",
+    "test",
+  ];
+
+  const envVars = {
+    "DENO_WEBGPU": "0",
+  };
+
   const { code } = await runShellCommandWithOutput(
-    ["bff", "test", "--no-check"],
+    testArgs,
+    envVars,
+    true,
+  );
+  return code;
+}
+
+async function runE2ETestStep(useGithub: boolean): Promise<number> {
+  logger.info("Running E2E tests...");
+
+  // We'll use the BFF e2e command that's already implemented
+  const e2eArgs = [
+    "bff",
+    "e2e",
+  ];
+
+  const { code } = await runShellCommandWithOutput(
+    e2eArgs,
     {},
-    /* useSpinner */ true,
-    /* silent */ useGithub,
+    true,
+    useGithub,
   );
   return code;
 }
@@ -333,17 +359,21 @@ async function ciCommand(options: string[]) {
   // 3) Lint (with or without JSON mode)
   const lintResult = await runLintStep(useGithub);
 
-  // 4) Test
+  // 4) Unit Test
   const testResult = await runTestStep(useGithub);
 
-  // 5) Format check
+  // 5) E2E Test
+  const e2eTestResult = await runE2ETestStep(useGithub);
+
+  // 6) Format check
   const fmtResult = await runFormatStep(useGithub);
 
-  // 6) Type check
+  // 7) Type check
   const typecheckResult = await runTypecheckStep(useGithub);
 
   const hasErrors = Boolean(
-    installResult || buildResult || lintResult || testResult || fmtResult ||
+    installResult || buildResult || lintResult || testResult || e2eTestResult ||
+      fmtResult ||
       typecheckResult,
   );
 
@@ -352,6 +382,7 @@ async function ciCommand(options: string[]) {
   logger.info(`Build:     ${buildResult === 0 ? "✅" : "❌"}`);
   logger.info(`Lint:      ${lintResult === 0 ? "✅" : "❌"}`);
   logger.info(`Test:      ${testResult === 0 ? "✅" : "❌"}`);
+  logger.info(`E2E Test:  ${e2eTestResult === 0 ? "✅" : "❌"}`);
   logger.info(`Format:    ${fmtResult === 0 ? "✅" : "❌"}`);
   logger.info(`TypeCheck: ${typecheckResult === 0 ? "✅" : "❌"}`);
 

--- a/infra/bff/friends/e2e.bff.ts
+++ b/infra/bff/friends/e2e.bff.ts
@@ -1,0 +1,70 @@
+import { register } from "infra/bff/bff.ts";
+import { runShellCommand } from "infra/bff/shellBase.ts";
+import { getLogger } from "packages/logger/logger.ts";
+
+const logger = getLogger(import.meta);
+
+export async function e2eCommand(args: string[]): Promise<number> {
+  logger.info("Starting e2e tests");
+
+  try {
+    // Check if we need to build first
+    if (args.includes("--build") || args.includes("-b")) {
+      logger.info("Building application...");
+      await runShellCommand(["bff", "build"]);
+    }
+
+    // Start the web server in the background
+    logger.info("Starting web server...");
+    const serverCommand = new Deno.Command("./build/web", {
+      stdout: "piped",
+      stderr: "piped",
+    });
+
+    const serverProcess = serverCommand.spawn();
+
+    // Wait a moment for the server to start
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    try {
+      // Run the e2e tests
+      logger.info("Running e2e tests...");
+      const testCommand = new Deno.Command("deno", {
+        args: [
+          "test",
+          "--allow-net",
+          "--allow-run",
+          "--allow-env",
+          "--allow-read",
+          "--allow-write",
+          "infra/testing/e2e/tests/",
+        ],
+        stdout: "inherit",
+        stderr: "inherit",
+      });
+
+      const testProcess = testCommand.spawn();
+      const testStatus = await testProcess.status;
+
+      if (!testStatus.success) {
+        logger.error(`E2E tests failed with code ${testStatus.code}`);
+        return testStatus.code;
+      }
+
+      logger.info("E2E tests completed successfully");
+      return 0;
+    } finally {
+      // Clean up the server process
+      serverProcess.kill();
+    }
+  } catch (error) {
+    logger.error(`E2E tests failed: ${(error as Error).message}`);
+    return 1;
+  }
+}
+
+register(
+  "e2e",
+  "Run end-to-end tests",
+  e2eCommand,
+);

--- a/infra/bff/friends/e2e.bff.ts
+++ b/infra/bff/friends/e2e.bff.ts
@@ -8,6 +8,24 @@ export async function e2eCommand(args: string[]): Promise<number> {
   logger.info("Starting e2e tests");
 
   try {
+    // Create a unique run ID based on timestamp
+    const runId = new Date().toISOString().replace(/[:.]/g, "-");
+    const screenshotBaseDir = `${Deno.cwd()}/tmp/screenshots`;
+    const runSpecificDir = `${screenshotBaseDir}/${runId}`;
+
+    // Create the run-specific screenshot directory
+    try {
+      await Deno.mkdir(runSpecificDir, { recursive: true });
+      logger.info(`Created screenshot directory for this run: ${runId}`);
+
+      // Set environment variable for the test context to use
+      Deno.env.set("BF_E2E_SCREENSHOT_DIR", runSpecificDir);
+    } catch (error) {
+      logger.warn(
+        `Failed to create screenshot directory: ${(error as Error).message}`,
+      );
+    }
+
     // Check if we need to build first
     if (args.includes("--build") || args.includes("-b")) {
       logger.info("Building application...");
@@ -25,26 +43,64 @@ export async function e2eCommand(args: string[]): Promise<number> {
 
     // Wait a moment for the server to start
     await new Promise((resolve) => setTimeout(resolve, 2000));
+    const paths = ["apps", "infra", "lib", "packages", "util", "sites"];
+    const pathsStrings = paths.map((path) => `${path}/**/*.test.e2e.ts`);
 
     try {
-      // Run the e2e tests
+      // Run the e2e tests with sanitization disabled
       logger.info("Running e2e tests...");
       const testCommand = new Deno.Command("deno", {
         args: [
           "test",
+          "--trace-leaks",
           "--allow-net",
           "--allow-run",
           "--allow-env",
           "--allow-read",
           "--allow-write",
-          "infra/testing/e2e/tests/",
+          "--no-check",
+          ...pathsStrings,
         ],
         stdout: "inherit",
         stderr: "inherit",
+        env: {
+          ...Deno.env.toObject(),
+          "BF_E2E_SCREENSHOT_DIR": runSpecificDir,
+        },
       });
 
       const testProcess = testCommand.spawn();
       const testStatus = await testProcess.status;
+
+      // Display screenshot location information
+      logger.info(`Screenshots were saved to: ${runSpecificDir}`);
+
+      try {
+        // Use asynchronous readDir instead of readDirSync
+        const screenshotFiles = [];
+        for await (const entry of Deno.readDir(runSpecificDir)) {
+          if (entry.isFile && entry.name.endsWith(".png")) {
+            screenshotFiles.push(entry);
+          }
+        }
+
+        // Sort and display screenshots
+        screenshotFiles
+          .sort((a, b) => {
+            // Sort by timestamp in filename
+            return b.name.localeCompare(a.name);
+          })
+          .slice(0, 10) // Show only the last 10 screenshots
+          .forEach((file) => {
+            logger.info(`- ${file.name}`);
+          });
+
+        if (screenshotFiles.length > 0) {
+          logger.info(`Latest screenshots:`);
+        }
+      } catch (error) {
+        logger.warn(`Could not list screenshots: ${(error as Error).message}`);
+      }
 
       if (!testStatus.success) {
         logger.error(`E2E tests failed with code ${testStatus.code}`);
@@ -55,7 +111,11 @@ export async function e2eCommand(args: string[]): Promise<number> {
       return 0;
     } finally {
       // Clean up the server process
-      serverProcess.kill();
+      logger.info("Shutting down server process...");
+      serverProcess.kill("SIGTERM");
+
+      // Give time for resources to clean up
+      await new Promise((resolve) => setTimeout(resolve, 500));
     }
   } catch (error) {
     logger.error(`E2E tests failed: ${(error as Error).message}`);

--- a/infra/bff/friends/test.bff.ts
+++ b/infra/bff/friends/test.bff.ts
@@ -7,7 +7,11 @@ const logger = getLogger(import.meta);
 export async function testCommand(options: string[]): Promise<number> {
   logger.info("Running tests...");
 
-  const testArgs = ["deno", "test", "-A"];
+  const paths = ["apps", "infra", "lib", "packages", "util", "sites"];
+  const pathsStrings = paths.map((path) => `${path}/**/*.test.ts`);
+  const pathsStringsX = paths.map((path) => `${path}/**/*.test.tsx`);
+
+  const testArgs = ["deno", "test", "-A", ...pathsStrings, ...pathsStringsX];
 
   // Allow passing specific test files or additional arguments
   if (options.length > 0) {

--- a/infra/docs/e2e-testing/0.1/version-0.1-implementation-plan.md
+++ b/infra/docs/e2e-testing/0.1/version-0.1-implementation-plan.md
@@ -1,0 +1,213 @@
+# E2E Testing Implementation Plan - Version 0.1
+
+**Version:** 0.1 **Date:** 2023-07-10
+
+## Version Summary
+
+Establish a foundation for end-to-end testing in Bolt Foundry, focusing on
+critical user flows and core functionality with a Deno-compatible testing
+solution.
+
+## Technical Goals
+
+- Set up a reliable e2e testing infrastructure using Deno-compatible tools
+- Create initial test coverage for the most critical user journeys
+- Establish patterns for writing and maintaining e2e tests
+- Integrate with existing BFF CLI for local and CI execution
+
+## Components and Implementation
+
+### 1. Testing Framework Setup
+
+**Description**: Implement a Deno-compatible e2e testing solution that works
+with our existing stack.
+
+**Technical Approach**:
+
+- Utilize Deno's built-in testing capabilities combined with Puppeteer or
+  Playwright
+- Create browser automation helpers optimized for our UI components
+- Set up test runner configuration with appropriate timeouts and retries
+
+**Implementation Steps**:
+
+```typescript
+// Example structure for e2e test setup
+// infra/testing/e2e-testing.ts
+
+import { DOMParser } from "@b-fuze/deno-dom";
+import { Browser, Page } from "puppeteer";
+
+export interface E2ETestContext {
+  browser: Browser;
+  page: Page;
+  // Additional context properties
+}
+
+/**
+ * Sets up the e2e test environment
+ */
+export async function setupE2ETest(): Promise<E2ETestContext> {
+  // Implementation details
+}
+
+/**
+ * Tears down the e2e test environment
+ */
+export async function teardownE2ETest(context: E2ETestContext): Promise<void> {
+  // Implementation details
+}
+
+/**
+ * Helper for navigation and waiting for page load
+ */
+export async function navigateTo(page: Page, url: string): Promise<void> {
+  // Implementation details
+}
+
+// Additional helper functions for common testing operations
+```
+
+### 2. Page Object Models
+
+**Description**: Create a structure for modeling application pages and
+components to make tests more maintainable.
+
+**Technical Approach**:
+
+- Define a base Page class that provides common functionality
+- Create specific page objects for each major application section
+- Implement component objects for reusable UI elements
+
+**Implementation Steps**:
+
+```typescript
+// Example page object structure
+// infra/testing/e2e/pages/BasePage.ts
+
+import { Page } from "puppeteer";
+
+export class BasePage {
+  constructor(protected page: Page) {}
+
+  async waitForPageLoad(): Promise<void> {
+    // Implementation details
+  }
+
+  async getByTestId(testId: string): Promise<Element | null> {
+    // Implementation details
+  }
+
+  // Additional common methods
+}
+
+// infra/testing/e2e/pages/LoginPage.ts
+import { BasePage } from "./BasePage.ts";
+
+export class LoginPage extends BasePage {
+  async login(username: string, password: string): Promise<void> {
+    // Implementation details
+  }
+
+  async verifyLoginError(expectedError: string): Promise<boolean> {
+    // Implementation details
+  }
+
+  // Additional page-specific methods
+}
+```
+
+### 3. Initial Test Coverage
+
+**Description**: Implement initial tests for critical user flows and core
+functionality.
+
+**Technical Approach**:
+
+- Focus on smoke tests for the most important user journeys
+- Create tests that verify end-to-end functionality rather than implementation
+  details
+- Structure tests to be resilient to UI changes
+
+**Implementation Steps**:
+
+```typescript
+// Example test for login flow
+// infra/testing/e2e/tests/authentication.test.ts
+
+import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+import { setupE2ETest, teardownE2ETest } from "../e2e-testing.ts";
+import { LoginPage } from "../pages/LoginPage.ts";
+import { HomePage } from "../pages/HomePage.ts";
+
+Deno.test("User can log in with valid credentials", async () => {
+  const context = await setupE2ETest();
+  try {
+    const loginPage = new LoginPage(context.page);
+    await loginPage.navigate();
+    await loginPage.login("testuser@example.com", "password123");
+
+    const homePage = new HomePage(context.page);
+    const isLoggedIn = await homePage.isUserLoggedIn();
+
+    assertEquals(
+      isLoggedIn,
+      true,
+      "User should be logged in after successful login",
+    );
+  } finally {
+    await teardownE2ETest(context);
+  }
+});
+```
+
+### 4. CI Integration
+
+**Description**: Integrate e2e tests with the existing CI/CD pipeline and BFF
+CLI.
+
+**Technical Approach**:
+
+- Add commands to BFF CLI for running e2e tests
+- Configure CI to run e2e tests on pull requests and main branch
+- Set up reporting and notifications for test failures
+
+**Implementation Steps**:
+
+```typescript
+// Example BFF command for e2e tests
+// infra/bff/friends/e2e.bff.ts
+
+import { Command } from "../shellBase.ts";
+
+export default class E2ECommand extends Command {
+  name = "e2e";
+  description = "Run end-to-end tests";
+
+  async execute(args: string[]): Promise<void> {
+    // Implementation details for running e2e tests
+  }
+}
+```
+
+## Integration Points
+
+- **UI Components**: Tests will interact with existing UI components via the DOM
+- **BFF CLI**: Add commands for running and managing e2e tests
+- **CI Pipeline**: Configure GitHub Actions to run e2e tests on PRs
+- **Reporting**: Generate test reports compatible with existing tools
+
+## Testing Strategy
+
+- **Test Selection**: Prioritize critical user flows for initial implementation
+- **Data Management**: Create test data setup and teardown utilities
+- **Environment Handling**: Configure tests to run against dev, staging, or
+  local environments
+- **Failure Handling**: Implement retry logic and clear failure reporting
+
+## Next Steps for Version 0.2
+
+- Expand test coverage to additional user flows
+- Implement visual regression testing for key components
+- Create performance measurement baselines
+- Improve test reporting and dashboards

--- a/infra/docs/e2e-testing/project-plan.md
+++ b/infra/docs/e2e-testing/project-plan.md
@@ -1,0 +1,107 @@
+# E2E Testing Project Plan
+
+## Project Purpose
+
+To implement a comprehensive end-to-end testing strategy for Bolt Foundry that
+ensures reliable user experiences across critical application workflows and
+integrations, following the team's "Worse is Better" philosophy and test-driven
+development principles.
+
+## Project Versions Overview
+
+1. **Version 0.1: Foundation**
+   - Set up basic e2e testing infrastructure using Deno-compatible tools
+   - Create initial tests for critical user flows
+   - Establish patterns for writing and maintaining e2e tests
+
+2. **Version 0.2: Integration**
+   - Integrate e2e tests with CI/CD pipeline
+   - Expand test coverage to include authentication flows
+   - Add visual regression testing capabilities
+
+3. **Version 0.3: Enhancement**
+   - Create automated test reporting and dashboards
+   - Implement performance testing for critical user journeys
+   - Add cross-browser testing capabilities
+
+## User Personas
+
+- **Developers**: Need confidence that changes don't break existing
+  functionality
+- **QA Engineers**: Need tools to verify application behavior across integrated
+  components
+- **Product Managers**: Need visibility into application reliability and
+  performance
+
+## Success Metrics
+
+- 90% test coverage for critical user flows
+- e2e test suite runs in under 10 minutes
+- All regressions caught before deployment
+- Automated visual regression tests for key UI components
+
+## Version 0.1: Foundation Implementation Plan
+
+### Technical Goals
+
+- Create reliable e2e testing infrastructure compatible with Deno
+- Establish patterns for testing full application workflows
+- Implement basic smoke tests for critical user paths
+
+### Components and Implementation
+
+1. **Testing Framework**
+   - Select and implement a Deno-compatible e2e testing solution
+   - Create helper utilities for common testing operations
+   - Set up browser automation capabilities
+
+2. **Test Structure**
+   - Define organization for test files and utilities
+   - Establish patterns for page objects and test helpers
+   - Create documentation for writing and maintaining tests
+
+3. **Initial Test Coverage**
+   - Authentication flows (login, registration)
+   - Basic navigation and routing
+   - Core feature functionality
+
+### Integration Points
+
+- BFF CLI integration for running tests locally and in CI
+- Test reporting compatible with existing tooling
+- Integration with existing UI components for testing
+
+### Testing Strategy
+
+- Define critical user flows to test first
+- Create baseline assertions for each flow
+- Implement visual testing for UI components
+- Set up monitoring for test reliability and performance
+
+## Test Plan
+
+Our tests define behavior, not implementation:
+
+1. **Authentication Flow Test**:
+   - Red: Write tests for user login and registration flows
+   - Green: Implement e2e tests with realistic user interactions
+   - Refactor: Improve test reliability and reduce flakiness
+
+2. **Navigation Test**:
+   - Red: Write tests for application navigation and routing
+   - Green: Implement tests that verify correct page rendering
+   - Refactor: Extract common patterns into reusable utilities
+
+3. **Core Feature Tests**:
+   - Red: Write tests for mission-critical features
+   - Green: Implement realistic user scenario tests
+   - Refactor: Optimize for speed and reliability
+
+4. **Visual Regression Tests**:
+   - Red: Write tests for visual consistency of key components
+   - Green: Implement basic screenshot comparison
+   - Refactor: Improve accuracy and reduce false positives
+
+Remember: Failure counts as done. This plan prioritizes building a simple but
+effective solution focused on real user needs, testing at each step, and getting
+working code into users' hands quickly rather than perfect code in development.

--- a/infra/testing/e2e/setup.ts
+++ b/infra/testing/e2e/setup.ts
@@ -1,0 +1,90 @@
+import { type Browser, launch, type Page } from "puppeteer-core";
+import { getLogger } from "packages/logger/logger.ts";
+
+const logger = getLogger(import.meta);
+
+export interface E2ETestContext {
+  browser: Browser;
+  page: Page;
+  baseUrl: string;
+}
+
+/**
+ * Sets up the e2e test environment
+ */
+export async function setupE2ETest(options: {
+  baseUrl?: string;
+  headless?: boolean;
+} = {}): Promise<E2ETestContext> {
+  const baseUrl = options.baseUrl || "http://localhost:8000";
+  const headless = options.headless !== false;
+
+  logger.info(`Starting e2e test with baseUrl: ${baseUrl}`);
+
+  try {
+    // Find the chromium executable path
+    let chromiumPath = "chromium";
+    try {
+      const command = new Deno.Command("which", {
+        args: ["chromium"],
+        stdout: "piped",
+      });
+      const output = await command.output();
+      const path = new TextDecoder().decode(output.stdout).trim();
+      if (path) {
+        chromiumPath = path;
+        logger.info(`Found Chromium at: ${chromiumPath}`);
+      }
+    } catch (error) {
+      logger.warn(
+        `Could not detect Chromium path: ${
+          (error as Error).message
+        }. Using default.`,
+      );
+    }
+
+    // Launch browser using puppeteer-core
+    const browser = await launch({
+      headless,
+      executablePath: chromiumPath,
+      args: ["--no-sandbox", "--disable-setuid-sandbox"],
+    });
+
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1280, height: 800 });
+
+    return { browser, page, baseUrl };
+  } catch (error) {
+    logger.error("Failed to setup e2e test:", error);
+    throw error;
+  }
+}
+
+/**
+ * Tears down the e2e test environment
+ */
+export async function teardownE2ETest(context: E2ETestContext): Promise<void> {
+  try {
+    if (context.browser) {
+      await context.browser.close();
+    }
+  } catch (error) {
+    logger.error("Error during teardown:", error);
+  }
+}
+
+/**
+ * Helper for navigation and waiting for page load
+ */
+export async function navigateTo(
+  context: E2ETestContext,
+  path: string,
+): Promise<void> {
+  const url = new URL(path, context.baseUrl).toString();
+  logger.info(`Navigating to ${url}`);
+
+  await context.page.goto(url, {
+    waitUntil: "networkidle2",
+    timeout: 30000,
+  });
+}

--- a/infra/testing/e2e/setup.ts
+++ b/infra/testing/e2e/setup.ts
@@ -1,5 +1,7 @@
 import { type Browser, launch, type Page } from "puppeteer-core";
 import { getLogger } from "packages/logger/logger.ts";
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
 
 const logger = getLogger(import.meta);
 
@@ -7,6 +9,7 @@ export interface E2ETestContext {
   browser: Browser;
   page: Page;
   baseUrl: string;
+  takeScreenshot: (name: string) => Promise<string>;
 }
 
 /**
@@ -43,6 +46,13 @@ export async function setupE2ETest(options: {
       );
     }
 
+    // Ensure screenshots directory exists, using environment variable if available
+    const runSpecificDir = Deno.env.get("BF_E2E_SCREENSHOT_DIR");
+    const screenshotsDir = runSpecificDir ||
+      join(Deno.cwd(), "tmp", "screenshots");
+    await ensureDir(screenshotsDir);
+    logger.info(`Screenshots will be saved to: ${screenshotsDir}`);
+
     // Launch browser using puppeteer-core
     const browser = await launch({
       headless,
@@ -53,7 +63,23 @@ export async function setupE2ETest(options: {
     const page = await browser.newPage();
     await page.setViewport({ width: 1280, height: 800 });
 
-    return { browser, page, baseUrl };
+    // Create screenshot function
+    const takeScreenshot = async (name: string): Promise<string> => {
+      const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+      const fileName = `${name.replace(/\s+/g, "-")}_${timestamp}.png`;
+      const filePath = join(screenshotsDir, fileName);
+
+      try {
+        await page.screenshot({ path: filePath, fullPage: true });
+        logger.info(`Screenshot saved to: ${filePath}`);
+        return filePath;
+      } catch (error) {
+        logger.error(`Failed to take screenshot: ${(error as Error).message}`);
+        return "";
+      }
+    };
+
+    return { browser, page, baseUrl, takeScreenshot };
   } catch (error) {
     logger.error("Failed to setup e2e test:", error);
     throw error;
@@ -65,9 +91,18 @@ export async function setupE2ETest(options: {
  */
 export async function teardownE2ETest(context: E2ETestContext): Promise<void> {
   try {
+    // First close any open pages
+    if (context.page && !context.page.isClosed()) {
+      await context.page.close();
+    }
+
+    // Then close the browser completely
     if (context.browser) {
       await context.browser.close();
     }
+
+    // Give time for all resources to be released
+    await new Promise((resolve) => setTimeout(resolve, 100));
   } catch (error) {
     logger.error("Error during teardown:", error);
   }

--- a/infra/testing/e2e/tests/home.test.ts
+++ b/infra/testing/e2e/tests/home.test.ts
@@ -1,0 +1,44 @@
+import { assertEquals } from "@std/assert";
+import { navigateTo, setupE2ETest, teardownE2ETest } from "../setup.ts";
+import { getLogger } from "packages/logger/logger.ts";
+
+const logger = getLogger(import.meta);
+
+Deno.test("Home page loads successfully", async () => {
+  const context = await setupE2ETest({ headless: true });
+
+  try {
+    // Navigate to the home page
+    await navigateTo(context, "/");
+
+    // Wait for content to ensure page loaded
+    const title = await context.page.title();
+    logger.info(`Page title: ${title}`);
+
+    // Check if the page contains expected content
+    const bodyText = await context.page.evaluate(() =>
+      document.body.textContent
+    );
+
+    // Basic assertion to verify the page loaded successfully
+    assertEquals(
+      typeof bodyText,
+      "string",
+      "Page body should contain text",
+    );
+
+    // Additional assertion that some content exists
+    assertEquals(
+      bodyText && bodyText.length > 0,
+      true,
+      "Page body should not be empty",
+    );
+
+    logger.info("Home page test completed successfully");
+  } catch (error) {
+    logger.error("Test failed:", error);
+    throw error;
+  } finally {
+    await teardownE2ETest(context);
+  }
+});

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "pg": "^8.13.3",
     "posthog-js": "^1.223.5",
     "posthog-node": "^4.7.0",
+    "puppeteer-core": "^24.6.0",
     "react-dom": "^19.0",
     "zod": "npm:zod@^3.24.1",
     "react": "npm:react@^19.0"

--- a/replit.nix
+++ b/replit.nix
@@ -15,5 +15,6 @@ in
     pkgs.python311Packages.tiktoken
     unstablePkgs.deno
     pkgs.nodejs_22
+    pkgs.chromium
   ];
 }


### PR DESCRIPTION

## SUMMARY
This commit introduces significant enhancements to the end-to-end (E2E) testing setup. Key changes include the installation of Chromium in the CI workflow to facilitate headless browser testing, the addition of a new E2E test for the home page, and improvements in the test setup and teardown processes. The `.replit` configuration file is updated to include a new workflow for running E2E tests. Additionally, the `ci.bff.ts` and `e2e.bff.ts` scripts are updated to include a step for running E2E tests, with improved logging and error handling. The tests now support taking and organizing screenshots for better debugging and test verification. An outdated home page test file has been deleted to avoid redundancy.

## TEST PLAN
1. Verify that the CI pipeline executes successfully, including the new Chromium installation step.
2. Run the `Run E2E Tests Only` workflow in the `.replit` configuration to ensure it triggers the E2E tests.
3. Execute the E2E tests locally to confirm that screenshots are taken and saved correctly during the tests.
4. Ensure that the new home page test completes successfully without errors, both locally and in the CI environment.
5. Validate that all changes are logged appropriately and that any errors provide useful debugging information.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/556).
* __->__ #556
* #555