### PR TITLE
Simplify build script path in GitHub Actions workflow

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -161,8 +161,7 @@ jobs:
           cd $GITHUB_WORKSPACE
           # Use the cached profile for the development shell
           nix develop . --impure --profile /tmp/nix-shell-cache/profile --command bash -c "
-            cd packages/bolt-foundry
-            deno run -A bin/build.ts
+            deno run -A packages/bolt-foundry/bin/build.ts
           "
 
       - name: Publish to npm


### PR DESCRIPTION
## SUMMARY
This commit modifies the GitHub Actions workflow file `publish-dev.yml` to streamline the execution of the build script. Previously, there was a redundant `cd` command to navigate into the `packages/bolt-foundry` directory before running the Deno build script. This commit removes the `cd` command and directly runs the Deno script with the full path `packages/bolt-foundry/bin/build.ts`, simplifying the script and potentially reducing errors related to directory navigation.

## TEST PLAN
1. Trigger the GitHub Actions workflow using the modified `publish-dev.yml`.
2. Verify that the build process for `bolt-foundry` executes successfully without errors.
3. Ensure that the output and artifacts from the build process are consistent with previous successful runs.
4. Confirm that the workflow continues to the subsequent steps, such as publishing to npm, without interruption.

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/623)
<!-- GitContextEnd -->