### PR TITLE
Add support for merging .replit.local.toml into .replit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ tmp/*
 **/.next/**
 .upm
 **/npm
+.replit.local.toml

--- a/apps/collector/__tests__/llm-event-tracker.test.ts
+++ b/apps/collector/__tests__/llm-event-tracker.test.ts
@@ -3,6 +3,11 @@ import { assertEquals, assertObjectMatch } from "@std/assert";
 import { trackLlmEvent } from "../llm-event-tracker.ts";
 import type { JSONValue } from "apps/bfDb/bfDb.ts";
 import type { PostHog } from "posthog-node";
+import type {
+  OpenAIRequestBody,
+  OpenAIResponseBody,
+  TelemetryData,
+} from "packages/bolt-foundry/bolt-foundry.ts";
 
 type PostHogEvent = {
   event: string;
@@ -56,93 +61,55 @@ Deno.test("trackLlmEvent captures and sends analytics data correctly", async () 
     ],
   };
 
-  // Create mock Request with body
-  const mockRequest = new Request(
-    "https://api.openai.com/v1/chat/completions",
-    {
+  // Create telemetry data object
+  const telemetryData: TelemetryData = {
+    request: {
+      url: "https://api.openai.com/v1/chat/completions",
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify(mockRequestBody),
+      body: mockRequestBody as unknown as OpenAIRequestBody,
     },
+    response: {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: mockResponseBody as unknown as OpenAIResponseBody,
+    },
+    duration: 1000, // 1 second
+    timestamp: new Date().toISOString(),
+  };
+
+  // Call the function under test
+  await trackLlmEvent(
+    telemetryData,
+    mockPosthog as unknown as PostHog,
   );
 
-  // Create mock Response with body
-  const mockResponse = new Response(JSON.stringify(mockResponseBody), {
-    status: 200,
-    headers: {
-      "Content-Type": "application/json",
-    },
+  // Assert that PostHog capture was called with correct parameters
+  assertEquals(mockPosthog.events.length, 1);
+  assertEquals(mockPosthog.flushed, true);
+
+  const capturedEvent = mockPosthog.events[0];
+  assertEquals(capturedEvent.event, "llm_api_request");
+
+  // Check that PostHog properties include the expected AI schema properties
+  const properties = capturedEvent.properties;
+  assertObjectMatch(properties, {
+    "$ai_provider": "openai",
+    "$ai_model": "gpt-3.5-turbo",
+    "$ai_input_tokens": 10,
+    "$ai_output_tokens": 20,
+    "$ai_total_tokens": 30,
+    "$ai_response_id": "chatcmpl-123",
+    "$ai_is_error": false,
+    "$ai_http_status": 200,
   });
 
-  // Mock Request and Response clone methods
-  const originalClone = Request.prototype.clone;
-  const originalResponseClone = Response.prototype.clone;
-  const originalText = Response.prototype.text;
-  const originalRequestText = Request.prototype.text;
-
-  // Stub Request.clone
-  Request.prototype.clone = function () {
-    return this;
-  };
-
-  // Stub Request.text
-  Request.prototype.text = function () {
-    return Promise.resolve(JSON.stringify(mockRequestBody));
-  };
-
-  // Stub Response.clone
-  Response.prototype.clone = function () {
-    return this;
-  };
-
-  // Stub Response.text
-  Response.prototype.text = function () {
-    return Promise.resolve(JSON.stringify(mockResponseBody));
-  };
-
-  try {
-    // Set a fixed starting time for deterministic testing
-    const startTime = Date.now() - 1000; // 1 second ago
-
-    // Call the function under test
-    await trackLlmEvent(
-      mockRequest,
-      mockResponse,
-      startTime,
-      mockPosthog as unknown as PostHog,
-    );
-
-    // Assert that PostHog capture was called with correct parameters
-    assertEquals(mockPosthog.events.length, 1);
-    assertEquals(mockPosthog.flushed, true);
-
-    const capturedEvent = mockPosthog.events[0];
-    assertEquals(capturedEvent.event, "llm_api_request");
-
-    // Check that PostHog properties include the expected AI schema properties
-    const properties = capturedEvent.properties;
-    assertObjectMatch(properties, {
-      "$ai_provider": "openai",
-      "$ai_model": "gpt-3.5-turbo",
-      "$ai_input_tokens": 10,
-      "$ai_output_tokens": 20,
-      "$ai_total_tokens": 30,
-      "$ai_response_id": "chatcmpl-123",
-      "$ai_is_error": false,
-      "$ai_http_status": 200,
-    });
-
-    // Verify cost calculation is included
-    assertEquals(typeof properties.cost, "number");
-  } finally {
-    // Restore original methods
-    Request.prototype.clone = originalClone;
-    Request.prototype.text = originalRequestText;
-    Response.prototype.clone = originalResponseClone;
-    Response.prototype.text = originalText;
-  }
+  // Verify cost calculation is included
+  assertEquals(typeof properties.cost, "number");
 });
 
 Deno.test("trackLlmEvent handles API errors correctly", async () => {
@@ -158,77 +125,41 @@ Deno.test("trackLlmEvent handles API errors correctly", async () => {
     },
   };
 
-  // Create mock Request
-  const mockRequest = new Request(
-    "https://api.openai.com/v1/chat/completions",
-    {
+  // Create telemetry data object with error
+  const telemetryData: TelemetryData = {
+    request: {
+      url: "https://api.openai.com/v1/chat/completions",
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ model: "gpt-3.5-turbo" }),
+      body: { model: "gpt-3.5-turbo" } as OpenAIRequestBody,
     },
-  );
-
-  // Create mock error Response
-  const mockErrorResponse = new Response(
-    JSON.stringify(mockErrorResponseBody),
-    {
+    response: {
       status: 401,
       headers: {
         "Content-Type": "application/json",
       },
+      body: mockErrorResponseBody as unknown as OpenAIResponseBody,
     },
+    duration: 500, // 0.5 seconds
+    timestamp: new Date().toISOString(),
+  };
+
+  // Call the function under test with error response
+  await trackLlmEvent(
+    telemetryData,
+    mockPosthog as unknown as PostHog,
   );
 
-  // Stub methods
-  const originalClone = Request.prototype.clone;
-  const originalResponseClone = Response.prototype.clone;
-  const originalText = Response.prototype.text;
-  const originalRequestText = Request.prototype.text;
+  // Assert that PostHog was called with error information
+  assertEquals(mockPosthog.events.length, 1);
+  assertEquals(mockPosthog.flushed, true);
 
-  Request.prototype.clone = function () {
-    return this;
-  };
-
-  Request.prototype.text = function () {
-    return Promise.resolve(JSON.stringify({ model: "gpt-3.5-turbo" }));
-  };
-
-  Response.prototype.clone = function () {
-    return this;
-  };
-
-  Response.prototype.text = function () {
-    return Promise.resolve(JSON.stringify(mockErrorResponseBody));
-  };
-
-  try {
-    const startTime = Date.now() - 500;
-
-    // Call the function under test with error response
-    await trackLlmEvent(
-      mockRequest,
-      mockErrorResponse,
-      startTime,
-      mockPosthog as unknown as PostHog,
-    );
-
-    // Assert that PostHog was called with error information
-    assertEquals(mockPosthog.events.length, 1);
-    assertEquals(mockPosthog.flushed, true);
-
-    // Verify error information in captured event
-    const capturedEvent = mockPosthog.events[0];
-    const properties = capturedEvent.properties;
-    assertEquals(properties["$ai_is_error"], true);
-    assertEquals(properties["$ai_http_status"], 401);
-    assertEquals(properties.success, false);
-  } finally {
-    // Restore original methods
-    Request.prototype.clone = originalClone;
-    Request.prototype.text = originalRequestText;
-    Response.prototype.clone = originalResponseClone;
-    Response.prototype.text = originalText;
-  }
+  // Verify error information in captured event
+  const capturedEvent = mockPosthog.events[0];
+  const properties = capturedEvent.properties;
+  assertEquals(properties["$ai_is_error"], true);
+  assertEquals(properties["$ai_http_status"], 401);
+  assertEquals(properties.success, false);
 });

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,6 +1,10 @@
 {
   "unstable": ["temporal", "webgpu"],
   "imports": {
+    "@bolt-foundry/bolt-foundry": "./packages/bolt-foundry/bolt-foundry.ts",
+    "@bolt-foundry/logger": "./packages/logger/logger.ts",
+    "@bolt-foundry/get-configuration-var": "./packages/get-configuration-var/get-configuration-var.ts",
+
     "@b-fuze/deno-dom": "jsr:@b-fuze/deno-dom@^0.1.49",
     "@deno/dnt": "jsr:@deno/dnt@^0.41.3",
     "@denosaurs/python": "jsr:@denosaurs/python@^0.4.4",
@@ -29,11 +33,7 @@
     "content/": "./content/",
     "build/content/": "./build/content/",
     "static/": "./static/",
-    "tmp/": "./tmp/",
-
-    "@bolt-foundry/bolt-foundry": "./packages/bolt-foundry/bolt-foundry.ts",
-    "@bolt-foundry/logger": "./packages/logger/logger.ts",
-    "@bolt-foundry/get-configuration-var": "./packages/get-configuration-var/get-configuration-var.ts"
+    "tmp/": "./tmp/"
   },
   "compilerOptions": {
     "jsx": "react-jsx",

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -7,7 +7,6 @@
 
     "@b-fuze/deno-dom": "jsr:@b-fuze/deno-dom@^0.1.49",
     "@deno/dnt": "jsr:@deno/dnt@^0.41.3",
-    "@denosaurs/python": "jsr:@denosaurs/python@^0.4.4",
     "@iso": "./apps/boltFoundry/__generated__/__isograph/iso.ts",
     "@iso/": "./apps/boltFoundry/__generated__/__isograph/",
     "@luca/esbuild-deno-loader": "jsr:@luca/esbuild-deno-loader@^0.11.1",
@@ -20,6 +19,7 @@
     "@std/http": "jsr:@std/http@^1.0.12",
     "@std/path": "jsr:@std/path@^1.0.8",
     "@std/testing": "jsr:@std/testing@^1.0.9",
+    "@std/toml": "jsr:@std/toml@^1.0.4",
     "sqlite": "node:sqlite",
 
     "apps/": "./apps/",

--- a/deno.lock
+++ b/deno.lock
@@ -7,14 +7,11 @@
     "jsr:@deno/cache-dir@~0.10.3": "0.10.3",
     "jsr:@deno/dnt@~0.41.3": "0.41.3",
     "jsr:@deno/graph@~0.73.1": "0.73.1",
-    "jsr:@denosaurs/plug@1": "1.0.6",
     "jsr:@denosaurs/plug@1.0.3": "1.0.3",
-    "jsr:@denosaurs/python@~0.4.4": "0.4.4",
     "jsr:@luca/esbuild-deno-loader@~0.11.1": "0.11.1",
     "jsr:@openai/openai@^4.78.1": "4.79.1",
     "jsr:@simplewebauthn/browser@^13.1.0": "13.1.0",
     "jsr:@simplewebauthn/server@^13.1.1": "13.1.1",
-    "jsr:@std/assert@0.221": "0.221.0",
     "jsr:@std/assert@0.223": "0.223.0",
     "jsr:@std/assert@0.226": "0.226.0",
     "jsr:@std/assert@^1.0.10": "1.0.11",
@@ -24,19 +21,17 @@
     "jsr:@std/bytes@0.223": "0.223.0",
     "jsr:@std/bytes@^1.0.2": "1.0.4",
     "jsr:@std/cli@^1.0.8": "1.0.10",
+    "jsr:@std/collections@^1.0.10": "1.0.10",
     "jsr:@std/collections@^1.0.9": "1.0.10",
     "jsr:@std/data-structures@^1.0.6": "1.0.6",
     "jsr:@std/encoding@0.213.1": "0.213.1",
-    "jsr:@std/encoding@0.221": "0.221.0",
     "jsr:@std/encoding@^1.0.5": "1.0.6",
     "jsr:@std/fmt@0.213.1": "0.213.1",
-    "jsr:@std/fmt@0.221": "0.221.0",
     "jsr:@std/fmt@0.223": "0.223.0",
     "jsr:@std/fmt@1": "1.0.4",
     "jsr:@std/fmt@^1.0.3": "1.0.4",
     "jsr:@std/front-matter@^1.0.5": "1.0.5",
     "jsr:@std/fs@0.213.1": "0.213.1",
-    "jsr:@std/fs@0.221": "0.221.0",
     "jsr:@std/fs@0.223": "0.223.0",
     "jsr:@std/fs@1": "1.0.10",
     "jsr:@std/fs@^1.0.10": "1.0.10",
@@ -49,7 +44,6 @@
     "jsr:@std/media-types@^1.1.0": "1.1.0",
     "jsr:@std/net@^1.0.4": "1.0.4",
     "jsr:@std/path@0.213.1": "0.213.1",
-    "jsr:@std/path@0.221": "0.221.0",
     "jsr:@std/path@0.223": "0.223.0",
     "jsr:@std/path@1": "1.0.8",
     "jsr:@std/path@1.0.0-rc.1": "1.0.0-rc.1",
@@ -60,6 +54,7 @@
     "jsr:@std/streams@^1.0.8": "1.0.8",
     "jsr:@std/testing@^1.0.9": "1.0.9",
     "jsr:@std/toml@^1.0.1": "1.0.2",
+    "jsr:@std/toml@^1.0.4": "1.0.4",
     "jsr:@std/yaml@^1.0.5": "1.0.5",
     "jsr:@ts-morph/bootstrap@0.24": "0.24.0",
     "jsr:@ts-morph/common@0.24": "0.24.0",
@@ -231,7 +226,7 @@
     "@b-fuze/deno-dom@0.1.49": {
       "integrity": "45c40175fdd1e74ab2d4b54c4fdaabbad6e5b76ee28df12a48e076b3fa7901a9",
       "dependencies": [
-        "jsr:@denosaurs/plug@1.0.3"
+        "jsr:@denosaurs/plug"
       ]
     },
     "@bolt-foundry/get-configuration-var@0.0.0-dev.0": {
@@ -273,24 +268,6 @@
         "jsr:@std/path@0.213.1"
       ]
     },
-    "@denosaurs/plug@1.0.6": {
-      "integrity": "6cf5b9daba7799837b9ffbe89f3450510f588fafef8115ddab1ff0be9cb7c1a7",
-      "dependencies": [
-        "jsr:@std/encoding@0.221",
-        "jsr:@std/fmt@0.221",
-        "jsr:@std/fs@0.221",
-        "jsr:@std/path@0.221"
-      ]
-    },
-    "@denosaurs/python@0.4.4": {
-      "integrity": "0eca587ac3a60ed5bce73ac9612126de39d7c26b0a98c03044838fd94aba812f",
-      "dependencies": [
-        "jsr:@denosaurs/plug@1",
-        "jsr:@std/fmt@1",
-        "jsr:@std/fs@1",
-        "jsr:@std/path@1"
-      ]
-    },
     "@luca/esbuild-deno-loader@0.11.1": {
       "integrity": "dc020d16d75b591f679f6b9288b10f38bdb4f24345edb2f5732affa1d9885267",
       "dependencies": [
@@ -319,9 +296,6 @@
     },
     "@std/assert@0.213.1": {
       "integrity": "24c28178b30c8e0782c18e8e94ea72b16282207569cdd10ffb9d1d26f2edebfe"
-    },
-    "@std/assert@0.221.0": {
-      "integrity": "a5f1aa6e7909dbea271754fd4ab3f4e687aeff4873b4cef9a320af813adb489a"
     },
     "@std/assert@0.223.0": {
       "integrity": "eb8d6d879d76e1cc431205bd346ed4d88dc051c6366365b1af47034b0670be24"
@@ -356,17 +330,11 @@
     "@std/encoding@0.213.1": {
       "integrity": "fcbb6928713dde941a18ca5db88ca1544d0755ec8fb20fe61e2dc8144b390c62"
     },
-    "@std/encoding@0.221.0": {
-      "integrity": "d1dd76ef0dc5d14088411e6dc1dede53bf8308c95d1537df1214c97137208e45"
-    },
     "@std/encoding@1.0.6": {
       "integrity": "ca87122c196e8831737d9547acf001766618e78cd8c33920776c7f5885546069"
     },
     "@std/fmt@0.213.1": {
       "integrity": "a06d31777566d874b9c856c10244ac3e6b660bdec4c82506cd46be052a1082c3"
-    },
-    "@std/fmt@0.221.0": {
-      "integrity": "379fed69bdd9731110f26b9085aeb740606b20428ce6af31ef6bd45ef8efa62a"
     },
     "@std/fmt@0.223.0": {
       "integrity": "6deb37794127dfc7d7bded2586b9fc6f5d50e62a8134846608baf71ffc1a5208"
@@ -377,7 +345,7 @@
     "@std/front-matter@1.0.5": {
       "integrity": "abddc64030a33eb5bc524b8c73e7c417cea09177aaeb4abf75a56b540c4b6e60",
       "dependencies": [
-        "jsr:@std/toml",
+        "jsr:@std/toml@^1.0.1",
         "jsr:@std/yaml"
       ]
     },
@@ -386,13 +354,6 @@
       "dependencies": [
         "jsr:@std/assert@~0.213.1",
         "jsr:@std/path@~0.213.1"
-      ]
-    },
-    "@std/fs@0.221.0": {
-      "integrity": "028044450299de8ed5a716ade4e6d524399f035513b85913794f4e81f07da286",
-      "dependencies": [
-        "jsr:@std/assert@0.221",
-        "jsr:@std/path@0.221"
       ]
     },
     "@std/fs@0.223.0": {
@@ -448,12 +409,6 @@
         "jsr:@std/assert@~0.213.1"
       ]
     },
-    "@std/path@0.221.0": {
-      "integrity": "0a36f6b17314ef653a3a1649740cc8db51b25a133ecfe838f20b79a56ebe0095",
-      "dependencies": [
-        "jsr:@std/assert@0.221"
-      ]
-    },
     "@std/path@0.223.0": {
       "integrity": "593963402d7e6597f5a6e620931661053572c982fc014000459edc1f93cc3989",
       "dependencies": [
@@ -489,7 +444,13 @@
     "@std/toml@1.0.2": {
       "integrity": "5892ba489c5b512265a384238a8fe8dddbbb9498b4b210ef1b9f0336a423a39b",
       "dependencies": [
-        "jsr:@std/collections"
+        "jsr:@std/collections@^1.0.9"
+      ]
+    },
+    "@std/toml@1.0.4": {
+      "integrity": "8781e687d04c8fbe246b9c5714be01925792a94d943462c33777675ab557cff1",
+      "dependencies": [
+        "jsr:@std/collections@^1.0.10"
       ]
     },
     "@std/yaml@1.0.5": {
@@ -9248,7 +9209,6 @@
     "dependencies": [
       "jsr:@b-fuze/deno-dom@~0.1.49",
       "jsr:@deno/dnt@~0.41.3",
-      "jsr:@denosaurs/python@~0.4.4",
       "jsr:@luca/esbuild-deno-loader@~0.11.1",
       "jsr:@openai/openai@^4.78.1",
       "jsr:@simplewebauthn/browser@^13.1.0",
@@ -9259,6 +9219,7 @@
       "jsr:@std/http@^1.0.12",
       "jsr:@std/path@^1.0.8",
       "jsr:@std/testing@^1.0.9",
+      "jsr:@std/toml@^1.0.4",
       "npm:@types/react@19",
       "npm:react@*"
     ],


### PR DESCRIPTION
## SUMMARY
This commit introduces functionality to merge a `.replit.local.toml` file into the existing `.replit` file. The `.gitignore` is updated to ignore `.replit.local.toml`. The `deno.jsonc` and `deno.lock` files are modified to include the `@std/toml` module, enabling TOML parsing and stringifying. Additionally, a deep merge function is implemented to handle merging of complex TOML structures, ensuring proper handling of nested objects and arrays, with special treatment for workflow arrays to prevent duplicates.

The removal of the `@denosaurs/python` dependency and associated entries in the lock file is also included, likely due to it no longer being required for the project.

## TEST PLAN
1. Verify that `.replit.local.toml` is correctly ignored by git.
2. Place a `.replit.local.toml` file with desired changes in the project root.
3. Run the modified process and check the `.replit` file to ensure it has been updated with the merged content from `.replit.local.toml`.
4. Ensure no errors occur during the merge process.
5. Validate that the project continues to build and run correctly after the changes.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/622).
* __->__ #622
* #621

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/622)
<!-- GitContextEnd -->