### PR TITLE
Fix module path in generated package.json for src inclusion

### DIFF
--- a/packages/bolt-foundry/bin/dnt.ts
+++ b/packages/bolt-foundry/bin/dnt.ts
@@ -33,3 +33,24 @@ await build({
     },
   },
 });
+
+// Read the generated package.json
+const pkgJson = JSON.parse(await Deno.readTextFile(`${outDir}/package.json`));
+
+// Update the paths to include the src directory
+pkgJson.main = pkgJson.main.replace("./script/", "./script/src/");
+pkgJson.module = pkgJson.module.replace("./esm/", "./esm/src/");
+pkgJson.exports["."].import = pkgJson.exports["."].import.replace(
+  "./esm/",
+  "./esm/src/",
+);
+pkgJson.exports["."].require = pkgJson.exports["."].require.replace(
+  "./script/",
+  "./script/src/",
+);
+
+// Write the modified package.json back to the file
+await Deno.writeTextFile(
+  `${outDir}/package.json`,
+  JSON.stringify(pkgJson, null, 2),
+);


### PR DESCRIPTION
## SUMMARY
This commit updates the generated `package.json` file to correct the paths for the `main`, `module`, and `exports` fields by including the `src` directory. The paths were previously pointing directly to the `script` and `esm` directories, which caused issues when trying to import or require modules. By appending `/src/` to these paths, it ensures that the correct files are referenced, allowing for proper resolution of modules in environments that rely on these fields.

## TEST PLAN
1. Run the build process to generate the `package.json`.
2. Verify that the `main`, `module`, and `exports` fields in `package.json` now include the `src` directory in their paths.
3. Import and require modules as specified in the `package.json` to ensure that they are correctly resolved and no path-related errors occur.

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/582)
<!-- GitContextEnd -->