### PR TITLE
Refactor BfNode.ts to use a storage façade

### DIFF
--- a/apps/bfDb/storage/storage.ts
+++ b/apps/bfDb/storage/storage.ts
@@ -1,0 +1,46 @@
+import {
+  bfCloseConnection,
+  bfDeleteItem,
+  bfGetItem,
+  bfPutItem,
+  bfQueryItemsUnified as bfQueryItems,
+  type DbItem,
+  type Props,
+} from "apps/bfDb/bfDb.ts";
+import type { BfGid } from "apps/bfDb/classes/BfNodeIds.ts";
+import type { BfMetadataNode } from "apps/bfDb/coreModels/BfNode.ts";
+import type { BfMetadataEdge } from "apps/bfDb/coreModels/BfEdge.ts";
+
+export const storage = {
+  async initialize() {},
+
+  get<T extends Props>(bfOid: BfGid, bfGid: BfGid) {
+    return bfGetItem<T>(bfOid, bfGid);
+  },
+
+  async put<T extends Props, M extends BfMetadataNode | BfMetadataEdge>(
+    props: T,
+    metadata: M,
+  ) {
+    await bfPutItem(props, metadata);
+  },
+
+  query<T extends Props>(
+    metadata: Record<string, unknown>,
+    props: Partial<T> = {},
+    bfGids?: BfGid[],
+    order: "ASC" | "DESC" = "ASC",
+    orderBy?: string,
+    options: Record<string, unknown> = {},
+  ): Promise<DbItem<T>[]> {
+    return bfQueryItems(metadata, props, bfGids, order, orderBy, options);
+  },
+
+  async delete(bfOid: BfGid, bfGid: BfGid) {
+    await bfDeleteItem(bfOid, bfGid);
+  },
+
+  async close() {
+    await bfCloseConnection();
+  },
+} as const;


### PR DESCRIPTION

## SUMMARY
This commit introduces a new storage façade to streamline database operations in the `BfNode.ts` file. The changes involve creating a new module, `storage.ts`, under `apps/bfDb/storage/`, which serves as a temporary façade for existing database helper functions. The primary goal is to abstract the database interaction logic and prepare for potential future refactoring or adapter swaps. The functions `bfGetItem`, `bfPutItem`, and `bfQueryItemsUnified` are replaced with `storage.get`, `storage.put`, and `storage.query`, respectively.

The introduction of `storage.ts` encapsulates the database operations, making it easier to maintain and alter the underlying database logic without affecting the rest of the codebase. The changes are specifically implemented in `BfNode.ts` to utilize this new façade, enhancing modularity and reducing direct dependencies on `bfDb.ts`.

## TEST PLAN
1. **Unit Tests**: Run existing unit tests to ensure that the functionality of `BfNode.ts` remains intact after the refactoring.
2. **Integration Tests**: Verify that all interactions with the database through the `storage` façade yield the expected results.
3. **Manual Testing**: Perform manual testing of critical features that rely on database operations to confirm they behave as expected.
4. **Check for Errors**: Ensure there are no console errors or warnings during the application startup and operation.
5. **Review Log Outputs**: Verify that debug logs in the database operations are correctly displayed, indicating successful replacements with the façade functions.
