### PR TITLE
Simplify Deno version script in GitHub Actions workflow

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -159,7 +159,7 @@ jobs:
             bff ci -g
             cd packages/bolt-foundry
             # Update version in deno.jsonc
-          deno run -A --unstable --eval "
+          deno eval -A "
             const denoJsonc = JSON.parse(Deno.readTextFileSync('./deno.json'));
             denoJsonc.version = `${denoJsonc.version}-dev.${{ env.sha_short }}`;
             Deno.writeTextFileSync('./deno.json', JSON.stringify(denoJsonc, null, 2));


### PR DESCRIPTION
## SUMMARY
The GitHub Actions workflow file `publish-dev.yml` was modified to simplify the command used for updating the version in the `deno.json` file. The previous command used `deno run -A --unstable --eval` to execute an inline script, which has been replaced with `deno eval -A`. This change makes the script execution more straightforward by using the `eval` subcommand directly, thereby removing the unnecessary `--unstable` flag and making the command cleaner and easier to read.

## TEST PLAN
1. Trigger the `publish-dev.yml` GitHub Actions workflow.
2. Ensure that the workflow executes without errors.
3. Verify that the version in `deno.json` is updated correctly with the new format including `-dev.${{ env.sha_short }}`.
4. Confirm that no functionality is broken by running the associated tests for the project.

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/575)
<!-- GitContextEnd -->