### PR TITLE
Update API endpoints and dependency versions

### DIFF
--- a/apps/graphql/types/graphqlJoinWaitlist.ts
+++ b/apps/graphql/types/graphqlJoinWaitlist.ts
@@ -37,7 +37,7 @@ export const joinWaitlistMutation = mutationField("joinWaitlist", {
       }
 
       const joinWaitlistResponse = await fetch(
-        "https://bf-cms.replit.app/api/contacts",
+        "https://bf-contacts.replit.app/api/contacts",
         {
           method: "POST",
           headers: {

--- a/infra/bff/friends/build.bff.ts
+++ b/infra/bff/friends/build.bff.ts
@@ -53,7 +53,7 @@ const DEFAULT_NETWORK_DESTINATIONS = [
   "openrouter.ai",
   "api.openai.com",
   "app.posthog.com",
-  "bf-cms.replit.app:443",
+  "bf-contacts.replit.app:443",
 ];
 
 const allowedNetworkDestionations = [...DEFAULT_NETWORK_DESTINATIONS];


### PR DESCRIPTION

## SUMMARY
This commit updates the API endpoint URL in `graphqlJoinWaitlist.ts` and `build.bff.ts` from `bf-cms.replit.app` to `bf-contacts.replit.app`. This change is likely made to reflect a backend service update or reorganization.

## TEST PLAN
1. Ensure that the application builds successfully without errors.
2. Verify that requests to the updated endpoint are functioning as expected.
3. Monitor logs for any warnings or errors related to the updated API endpoints.
