### PR TITLE
Add generated-icon.png to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ tmp/*
 .upm
 **/npm
 .replit.local.toml
+generated-icon.png


### PR DESCRIPTION

## SUMMARY
This commit updates the `.gitignore` file to include `generated-icon.png`, ensuring that this file is ignored by Git. The addition of this file to `.gitignore` indicates that `generated-icon.png` is likely a dynamically generated or temporary file that should not be tracked in version control. Additionally, there is a change in the `generated-icon.png` binary file itself, but these changes are not detailed in the diff output. This update helps maintain a clean repository by preventing unnecessary files from being committed.

## TEST PLAN
1. Verify that after this change, `generated-icon.png` is not tracked by Git.
   - Run `git status` to ensure `generated-icon.png` does not appear in the list of changed files.
2. If `generated-icon.png` was previously committed, ensure it is removed from the repository history if desired using `git rm --cached generated-icon.png` and commit the removal separately.
3. Confirm that the `.gitignore` file correctly lists `generated-icon.png` and that no syntax errors are present.
