### PR TITLE
Add npm auth token configuration for dev package publishing

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -174,6 +174,7 @@ jobs:
           # Use the cached profile for the development shell
           nix develop . --impure --profile /tmp/nix-shell-cache/profile --command bash -c "
             cd packages/bolt-foundry/npm
+            echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
             npm publish --access public --tag dev
           "
         env:


### PR DESCRIPTION
## SUMMARY
This change modifies the GitHub Actions workflow for the `publish-dev` job to include the configuration of the npm authentication token. Specifically, it echoes the npm auth token into the `.npmrc` file within the development shell environment. This is necessary to authenticate with the npm registry before publishing the package. Without this step, attempts to publish to npm could fail due to missing authentication information. The change ensures that the `NODE_AUTH_TOKEN` environment variable is used to authorize the `npm publish` command, enabling successful publication to the npm registry under the 'dev' tag.

## TEST PLAN
1. Verify that the `publish-dev` workflow runs successfully in a GitHub Actions environment.
2. Ensure that the step involving `npm publish` does not fail due to authentication issues.
3. Confirm that the package is published to the npm registry with the 'dev' tag.
4. Check for the presence of the npm auth token in the `.npmrc` file during the workflow execution.

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/571)
<!-- GitContextEnd -->