### PR TITLE
Add debug and slow-exit options to build script

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -65,6 +65,7 @@
     "jsr:@ts-morph/common@0.24": "0.24.0",
     "npm:@ai-sdk/openai@^1.3.7": "1.3.7_zod@3.24.1",
     "npm:@anthropic-ai/claude-code@~0.2.18": "0.2.18",
+    "npm:@bolt-foundry/bolt-foundry@0.0.0-dev.0281c4c": "0.0.0-dev.0281c4c",
     "npm:@daily-co/daily-js@0.77": "0.77.0",
     "npm:@hexagon/base64@^1.1.27": "1.1.28",
     "npm:@hookform/resolvers@^3.9.1": "3.10.0_react-hook-form@7.55.0__react@18.3.1_react@18.3.1",
@@ -191,6 +192,7 @@
     "npm:nodemailer@^6.10.0": "6.10.0",
     "npm:notebookjs@~0.8.3": "0.8.3",
     "npm:openai@*": "4.79.1_zod@3.24.1",
+    "npm:openai@^4.92.1": "4.93.0_ws@8.18.1_zod@3.24.1",
     "npm:passport-local@1": "1.0.0",
     "npm:passport@0.7": "0.7.0",
     "npm:pg@^8.13.3": "8.13.3",
@@ -731,6 +733,12 @@
       "dependencies": [
         "@babel/helper-string-parser",
         "@babel/helper-validator-identifier"
+      ]
+    },
+    "@bolt-foundry/bolt-foundry@0.0.0-dev.0281c4c": {
+      "integrity": "sha512-rFUihp/HSyQsu+eD7+aEbqIzdm6xhgWotITmmQ+cpAgsv4kIUzhmgWO0vOFIphOD9+qhXn34JUKspUXCgS08gQ==",
+      "dependencies": [
+        "posthog-node@4.11.2"
       ]
     },
     "@codemirror/state@6.5.2": {
@@ -7187,6 +7195,20 @@
         "form-data-encoder",
         "formdata-node",
         "node-fetch",
+        "zod"
+      ]
+    },
+    "openai@4.93.0_ws@8.18.1_zod@3.24.1": {
+      "integrity": "sha512-2kONcISbThKLfm7T9paVzg+QCE1FOZtNMMUfXyXckUAoXRRS/mTP89JSDHPMp8uM5s0bz28RISbvQjArD6mgUQ==",
+      "dependencies": [
+        "@types/node@18.19.71",
+        "@types/node-fetch",
+        "abort-controller",
+        "agentkeepalive",
+        "form-data-encoder",
+        "formdata-node",
+        "node-fetch",
+        "ws@8.18.1",
         "zod"
       ]
     },


### PR DESCRIPTION

## SUMMARY
This commit updates the `build` function in `build.bff.ts` to introduce two new command-line options: `--debug` and `--slow-exit`. The `--debug` flag enables detailed memory usage logging during the build process, while `--slow-exit` ensures the build process waits on failure, which is useful for debugging. The `logMemoryUsage` and `startContinuousMemoryLogging` calls are now conditional on the `--debug` flag, reducing unnecessary logging during routine builds. Additionally, the build script registration description has been updated to reflect these changes.

The `deno.lock` file is also updated to include new dependencies: `@bolt-foundry/bolt-foundry` and an updated version of `openai`. These changes ensure that the latest functionalities and fixes are incorporated into the project.

## TEST PLAN
1. Run the build script without any flags to ensure the build completes without memory logging.
2. Run the build script with the `--debug` flag and verify that memory usage is logged at each stage of the build process.
3. Run the build script with the `--slow-exit` flag and induce a failure to check if the process waits as expected.
4. Verify that the updated dependencies work correctly by running the application and checking for any dependency-related issues.
