### PR TITLE
Reorder git commit to follow .replit.local.toml merge

### DIFF
--- a/infra/bff/friends/land.bff.ts
+++ b/infra/bff/friends/land.bff.ts
@@ -132,23 +132,8 @@ export async function land(): Promise<number> {
 
   logger.info("Proceeding with commit");
 
-  // Create git commit with sapling commits and hash
-  logger.info("Creating git commit...");
-  const fullCommitMsg =
-    `${commitMsg.trim()}\n\nSapling-Hash: ${currentSaplingHash}`;
-  const commitResult = await runShellCommand([
-    "git",
-    "commit",
-    "-m",
-    fullCommitMsg,
-  ]);
-
-  if (commitResult !== 0) {
-    logger.error("Failed to create git commit");
-    return commitResult;
-  }
-
-  // Check for .replit.local.toml file and merge with .replit if it exists
+  // First check for .replit.local.toml file and merge with .replit if it exists
+  // Do this before git commit so it happens regardless of commit success/failure
   logger.info("Checking for .replit.local.toml file...");
   const replitLocalExists = await exists(".replit.local.toml");
 
@@ -176,6 +161,22 @@ export async function land(): Promise<number> {
     }
   } else {
     logger.info("No .replit.local.toml file found, skipping merge step.");
+  }
+
+  // Create git commit with sapling commits and hash
+  logger.info("Creating git commit...");
+  const fullCommitMsg =
+    `${commitMsg.trim()}\n\nSapling-Hash: ${currentSaplingHash}`;
+  const commitResult = await runShellCommand([
+    "git",
+    "commit",
+    "-m",
+    fullCommitMsg,
+  ]);
+
+  if (commitResult !== 0) {
+    logger.error("Failed to create git commit");
+    return commitResult;
   }
 
   logger.info("Successfully landed changes!");


### PR DESCRIPTION
## SUMMARY
This change reorders the process of creating a git commit and merging the `.replit.local.toml` file with `.replit`. Previously, the git commit was attempted before checking for the presence of `.replit.local.toml` and performing a merge if it existed. The logic has been adjusted so that the check and potential merge of `.replit.local.toml` occur before the git commit is attempted. This ensures that the merge step is always executed, regardless of whether the commit succeeds or fails, providing a more robust and predictable workflow.

## TEST PLAN
1. Verify that the `.replit.local.toml` merge step is executed before the git commit.
2. Test with a project that includes a `.replit.local.toml` file and ensure the merge with `.replit` occurs correctly.
3. Confirm that the git commit is performed successfully after the merge.
4. Check that error handling for the commit remains functional and logs an error if the commit fails.

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/631)
<!-- GitContextEnd -->