### PR TITLE
Switch version update in deno.json from Deno eval to jq

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -158,12 +158,13 @@ jobs:
           nix develop . --impure --profile /tmp/nix-shell-cache/profile --command bash -c "
             bff ci -g
             cd packages/bolt-foundry
-            # Update version in deno.jsonc
-          deno eval -A "
-            const denoJsonc = JSON.parse(Deno.readTextFileSync('./deno.json'));
-            denoJsonc.version = `${denoJsonc.version}-dev.${{ env.sha_short }}`;
-            Deno.writeTextFileSync('./deno.json', JSON.stringify(denoJsonc, null, 2));
-            console.log(`Updated deno.json version to ${denoJsonc.version}-dev.${{ env.sha_short }}`);
+
+            # Update version in deno.json using jq instead of deno eval
+            CURRENT_VERSION=$(jq -r '.version' ./deno.json)
+            NEW_VERSION=\"${CURRENT_VERSION}-dev.${sha_short}\"
+            jq --arg version \$NEW_VERSION '.version = \$version' ./deno.json > ./deno.json.tmp
+            mv ./deno.json.tmp ./deno.json
+            echo \"Updated deno.json version to \${CURRENT_VERSION}-dev.${sha_short}\"
           "
 
       - name: Build package


### PR DESCRIPTION
## SUMMARY
This commit changes the method of updating the version in the `deno.json` file within the GitHub Actions workflow for publishing development builds. Instead of using `deno eval` to parse and update the JSON file, the workflow now employs `jq` to accomplish this task. The version is extracted, incremented with the `-dev` suffix and the short SHA, and then written back to `deno.json`. This change enhances the readability and maintainability of the script by leveraging `jq`, a powerful tool for processing JSON.

## TEST PLAN
1. Trigger the GitHub Actions workflow with this change.
2. Ensure that the `deno.json` file version is correctly updated to include the `-dev` suffix and the short SHA.
3. Verify that the workflow completes successfully without errors.
4. Manually inspect the `deno.json` file in the workflow run to confirm the version changes are accurate.

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/576)
<!-- GitContextEnd -->