### PR TITLE
Fix Deno script syntax for version update in publish workflow

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -159,12 +159,11 @@ jobs:
             bff ci -g
             cd packages/bolt-foundry
             # Update version in deno.jsonc
-            deno run -A --unstable -e "
-              const denoJsonc = JSON.parse(Deno.readTextFileSync('./deno.json'));
-              denoJsonc.version = `${denoJsonc.version}-dev.${{ env.sha_short }}`;
-              Deno.writeTextFileSync('./deno.json', JSON.stringify(denoJsonc, null, 2));
-              console.log(`Updated deno.json version to `${denoJsonc.version}-dev.${{ env.sha_short }}`);
-            "
+          deno run -A --unstable --eval "
+            const denoJsonc = JSON.parse(Deno.readTextFileSync('./deno.json'));
+            denoJsonc.version = `${denoJsonc.version}-dev.${{ env.sha_short }}`;
+            Deno.writeTextFileSync('./deno.json', JSON.stringify(denoJsonc, null, 2));
+            console.log(`Updated deno.json version to ${denoJsonc.version}-dev.${{ env.sha_short }}`);
           "
 
       - name: Build package


### PR DESCRIPTION
## SUMMARY
The Deno script used to update the version in the `deno.jsonc` file within the `publish-dev.yml` GitHub Actions workflow has been corrected. The previous implementation used an incorrect syntax for the inline JavaScript execution with Deno, specifically around the inline string template and the JSON file handling. This fix addresses the syntax issue by ensuring the correct use of the `--eval` flag and removing redundant backticks in the `console.log` statement, which could have led to runtime errors and incorrect version logging during the workflow execution.

## TEST PLAN
1. Trigger the `publish-dev.yml` workflow manually in a development branch to ensure the workflow runs without errors.
2. Verify that the console output correctly logs the updated version string from `deno.jsonc`.
3. Check the `deno.jsonc` file to confirm that the version number is updated as expected, including the `-dev.<sha_short>` suffix.
4. Review the overall workflow execution to ensure no other unintended side effects occur.

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/574)
<!-- GitContextEnd -->