### PR TITLE
Refactor metadata generation into utility functions

### DIFF
--- a/apps/bfDb/classes/BfEdgeBase.ts
+++ b/apps/bfDb/classes/BfEdgeBase.ts
@@ -1,3 +1,4 @@
+import { generateEdgeMetadata } from "apps/bfDb/utils/metadata.ts";
 import {
   type BfMetadataBase,
   BfNodeBase,
@@ -39,25 +40,14 @@ export class BfEdgeBase<
    * @param targetNode - The target node to connect to
    * @returns Edge metadata with source and target information
    */
-  static generateEdgeMetadata<
-    TMetadata extends BfMetadataEdgeBase,
-  >(
+  static generateEdgeMetadata<TMetadata extends BfMetadataEdgeBase>(
     cv: BfCurrentViewer,
     sourceNode: BfNodeBase,
     targetNode: BfNodeBase,
-    metadata?: Partial<TMetadata>,
+    metadata: Partial<TMetadata> = {},
   ): TMetadata {
-    // First, get the base metadata from parent class
-    const baseMetadata = this.generateMetadata(cv, metadata);
-
-    // Then add edge-specific fields
-    return {
-      ...baseMetadata,
-      bfSClassName: sourceNode.constructor.name,
-      bfSid: sourceNode.metadata.bfGid,
-      bfTClassName: targetNode.constructor.name,
-      bfTid: targetNode.metadata.bfGid,
-    } as TMetadata;
+    const base = generateEdgeMetadata(cv, sourceNode, targetNode, metadata);
+    return { ...base, className: this.name } as TMetadata;
   }
 
   /**

--- a/apps/bfDb/classes/BfNodeBase.ts
+++ b/apps/bfDb/classes/BfNodeBase.ts
@@ -1,7 +1,7 @@
+import { generateNodeMetadata } from "apps/bfDb/utils/metadata.ts";
 import { BfErrorNodeNotFound } from "apps/bfDb/classes/BfErrorNode.ts";
-import { type BfGid, toBfGid } from "apps/bfDb/classes/BfNodeIds.ts";
+import type { BfGid } from "apps/bfDb/classes/BfNodeIds.ts";
 import type { BfCurrentViewer } from "apps/bfDb/classes/BfCurrentViewer.ts";
-import { generateUUID } from "lib/generateUUID.ts";
 import { getLogger } from "packages/logger/logger.ts";
 import type { JSONValue } from "apps/bfDb/bfDb.ts";
 import { BfErrorNotImplemented } from "infra/BfError.ts";
@@ -52,16 +52,14 @@ export class BfNodeBase<
   >(
     this: TThis,
     cv: BfCurrentViewer,
-    metadata?: Partial<TMetadata>,
+    metadata: Partial<TMetadata> = {},
   ): TMetadata {
-    const bfGid = toBfGid(generateUUID());
-    const defaults = {
-      bfGid: bfGid,
-      bfOid: cv.bfOid,
-      className: this.name,
+    // delegate to the new util and override sortValue so subclasses
+    // can customise it via generateSortValue()
+    return generateNodeMetadata(cv, this.name, {
       sortValue: this.generateSortValue(),
-    } as TMetadata;
-    return { ...defaults, ...metadata } as TMetadata;
+      ...metadata,
+    }) as TMetadata;
   }
 
   static findX<

--- a/apps/bfDb/utils/metadata.ts
+++ b/apps/bfDb/utils/metadata.ts
@@ -1,0 +1,36 @@
+import { toBfGid } from "apps/bfDb/classes/BfNodeIds.ts";
+import { generateUUID } from "lib/generateUUID.ts";
+import type { BfCurrentViewer } from "apps/bfDb/classes/BfCurrentViewer.ts";
+import type { BfMetadataBase } from "apps/bfDb/classes/BfNodeBase.ts";
+import type { BfMetadataEdgeBase } from "apps/bfDb/classes/BfEdgeBase.ts";
+
+/** Generate base node metadata */
+export function generateNodeMetadata<T extends BfMetadataBase>(
+  cv: BfCurrentViewer,
+  className: string,
+  partial: Partial<T> = {},
+): T {
+  return {
+    bfGid: toBfGid(generateUUID()),
+    bfOid: cv.bfOid,
+    className,
+    sortValue: Date.now(),
+    ...(partial as object),
+  } as T;
+}
+
+/** Generate base edge metadata (node + source/target fields) */
+export function generateEdgeMetadata<T extends BfMetadataEdgeBase>(
+  cv: BfCurrentViewer,
+  source: { metadata: { bfGid: string; className: string } },
+  target: { metadata: { bfGid: string; className: string } },
+  partial: Partial<T> = {},
+): T {
+  return {
+    ...generateNodeMetadata(cv, "BfEdgeBase", partial),
+    bfSid: source.metadata.bfGid,
+    bfSClassName: source.metadata.className,
+    bfTid: target.metadata.bfGid,
+    bfTClassName: target.metadata.className,
+  } as T;
+}


### PR DESCRIPTION



## SUMMARY
This commit refactors the metadata generation logic for nodes and edges into standalone utility functions located in `apps/bfDb/utils/metadata.ts`. The refactored functions, `generateNodeMetadata` and `generateEdgeMetadata`, encapsulate the logic for creating metadata, making it reusable across different classes. The changes also involve updating existing classes to use these utility functions instead of inline logic.

For `BfEdgeBase`, the `generateEdgeMetadata` method was simplified by delegating to the new utility function, enriching the resulting metadata with the class name. Similarly, in `BfNodeBase`, the `generateMetadata` method now uses `generateNodeMetadata` and allows subclasses to customize the `sortValue` property.

In `BfNode`, the internal properties handling was also updated. The `_serverProps` and `_clientProps` were consolidated into `_savedProps` and `_props` for cleaner management of the node's properties and their state changes. This change simplifies the logic for determining if a node is "dirty" by comparing JSON strings of the current and saved properties.

## TEST PLAN
1. Verify that the application compiles without errors after the refactoring.
2. Execute existing test cases to ensure that node and edge metadata are generated correctly.
3. Create unit tests for the new utility functions `generateNodeMetadata` and `generateEdgeMetadata` to validate their output given various inputs.
4. Test the `isDirty` method of `BfNode` to ensure it correctly identifies unsaved changes.
5. Confirm that nodes and edges can be created, saved, and retrieved with correct metadata in the database.
