### PR TITLE
Improve E2E test setup with server status check and better cleanup

### DIFF
--- a/apps/boltFoundry/__tests__/e2e/home.test.e2e.ts
+++ b/apps/boltFoundry/__tests__/e2e/home.test.e2e.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import {
   navigateTo,
   setupE2ETest,
@@ -25,6 +25,11 @@ Deno.test("Home page loads successfully", async () => {
     // Check if the page contains expected content
     const bodyText = await context.page.evaluate(() =>
       document.body.textContent
+    );
+
+    assert(
+      title.includes("Bolt Foundry"),
+      "Page title should include 'Bolt Foundry'",
     );
 
     // Basic assertion to verify the page loaded successfully


### PR DESCRIPTION

## SUMMARY
This commit enhances the end-to-end (E2E) testing setup by introducing a server status check and refining the cleanup process. Key changes include:
- Addition of a function to check if the web server is already running on port 8000, which allows us to skip the build step if it's not needed.
- Implementation of the `--no-build` flag to explicitly skip the build process if desired.
- Replacement of static server start delay with a dynamic check to ensure the server is ready before running tests.
- Improved handling of screenshot listing and sorting for E2E tests.
- Enhanced error handling and logging for better traceability.
- Ensured all processes are properly cleaned up even if errors occur during testing.

## TEST PLAN
1. Run E2E tests without any flags: verify that the application builds and the server starts if not already running.
2. Run E2E tests with the `--no-build` flag: confirm that the build step is skipped and tests run against an existing server.
3. Validate that the server status check correctly identifies if the server is running on port 8000.
4. Ensure screenshots are correctly listed and the latest ones are displayed.
5. Confirm proper shutdown of the server process after tests, even if an error occurs.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/609).
* #611
* #610
* __->__ #609