### PR TITLE
Add section on Cards to documentation

### DIFF
--- a/docs/wut.md
+++ b/docs/wut.md
@@ -6,6 +6,18 @@ At Bolt Foundry, we use the term **samples** instead of "examples" when
 referring to instances of LLM behavior or output. Samples represent concrete
 instances of an LLM's capabilities that can be tested, verified, and reused.
 
+## Cards
+
+Cards are simply a document that:
+
+1. A title
+2. A summary
+3. A hierarchical set of rules that are typically only 1-2 levels great
+
+The intention is for both humans and machines to understand them, and reference
+them directly and point samples to them to reinforce and disambiguate specific
+principles.
+
 ## Identity Card vs Constitution
 
 We use **Identity Card** to define the core essence and characteristics of an


### PR DESCRIPTION
## SUMMARY
This update introduces a new section titled "Cards" in `docs/wut.md`. The section provides a definition and explanation of what cards are, listing their components such as a title, a summary, and a hierarchical set of rules. It clarifies that cards are designed to be understood by both humans and machines and are used to reinforce and clarify specific principles by linking them to samples.

## TEST PLAN
1. Review the rendered Markdown in `docs/wut.md` to ensure the new "Cards" section appears correctly and coherently.
2. Verify that the explanation of cards is clear and understandable.
3. Ensure there are no formatting errors in the Markdown file after the addition.

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/629)
<!-- GitContextEnd -->