### PR TITLE
Add failing test for automatic adapter registration in withIsolatedDb

### DIFF
--- a/apps/bfDb/storage/__tests__/AdapterDefaultRegistration.test.ts
+++ b/apps/bfDb/storage/__tests__/AdapterDefaultRegistration.test.ts
@@ -1,0 +1,36 @@
+#! /usr/bin/env -S bff test
+
+// ------------------------------------------------------------------
+// RED‑phase test: proves that withIsolatedDb automatically registers a
+// backend adapter (InMemory by default).
+// This will FAIL until we implement `registerDefaultAdapter()` and wire it
+// into withIsolatedDb (Refactors #6/#7).
+// ------------------------------------------------------------------
+import { assertExists } from "@std/assert";
+import { withIsolatedDb } from "apps/bfDb/bfDb.ts";
+import { BfCurrentViewer } from "apps/bfDb/classes/BfCurrentViewer.ts";
+import { BfNode } from "apps/bfDb/coreModels/BfNode.ts";
+import { AdapterRegistry } from "apps/bfDb/storage/AdapterRegistry.ts";
+
+// Simple dummy node model for the test
+class TestNode extends BfNode<{ name: string }> {}
+
+Deno.test("withIsolatedDb auto‑registers adapter (future green)", async () => {
+  await withIsolatedDb(async () => {
+    const cv = BfCurrentViewer.__DANGEROUS_USE_IN_SCRIPTS_ONLY__createLoggedIn(
+      import.meta,
+      "tester",
+      "tester",
+    );
+
+    // Creating a node should not throw even though we didn't manually register an adapter.
+    const node = await TestNode.__DANGEROUS__createUnattached(cv, {
+      name: "auto",
+    });
+    assertExists(node);
+
+    // And the adapter registry should have an active adapter.
+    const adapter = AdapterRegistry.get();
+    assertExists(adapter);
+  });
+});


### PR DESCRIPTION

## SUMMARY
This commit introduces a new test file `AdapterDefaultRegistration.test.ts` that contains a RED-phase test for the `withIsolatedDb` function. The test is designed to fail intentionally until the `registerDefaultAdapter()` function is implemented and integrated into `withIsolatedDb`. The test ensures that a backend adapter is automatically registered, specifically the `InMemory` adapter by default, without manual intervention. This sets the stage for future functionality (related to Refactors #6/#7) where `withIsolatedDb` should automatically handle adapter registration.

## TEST PLAN
1. Run the test suite using the command specified in the shebang (`bff test`).
2. Confirm that the new test fails, as expected, due to the absence of the `registerDefaultAdapter()` implementation.
3. Implement `registerDefaultAdapter()` in future commits and integrate it with `withIsolatedDb`.
4. Re-run the test suite to ensure the test passes once the implementation is complete.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/641).
* #645
* #644
* #643
* #642
* __->__ #641