### PR TITLE
Simplify array merging logic in land.bff.ts

### DIFF
--- a/infra/bff/friends/land.bff.ts
+++ b/infra/bff/friends/land.bff.ts
@@ -237,13 +237,8 @@ function deepMergeToml(
             }
           }
         } else {
-          // For other arrays, append unique items
-          output[key] = [
-            ...new Set([
-              ...(target[key] as Array<unknown>),
-              ...(source[key] as Array<unknown>),
-            ]),
-          ];
+          // Don't merge any arrays - just use the source value
+          output[key] = source[key];
         }
       } else {
         // Otherwise, just overwrite with the source value


### PR DESCRIPTION

## SUMMARY
The logic for handling array merging in the `land.bff.ts` file has been simplified. Previously, arrays from the `target` and `source` were combined, and duplicates were removed by converting the combined array into a `Set`. Now, the logic has been changed to directly use the array from the `source`, eliminating the need to merge arrays and handle duplicates. This change reduces complexity and improves performance by avoiding unnecessary operations.

## TEST PLAN
1. Run existing unit tests to ensure no regressions occur due to the change in array handling.
2. Create tests that specifically check scenarios where arrays are involved to verify that the `source` array is correctly used.
3. Test with mock data that includes arrays to confirm the new behavior aligns with expectations, ensuring the `target` array is not used.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/632).
* #633
* __->__ #632