### PR TITLE
Add caching for node_modules and vendor directories in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,23 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nix-store-
 
+      # Cache node_modules and vendor directories
+      - name: Cache node_modules and vendor folders
+        uses: actions/cache@v4
+        id: dependency-cache
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+            */*/*/node_modules
+            vendor
+            */*/vendor
+            */*/*/vendor
+            ~/.npm
+          key: ${{ runner.os }}-deps-${{ hashFiles('**/package-lock.json', '**/package.json', 'package-lock.json', 'package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-deps-
+
       # Parse .replit env using pure bash
       - name: Parse .replit env and export to GitHub Actions
         run: |

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-and-publish:
-    name: bff ci
+    name: Build and Publish Dev Version
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -49,6 +49,24 @@ jobs:
           key: ${{ runner.os }}-nix-store-${{ hashFiles('**/*.nix', 'flake.lock') }}
           restore-keys: |
             ${{ runner.os }}-nix-store-
+
+      # Cache node_modules and vendor directories
+      - name: Cache node_modules and vendor folders
+        uses: actions/cache@v4
+        id: dependency-cache
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+            */*/*/node_modules
+            vendor
+            */*/vendor
+            */*/*/vendor
+            ~/.npm
+            packages/bolt-foundry/npm/node_modules
+          key: ${{ runner.os }}-deps-${{ hashFiles('**/package-lock.json', '**/package.json', 'package-lock.json', 'package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-deps-
 
       # Parse .replit env using pure bash
       - name: Parse .replit env and export to GitHub Actions

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -34,6 +34,24 @@ jobs:
         with:
           deno-version: v1.x
 
+      # Cache node_modules and vendor directories
+      - name: Cache node_modules and vendor folders
+        uses: actions/cache@v4
+        id: dependency-cache
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+            */*/*/node_modules
+            vendor
+            */*/vendor
+            */*/*/vendor
+            ~/.npm
+            packages/bolt-foundry/npm/node_modules
+          key: ${{ runner.os }}-deps-${{ hashFiles('**/package-lock.json', '**/package.json', 'package-lock.json', 'package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-deps-
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION

## SUMMARY
This commit introduces caching for `node_modules` and `vendor` directories across multiple GitHub Actions workflows (`ci.yml`, `publish-dev.yml`, and `publish-release.yml`). The caching is implemented using the `actions/cache@v4` action to speed up job execution by reusing previously built dependencies. The cache key is generated based on the operating system and the hash of package lock files to ensure cache validity. The changes aim to optimize build times by avoiding redundant installations of dependencies.

## TEST PLAN
1. Trigger the `ci.yml`, `publish-dev.yml`, and `publish-release.yml` workflows to ensure they run successfully with caching enabled.
2. Verify that cache is being stored and retrieved correctly by checking the GitHub Actions logs for cache hit/miss information.
3. Confirm that subsequent runs of the workflows benefit from reduced execution time due to the cached dependencies.
