### PR TITLE
Add upload step for E2E test screenshots in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
       # Restore Nix store cache
       - name: Restore nix store cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: nix-cache
         with:
           path: |
@@ -118,6 +118,14 @@ jobs:
           nix develop . --impure --profile /tmp/nix-shell-cache/profile --command bash -c "
             bff ci -g
           "
+
+      - name: Upload test screenshots
+        uses: actions/upload-artifact@v4
+        if: always() # Run even if previous steps failed
+        with:
+          name: e2e-screenshots-${{ github.run_id }}
+          path: ${{ github.workspace }}/tmp/screenshots/
+          retention-days: 5
 
       # Optional: Collect and upload build outputs
       - name: Cache build outputs


### PR DESCRIPTION

## SUMMARY
This commit updates the GitHub Actions CI workflow to include a new step that uploads end-to-end (E2E) test screenshots as artifacts. The step is configured to execute regardless of the success or failure of previous steps, ensuring that screenshots are always available for review. The uploaded screenshots are named with the current GitHub run ID and will be retained for 5 days. This change facilitates better diagnostics and debugging by providing visual evidence of test results.

## TEST PLAN
1. Trigger a CI run and ensure the workflow executes successfully.
2. Verify that the new "Upload test screenshots" step runs, even if prior steps fail.
3. Check the Actions tab in GitHub to confirm the screenshots are uploaded as expected.
4. Ensure that the artifacts are named correctly using the `e2e-screenshots-${{ github.run_id }}` format.
5. Confirm that the artifacts are set to expire after 5 days.
