### PR TITLE
Update server port and configure new route handler

### DIFF
--- a/apps/boltFoundry/components/BfCurrentViewer/Home.tsx
+++ b/apps/boltFoundry/components/BfCurrentViewer/Home.tsx
@@ -105,6 +105,7 @@ export const Home = iso(`
               if (!joinWaitlist.success) {
                 logger.error(joinWaitlist.message);
                 setError(true);
+                return;
               }
               modalRef.current?.closeModal();
               setFormSubmitting(false);

--- a/apps/contacts/server.ts
+++ b/apps/contacts/server.ts
@@ -4,7 +4,7 @@ import { getLogger } from "packages/logger/logger.ts";
 
 const logger = getLogger(import.meta);
 const app = express();
-const port = Number(Deno.env.get("PORT") ?? 5000);
+const port = Number(Deno.env.get("PORT") ?? 9999);
 
 app.use(express.json());
 app.use(passport.initialize());

--- a/apps/contacts/server/index.ts
+++ b/apps/contacts/server/index.ts
@@ -154,10 +154,10 @@ app.use((req, res, next) => {
     serveStatic(app);
   }
 
-  // ALWAYS serve the app on port 5000
+  // ALWAYS serve the app on port 9999
   // this serves both the API and the client.
   // It is the only port that is not firewalled.
-  const port = 5000;
+  const port = 9999;
 
   server.on("error", (error: NodeJS.ErrnoException) => {
     if (error.code === "EADDRINUSE") {

--- a/apps/contacts/server/services/email.ts
+++ b/apps/contacts/server/services/email.ts
@@ -410,7 +410,7 @@ export async function sendVerificationEmail(
   token: string,
 ): Promise<boolean> {
   // Determine the base URL for verification links
-  let baseUrl = "http://localhost:5000";
+  let baseUrl = "http://localhost:9999";
 
   // First try Replit domain for production
   if (process.env.REPLIT_DOMAINS) {

--- a/apps/graphql/types/graphqlJoinWaitlist.ts
+++ b/apps/graphql/types/graphqlJoinWaitlist.ts
@@ -36,8 +36,13 @@ export const joinWaitlistMutation = mutationField("joinWaitlist", {
         };
       }
 
+      const slug = Deno.env.get("REPL_SLUG");
+      const baseUrl = Deno.env.get("NODE_ENV") === "production"
+        ? `https://${slug}.replit.app`
+        : "http://localhost:8000";
+
       const joinWaitlistResponse = await fetch(
-        "https://bf-contacts.replit.app/api/contacts",
+        `${baseUrl}/contacts-cms`,
         {
           method: "POST",
           headers: {

--- a/apps/web/routes/routeRegistry.ts
+++ b/apps/web/routes/routeRegistry.ts
@@ -46,6 +46,37 @@ function registerSpecialRoutes(routes: Map<string, Handler>): void {
 
   // Simple logout route that clears cookies
   routes.set("/logout", handleLogout);
+
+  // Forward requests to contacts-cms to local handler
+  routes.set("/contacts-cms", async (req) => {
+    const url = "https://bf-contacts.replit.app/api/contacts";
+    const headers = new Headers(req.headers);
+
+    // Read the body first
+    const body = req.method !== "GET" ? await req.json() : undefined;
+
+    // Forward the request to the external API
+    const response = await fetch(url, {
+      method: req.method,
+      headers: headers,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    const responseData = await response.json();
+
+    return new Response(
+      JSON.stringify({
+        success: responseData.success !== false,
+        message: responseData.message || null,
+      }),
+      {
+        status: response.status,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    );
+  });
 }
 
 /**

--- a/infra/bff/friends/build.bff.ts
+++ b/infra/bff/friends/build.bff.ts
@@ -29,6 +29,7 @@ const allowedEnvironmentVariables = [
   "POSTHOG_API_KEY",
   "POSTHOG_HOST",
   "REPL_HOME",
+  "REPL_SLUG",
   "REPLIT_DEV_DOMAIN",
   "RPID",
   "FORCE_DOMAIN",


### PR DESCRIPTION
## SUMMARY
This commit introduces several key changes across multiple files:

1. **Port Configuration**: The default server port has been changed from 5000 to 9999 in `server.ts`, `index.ts`, and `email.ts`. This ensures consistency across the server configuration and aligns with the intended deployment setup.

2. **Error Handling Improvement**: An early return was added in `Home.tsx` when the `joinWaitlist` fails, preventing further execution and potential errors.

3. **Dynamic URL Configuration**: The base URL in `graphqlJoinWaitlist.ts` is now dynamically set based on the environment, switching between a production URL and a localhost URL for development purposes.

4. **New Route Handler**: A new route `/contacts-cms` was added in `routeRegistry.ts` to forward requests to an external API. This route reads the request body, forwards it, and then returns the response, ensuring seamless integration with the external contacts API.

5. **Environment Variable Addition**: Added `REPL_SLUG` to the environment variables in `build.bff.ts` for better environment management and configuration.

## TEST PLAN
1. **Port Configuration**:
   - Start the server and verify it listens on port 9999.
   - Attempt to access services via localhost:9999 and ensure they respond correctly.

2. **Error Handling**:
   - Trigger a failure in `joinWaitlist` and confirm the process halts as expected without executing further code.

3. **Dynamic URL Configuration**:
   - Set `NODE_ENV` to production and development, ensuring the correct base URL is used in each case.

4. **Route Handler**:
   - Send test requests to `/contacts-cms` and validate that they are correctly forwarded and responses are returned accurately.

5. **Environment Variables**:
   - Confirm that `REPL_SLUG` is correctly read from the environment in various scenarios and used as intended.

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/602)
<!-- GitContextEnd -->