### PR TITLE
Rename "Content Foundry" to "Bolt Foundry" across codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ systems.
 ## Developer Experience
 
 We want to create the best developer experience possible. We want it to be
-simpler to contribute to Content Foundry than it is to contribute to Wikipedia.
+simpler to contribute to Bolt Foundry than it is to contribute to Wikipedia.
 We're not there yet, but here's what we do have.
 
 ### Replit-first Developer Experience
 
-The best way to get started with Content Foundry is to
+The best way to get started with Bolt Foundry is to
 [head to our Replit project](https://replit.com/t/bolt-foundry/repls/Content-Foundry/view).
 
 From there, you can fork (they call it remix now) our app into your own Replit
@@ -62,8 +62,8 @@ This will start various tools including:
 
 #### Dependencies
 
-Content Foundry uses Deno 2's built-in dependency management with both JSR and
-npm packages:
+Bolt Foundry uses Deno 2's built-in dependency management with both JSR and npm
+packages:
 
 ```bash
 # Add a dependency from JSR (JavaScript Registry)
@@ -78,7 +78,7 @@ and `package.json`.
 
 ### BFF (Bolt Foundry Friend)
 
-Content Foundry uses BFF, our custom task runner to simplify common development
+Bolt Foundry uses BFF, our custom task runner to simplify common development
 tasks:
 
 - `bff build` - Build the project
@@ -105,7 +105,7 @@ Run `bff help` to see all available commands.
 
 ### Development Workflow
 
-For more details on contributing to Content Foundry, check out our
+For more details on contributing to Bolt Foundry, check out our
 [contributing guide](/content/documentation/community/contributing.md) and the
 [AGENT.md](AGENT.md) file which contains comprehensive documentation on our
 coding practices and workflows.

--- a/apps/bfDb/bfDbUtils.ts
+++ b/apps/bfDb/bfDbUtils.ts
@@ -91,7 +91,7 @@ export async function upsertBfDb() {
   // if (!(await BfOrganization.find(omniCv, toBfOid(BF_INTERNAL_ORG_NAME)))) {
   //   logger.info("Creating internal org");
   //   await BfOrganization.__DANGEROUS__createUnattached(omniCv, {
-  //     name: "Content Foundry internal",
+  //     name: "Bolt Foundry internal",
   //     domainName: "contentfoundry.com",
   //   }, {
   //     bfGid: toBfGid(BF_INTERNAL_ORG_NAME),

--- a/apps/bfDb/models/BfPerson.ts
+++ b/apps/bfDb/models/BfPerson.ts
@@ -90,7 +90,7 @@ export class BfPerson extends BfNode<BfPersonProps> {
 
     const userName = person.props.name;
     const result = await generateRegistrationOptions({
-      rpName: "Content Foundry",
+      rpName: "Bolt Foundry",
       rpID,
       userName,
       userID, // Make sure we pass userID so the authenticator knows who we're registering

--- a/apps/boltFoundry/AppRoot.tsx
+++ b/apps/boltFoundry/AppRoot.tsx
@@ -62,7 +62,7 @@ export function AppRoot() {
 AppRoot.HeaderComponent = function AppRootHeaderComponent() {
   return (
     <HeaderTitle>
-      Content Foundry
+      Bolt Foundry
     </HeaderTitle>
   );
 };

--- a/apps/boltFoundry/entrypoints/EntrypointApp.tsx
+++ b/apps/boltFoundry/entrypoints/EntrypointApp.tsx
@@ -17,5 +17,5 @@ export const EntrypointContentFoundryApp = iso(`
   if (Body == null) {
     throw new Error("No Body found");
   }
-  return { Body, title: "Content Foundry" };
+  return { Body, title: "Bolt Foundry" };
 });

--- a/apps/boltFoundry/entrypoints/EntrypointHome.ts
+++ b/apps/boltFoundry/entrypoints/EntrypointHome.ts
@@ -12,6 +12,6 @@ export const EntrypointHome = iso(`
 `)(function EntrypointHome({ data }) {
   const Body = data?.me?.Home;
   logger.debug("dataer", data);
-  const title = "Content Foundry: The Content Operating System.";
+  const title = "Bolt Foundry: The Content Operating System.";
   return { Body, title };
 });

--- a/apps/boltFoundry/resources/CfLogo.tsx
+++ b/apps/boltFoundry/resources/CfLogo.tsx
@@ -17,9 +17,9 @@ export function CfLogo(
       viewBox="0 0 820 74.2"
       xmlSpace="preserve"
       role="img"
-      aria-label="Content Foundry"
+      aria-label="Bolt Foundry"
     >
-      <title>Content Foundry</title>
+      <title>Bolt Foundry</title>
       <path
         fill={foundryColor}
         d="M506.9,73.4c-20,0-36.3-16.3-36.3-36.3c0-20,16.3-36.3,36.3-36.3s36.3,16.3,36.3,36.3C543.2,57.1,527,73.4,506.9,73.4z

--- a/infra/bff/friends/fork.bff.ts
+++ b/infra/bff/friends/fork.bff.ts
@@ -8,7 +8,7 @@ import { getLogger } from "packages/logger/logger.ts";
 const logger = getLogger(import.meta);
 
 export async function fork(): Promise<number> {
-  logger.info("Forking Content Foundry repository...");
+  logger.info("Forking Bolt Foundry repository...");
 
   // 1. Check GitHub auth status first
   const { stdout: authStatus } = await runShellCommandWithOutput([
@@ -137,6 +137,6 @@ export async function fork(): Promise<number> {
 
 register(
   "fork",
-  "Fork the Content Foundry repository to your personal GitHub account",
+  "Fork the Bolt Foundry repository to your personal GitHub account",
   fork,
 );

--- a/infra/bff/prompts/base.md
+++ b/infra/bff/prompts/base.md
@@ -1,5 +1,5 @@
 You are a helpful assistant called BFF. That stands for "bolt foundry friend."
-You support an open source project called content foundry. Much of the
+You support an open source project called Bolt Foundry. Much of the
 documentation and information can be found about the project in the content
 folder. The user who will be speaking to you will be a developer on this
 project. They may have familiarity with the codebase, but they also might not.


### PR DESCRIPTION

## SUMMARY
This commit updates all references of "Content Foundry" to "Bolt Foundry" across the codebase. This change affects documentation files, code comments, variables, and user-facing text in the application. The update is necessary to align with the recent rebranding of the project from "Content Foundry" to "Bolt Foundry". Specific files that were updated include README.md, bfDbUtils.ts, BfPerson.ts, AppRoot.tsx, EntrypointApp.tsx, EntrypointHome.ts, CfLogo.tsx, fork.bff.ts, and base.md. These changes ensure consistency in the project's branding and prevent any confusion among users and contributors.

## TEST PLAN
1. Review the updated README.md to ensure all instances of "Content Foundry" are changed to "Bolt Foundry".
2. Launch the application and verify that all user-facing text now displays "Bolt Foundry" correctly.
3. Run existing test suites to ensure no functionality is broken due to the renaming.
4. Check the logs and console outputs to confirm that "Bolt Foundry" appears where expected.
5. Verify that documentation files accurately reflect the new project name "Bolt Foundry".
