### PR TITLE
Fix version extraction command in publish-dev workflow

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -160,7 +160,7 @@ jobs:
             cd packages/bolt-foundry
 
             # Update version in deno.json using jq instead of deno eval
-            CURRENT_VERSION=$(jq -r '.version' ./deno.json)
+            CURRENT_VERSION=$(cat deno.json | jq -r '.version')
             NEW_VERSION=\"${CURRENT_VERSION}-dev.${sha_short}\"
             jq --arg version \$NEW_VERSION '.version = \$version' ./deno.json > ./deno.json.tmp
             mv ./deno.json.tmp ./deno.json


### PR DESCRIPTION

## SUMMARY
The GitHub Actions workflow file `publish-dev.yml` was updated to correct the command used for extracting the current version from the `deno.json` file. Previously, the version was extracted using the command `jq -r '.version' ./deno.json`, which has now been modified to use `cat deno.json | jq -r '.version'`. This change ensures the version extraction is done more explicitly by first reading the file content with `cat` and then piping it to `jq` for processing. This modification may improve readability and consistency in how file content is handled before processing.

## TEST PLAN
1. Trigger the GitHub Actions workflow to run the updated `publish-dev.yml`.
2. Verify that the workflow correctly extracts the current version from `deno.json` without errors.
3. Ensure that the subsequent steps using the `CURRENT_VERSION` and `NEW_VERSION` variables execute successfully.
4. Check that the `deno.json` file is updated correctly with the new version format as expected.
