### PR TITLE
Add AdapterRegistry tests with intentional red state

### DIFF
--- a/apps/bfDb/backend/__tests__/adapterRegistry.test.ts
+++ b/apps/bfDb/backend/__tests__/adapterRegistry.test.ts
@@ -1,0 +1,22 @@
+#! /usr/bin/env -S bff test
+import { assertEquals, assertThrows } from "@std/assert";
+import { AdapterRegistry } from "../../storage/AdapterRegistry.ts";
+
+// Dummy adapter that fulfils the (aliased) interface shape at compile‑time.
+// Cast as `never` for now – we never call its methods in this test.
+const dummyAdapter = {} as never;
+
+Deno.test("AdapterRegistry.get throws before register()", () => {
+  AdapterRegistry.clear();
+  assertThrows(() => AdapterRegistry.get());
+});
+
+Deno.test("AdapterRegistry registers & returns the same instance", () => {
+  AdapterRegistry.clear();
+  AdapterRegistry.register(dummyAdapter);
+
+  // ↓ This *should* return the adapter we just registered.
+  // With the current stub, `get()` still throws, so this test fails (red).
+  const active = AdapterRegistry.get();
+  assertEquals(active, dummyAdapter);
+});

--- a/apps/bfDb/classes/__tests__/BfEdgeBaseTest.ts
+++ b/apps/bfDb/classes/__tests__/BfEdgeBaseTest.ts
@@ -7,6 +7,9 @@ import { BfCurrentViewer } from "apps/bfDb/classes/BfCurrentViewer.ts";
 import type { BfMetadataEdge } from "apps/bfDb/coreModels/BfEdge.ts";
 import { BfNodeInMemory } from "apps/bfDb/coreModels/BfNodeInMemory.ts";
 import { withIsolatedDb } from "apps/bfDb/bfDb.ts";
+// import { AdapterRegistry } from "apps/bfDb/storage/AdapterRegistry.ts";
+// import { InMemoryAdapter } from "apps/bfDb/storage/InMemoryAdapter.ts";
+// AdapterRegistry.register(new InMemoryAdapter());
 
 export function testBfEdgeBase<
   TEdgeProps extends BfEdgeBaseProps,

--- a/apps/bfDb/classes/__tests__/BfNodeBaseTest.ts
+++ b/apps/bfDb/classes/__tests__/BfNodeBaseTest.ts
@@ -3,6 +3,9 @@ import { BfCurrentViewer } from "apps/bfDb/classes/BfCurrentViewer.ts";
 import type { BfNodeBase } from "apps/bfDb/classes/BfNodeBase.ts";
 import { getLogger } from "packages/logger/logger.ts";
 import { BfErrorNodeNotFound } from "apps/bfDb/classes/BfErrorNode.ts";
+// import { AdapterRegistry } from "apps/bfDb/storage/AdapterRegistry.ts";
+// import { InMemoryAdapter } from "apps/bfDb/storage/InMemoryAdapter.ts";
+// AdapterRegistry.register(new InMemoryAdapter());
 
 const _logger = getLogger(import.meta);
 

--- a/apps/bfDb/storage/AdapterRegistry.ts
+++ b/apps/bfDb/storage/AdapterRegistry.ts
@@ -1,0 +1,35 @@
+// Temporary stub — just enough for imports to compile.
+// Real implementation will track an active adapter and expose get()/register().
+
+/**
+ * Generic contract every backend adapter must fulfil.
+ * For now we alias the existing DatabaseBackend interface so we don't
+ * break any imports while refactoring.
+ */
+export type IBackendAdapter =
+  import("../backend/DatabaseBackend.ts").DatabaseBackend;
+
+export class AdapterRegistry {
+  // We intentionally start with `null` so tests that call `get()` without
+  // registering will throw — giving us a clear red state.
+  private static _active: IBackendAdapter | null = null;
+
+  static register(adapter: IBackendAdapter) {
+    this._active = adapter;
+  }
+
+  /**
+   * Returns the currently‑active adapter or throws if none registered.
+   * Keeping the throw ensures existing tests fail until we wire up
+   * the correct adapter in each suite.
+   */
+  static get(): IBackendAdapter {
+    throw new Error("AdapterRegistry.get(): no adapter registered yet (stub)");
+    // return this._active!;  // <- real impl will return and maybe throw
+  }
+
+  /** Test helper to clear registry between suites */
+  static clear() {
+    this._active = null;
+  }
+}


### PR DESCRIPTION

## SUMMARY
This commit introduces a new test suite for the `AdapterRegistry` class, which is designed to manage backend adapters. The `adapterRegistry.test.ts` file was added to test the `AdapterRegistry`'s behavior. The test suite intentionally results in a red state by not implementing a functional `get()` method in the `AdapterRegistry`. The purpose is to ensure that `get()` throws an error when called without a prior adapter registration. Additionally, comments were added in `BfEdgeBaseTest.ts` and `BfNodeBaseTest.ts` to document the potential use of the `AdapterRegistry` and `InMemoryAdapter` in future tests. The `AdapterRegistry.ts` file is a temporary stub with minimal implementation to allow successful compilation of imports. This setup is part of a larger refactoring effort and currently serves as a placeholder to facilitate the testing process.

## TEST PLAN
1. Run the test suite using the command specified in the test file's shebang (`bff test`) to verify the intentional red state.
2. Confirm that the `AdapterRegistry.get()` method throws an error as expected when no adapter is registered.
3. Ensure that the `AdapterRegistry.register()` method successfully registers an adapter and that the test for returning the registered instance fails due to the stub implementation.
4. Review the added comments in `BfEdgeBaseTest.ts` and `BfNodeBaseTest.ts` for clarity and future reference.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/639).
* #640
* __->__ #639