### PR TITLE
Refactor GraphQL conversion and connection logic in BfNodeBase

### DIFF
--- a/apps/bfDb/classes/BfNodeBase.ts
+++ b/apps/bfDb/classes/BfNodeBase.ts
@@ -1,4 +1,9 @@
 import { generateNodeMetadata } from "apps/bfDb/utils/metadata.ts";
+import {
+  connectionFromNodes,
+  type GraphqlNode,
+  toGraphqlFromNode,
+} from "apps/bfDb/graphql/helpers.ts";
 import { BfErrorNodeNotFound } from "apps/bfDb/classes/BfErrorNode.ts";
 import type { BfGid } from "apps/bfDb/classes/BfNodeIds.ts";
 import type { BfCurrentViewer } from "apps/bfDb/classes/BfCurrentViewer.ts";
@@ -177,21 +182,8 @@ export class BfNodeBase<
     return false;
   }
 
-  toGraphql() {
-    const descriptors = Object.getOwnPropertyDescriptors(this);
-    const skippedKeys = ["metadata", "cv", "props"];
-    const getters = Object.entries(descriptors)
-      .filter(([key, descriptor]) =>
-        typeof descriptor.get === "function" && !skippedKeys.includes(key)
-      )
-      .map(([key]) => [key, this[key as keyof this]]);
-
-    return {
-      ...this.props,
-      ...Object.fromEntries(getters),
-      id: this.metadata.bfGid,
-      __typename: this.__typename,
-    };
+  toGraphql(): GraphqlNode {
+    return toGraphqlFromNode(this as unknown as BfNodeBase);
   }
 
   toString() {
@@ -296,17 +288,24 @@ export class BfNodeBase<
    * This method provides a standardized interface for implementing GraphQL connections
    * following the Relay specification
    */
-  queryTargetsConnectionForGraphql<
+  async queryTargetsConnectionForGraphql<
     TTargetProps extends BfNodeBaseProps,
     TTargetClass extends typeof BfNodeBase<TTargetProps>,
   >(
-    _TargetClass: TTargetClass,
-    _args: ConnectionArguments,
-    _props: Partial<TTargetProps> = {},
-    _edgeProps: Partial<Record<string, JSONValue>> = {},
-    _cache?: BfNodeCache,
-  ): Promise<Connection<ReturnType<InstanceType<TTargetClass>["toGraphql"]>>> {
-    throw new BfErrorNotImplemented();
+    TargetClass: TTargetClass,
+    args: ConnectionArguments,
+    props: Partial<TTargetProps> = {},
+    edgeProps: Partial<TEdgeProps> = {},
+    cache?: BfNodeCache,
+  ): Promise<Connection<GraphqlNode>> {
+    const targets = await this.queryTargets(
+      TargetClass,
+      props,
+      edgeProps,
+      cache,
+    );
+    const gNodes = targets.map((n) => n.toGraphql());
+    return connectionFromNodes(gNodes, args);
   }
 
   /** CALLBACKS */

--- a/apps/bfDb/graphql/helpers.ts
+++ b/apps/bfDb/graphql/helpers.ts
@@ -1,0 +1,44 @@
+import {
+  type Connection,
+  type ConnectionArguments,
+  connectionFromArray,
+} from "graphql-relay";
+import type { BfNodeBase } from "apps/bfDb/classes/BfNodeBase.ts";
+
+export type GraphqlNode = Record<string, unknown> & {
+  id: string;
+  __typename: string;
+};
+/**
+ * Convert a BfNodeBase instance into the standard GraphQL representation
+ * (id, __typename, props + computed getters).
+ */
+export function toGraphqlFromNode(node: BfNodeBase): GraphqlNode {
+  const descriptors = Object.getOwnPropertyDescriptors(node as object);
+  const skip = new Set(["metadata", "cv", "props"]);
+
+  const getters = Object.entries(descriptors)
+    .filter(([k, d]) => typeof d.get === "function" && !skip.has(k))
+    // deno-lint-ignore no-explicit-any
+    .map(([k]) => [k, (node as any)[k]]);
+
+  return {
+    // deno-lint-ignore no-explicit-any
+    ...(node as any).props,
+    ...Object.fromEntries(getters),
+    // deno-lint-ignore no-explicit-any
+    id: (node as any).metadata.bfGid,
+    __typename: node.__typename,
+  };
+}
+
+/**
+ * Build a Relay‑style Connection from an array of GraphQL‑ready nodes.
+ */
+export function connectionFromNodes<N>(
+  graphqlNodes: N[],
+  args: ConnectionArguments,
+): Connection<N> {
+  // deno-lint-ignore no-explicit-any
+  return connectionFromArray(graphqlNodes as any[], args) as Connection<N>;
+}


### PR DESCRIPTION

## SUMMARY
This commit refactors the `BfNodeBase` class and its related components to streamline the conversion of node instances to their GraphQL representations and improve the handling of GraphQL connections. Key changes include:

1. **GraphQL Conversion Refactor**: The `toGraphql` method in `BfNodeBase` has been simplified by offloading the conversion logic to a new utility function `toGraphqlFromNode` in the newly created `graphql/helpers.ts` module. This enhances code maintainability and reuse.

2. **Relay Connection Logic Update**: The `queryTargetsConnectionForGraphql` method in both `BfNodeBase` and `BfNodeInMemory` now leverages the new `connectionFromNodes` function to construct GraphQL Relay connections. This change is aimed at unifying the connection creation logic and removing redundant code.

3. **Code Cleanup and Type Improvements**: Updated various function signatures and type annotations to improve type safety and readability. Removed redundant comments and improved the documentation of methods to better reflect their current implementations.

These changes are intended to improve the clarity, maintainability, and efficiency of the codebase related to GraphQL operations.

## TEST PLAN
1. **Unit Tests**: Run existing unit tests to ensure no regressions have been introduced. Focus particularly on tests related to node creation, querying, and GraphQL conversion.

2. **Integration Tests**: Execute integration tests that cover GraphQL API endpoints to validate the correctness of the connections and data transformations.

3. **Manual Testing**: Perform manual testing of key GraphQL queries and mutations to verify that the refactored methods behave as expected within the application context.

4. **Code Review**: Conduct a code review to ensure that the refactoring aligns with the project's coding standards and that all changes are well-documented and justified.
