### PR TITLE
Add GraphQL builder with test for defining nodes and relations

### DIFF
--- a/apps/bfDb/graphql/__tests__/builder.test.ts
+++ b/apps/bfDb/graphql/__tests__/builder.test.ts
@@ -1,0 +1,52 @@
+#! /usr/bin/env -S bff test
+import { defineGqlNode, Direction } from "apps/bfDb/graphql/builder.ts";
+import { assertEquals, assertExists } from "@std/assert";
+import { BfNode } from "apps/bfDb/coreModels/BfNode.ts";
+
+Deno.test("defineGqlNode – full DSL", () => {
+  const spec = defineGqlNode((field, relation, mutation) => {
+    field.id("id");
+    field.string("name");
+    field.nullable.int("age");
+    field.boolean(
+      "isFollowedByViewer",
+      { viewerId: "id" },
+      () => true,
+    );
+
+    relation.one("account", () => BfNode);
+    relation.many.in("followers", () => BfNode);
+    relation.one.in("likedByViewer", () => BfNode);
+
+    // — mutations —
+    mutation.update()
+      .delete()
+      .custom(
+        "greet",
+        { to: "string" },
+        (src, { to }) => `hi ${to}, I'm ${src.props.name}`,
+      );
+  });
+
+  // ------------------------------------------------------------------
+  //  Field store checks
+  // ------------------------------------------------------------------
+  assertExists(spec.field.id);
+  assertEquals(spec.field.age.nullable, true);
+  assertEquals(spec.field.isFollowedByViewer.args?.viewerId, "id");
+
+  // ------------------------------------------------------------------
+  //  Relation store checks
+  // ------------------------------------------------------------------
+  assertEquals(spec.relation.account.direction, Direction.OUT);
+  assertEquals(spec.relation.followers.many, true);
+  assertEquals(spec.relation.followers.direction, Direction.IN);
+
+  // ------------------------------------------------------------------
+  //  Mutation spec checks
+  // ------------------------------------------------------------------
+  assertEquals(spec.mutation.standard.update, true);
+  assertEquals(spec.mutation.standard.delete, true);
+  assertEquals(spec.mutation.customs.length, 1);
+  assertEquals(spec.mutation.customs[0].name, "greet");
+});

--- a/apps/bfDb/graphql/builder.ts
+++ b/apps/bfDb/graphql/builder.ts
@@ -1,0 +1,244 @@
+import type { BfNodeBase } from "apps/bfDb/classes/BfNodeBase.ts";
+import type { BfEdgeBase } from "apps/bfDb/classes/BfEdgeBase.ts";
+import type { Context } from "apps/bfDb/graphql/graphqlContext.ts";
+
+export type GqlScalar = "id" | "string" | "int" | "float" | "boolean" | "json";
+
+export enum Direction {
+  OUT = "OUT",
+  IN = "IN",
+}
+
+export type FieldSpec = {
+  type: GqlScalar;
+  nullable: boolean;
+  args?: Record<string, GqlScalar>;
+  resolver?: (
+    src: BfNodeBase,
+    args: unknown,
+    ctx: Context,
+  ) => unknown | Promise<unknown>;
+};
+
+export type RelationSpec = {
+  target: () => typeof BfNodeBase;
+  many: boolean;
+  edge?: () => typeof BfEdgeBase;
+  direction: Direction;
+};
+
+type AddFieldFn = <
+  Name extends string,
+  Args extends Record<string, GqlScalar> | undefined = undefined,
+  Res extends FieldSpec["resolver"] | undefined = undefined,
+>(
+  name: Name,
+  argOrRes?: Args | Res,
+  maybeRes?: Res,
+) => FieldBuilder;
+
+interface FieldBuilder {
+  id: AddFieldFn;
+  string: AddFieldFn;
+  int: AddFieldFn;
+  float: AddFieldFn;
+  boolean: AddFieldFn;
+  json: AddFieldFn;
+  nullable: {
+    string: AddFieldFn;
+    int: AddFieldFn;
+    float: AddFieldFn;
+    boolean: AddFieldFn;
+    json: AddFieldFn;
+  };
+}
+
+function buildField(store: Record<string, FieldSpec>): FieldBuilder {
+  type Res = FieldSpec["resolver"];
+  const save = (
+    name: string,
+    type: GqlScalar,
+    nullable: boolean,
+    args?: Record<string, GqlScalar>,
+    resolver?: Res,
+  ) => {
+    store[name] = { type, nullable, args, resolver };
+    return api;
+  };
+
+  const add = (type: GqlScalar, nullable = false): AddFieldFn =>
+  (
+    name,
+    argOrRes,
+    maybeRes,
+  ) => {
+    const args = typeof argOrRes === "object" && argOrRes
+      ? (argOrRes as Record<string, GqlScalar>)
+      : undefined;
+    const resolver = typeof argOrRes === "function"
+      ? (argOrRes as Res)
+      : maybeRes;
+    return save(name, type, nullable, args, resolver);
+  };
+
+  const api = {
+    id: add("id"),
+    string: add("string"),
+    int: add("int"),
+    float: add("float"),
+    boolean: add("boolean"),
+    json: add("json"),
+    nullable: {
+      string: add("string", true),
+      int: add("int", true),
+      float: add("float", true),
+      boolean: add("boolean", true),
+      json: add("json", true),
+    },
+  } satisfies FieldBuilder;
+
+  return api;
+}
+
+// Generic callable that also carries properties (intersection
+type MergeCallable<T, U> = T & U;
+
+type AddRelationFn<_M extends boolean, _D extends Direction> = <
+  Name extends string,
+>(
+  name: Name,
+  target: () => typeof BfNodeBase,
+  opts?: Partial<Omit<RelationSpec, "target" | "many" | "direction">>,
+) => RelationBuilder;
+
+interface OneDirBuilder {
+  out: AddRelationFn<false, Direction.OUT>;
+  in: AddRelationFn<false, Direction.IN>;
+}
+
+interface ManyDirBuilder {
+  out: AddRelationFn<true, Direction.OUT>;
+  in: AddRelationFn<true, Direction.IN>;
+}
+
+interface RelationBuilder {
+  one: MergeCallable<AddRelationFn<false, Direction.OUT>, OneDirBuilder>;
+  many: MergeCallable<AddRelationFn<true, Direction.OUT>, ManyDirBuilder>;
+}
+
+function buildRelation(store: Record<string, RelationSpec>): RelationBuilder {
+  const add = <M extends boolean, D extends Direction>(
+    many: M,
+    direction: D,
+  ): AddRelationFn<M, D> =>
+    ((name, target, opts = {}) => {
+      store[name] = { target, many, direction, edge: opts.edge };
+      return api;
+    }) as AddRelationFn<M, D>;
+
+  const oneDir = {
+    out: add(false, Direction.OUT),
+    in: add(false, Direction.IN),
+  } as const;
+
+  const manyDir = {
+    out: add(true, Direction.OUT),
+    in: add(true, Direction.IN),
+  } as const;
+
+  // callable aliases so relation.one(...) defaults to .one.out(...)
+  const oneAlias =
+    ((name, target, opts?) =>
+      oneDir.out(name, target, opts)) as RelationBuilder["one"];
+  Object.assign(oneAlias, oneDir);
+
+  const manyAlias =
+    ((name, target, opts?) =>
+      manyDir.out(name, target, opts)) as RelationBuilder["many"];
+  Object.assign(manyAlias, manyDir);
+
+  const api: RelationBuilder = {
+    one: oneAlias,
+    many: manyAlias,
+  };
+
+  return api;
+}
+
+export type StandardMutations = {
+  update: boolean;
+  delete: boolean;
+};
+
+export type CustomMutation = {
+  name: string;
+  args: Record<string, GqlScalar>;
+  resolver: (
+    src: InstanceType<typeof BfNodeBase>,
+    args: Record<string, unknown>,
+    ctx: Context,
+  ) => unknown | Promise<unknown>;
+};
+
+export type MutationSpec = {
+  createdBy?: {
+    parent: () => typeof BfNodeBase;
+    relation?: string;
+    name?: string;
+  };
+  standard: StandardMutations;
+  customs: CustomMutation[];
+};
+
+function buildMutation() {
+  const spec: MutationSpec = {
+    standard: { update: false, delete: false },
+    customs: [],
+  };
+  return {
+    createdBy(
+      parent: () => typeof BfNodeBase,
+      opts: Partial<{ relation: string; name: string }> = {},
+    ) {
+      spec.createdBy = { parent, ...opts };
+      return this;
+    },
+    update() {
+      spec.standard.update = true;
+      return this;
+    },
+    delete() {
+      spec.standard.delete = true;
+      return this;
+    },
+    custom(
+      name: string,
+      args: Record<string, GqlScalar>,
+      resolver: CustomMutation["resolver"],
+    ) {
+      spec.customs.push({ name, args, resolver });
+      return this;
+    },
+    _build() {
+      return spec;
+    },
+  } as const;
+}
+
+export function defineGqlNode(
+  def: (
+    field: ReturnType<typeof buildField>,
+    relation: ReturnType<typeof buildRelation>,
+    mutation: ReturnType<typeof buildMutation>,
+  ) => void,
+) {
+  const fieldStore: Record<string, FieldSpec> = {};
+  const relationStore: Record<string, RelationSpec> = {};
+  const mutBuilder = buildMutation();
+  def(buildField(fieldStore), buildRelation(relationStore), mutBuilder);
+  return {
+    field: fieldStore,
+    relation: relationStore,
+    mutation: mutBuilder._build(),
+  } as const;
+}


### PR DESCRIPTION

## SUMMARY
This commit introduces a new GraphQL builder utility in the `builder.ts` file, designed to facilitate the definition of GraphQL nodes and their properties, relations, and mutations. The builder provides a DSL (Domain Specific Language) for defining fields, relations, and mutations for nodes in a structured and type-safe manner. It supports various scalar types, nullable fields, and allows for custom resolver functions.

Additionally, a test suite (`builder.test.ts`) is added to ensure the functionality of the GraphQL builder. The test verifies the correct definition and storage of node fields, relations, and mutation specifications using the `defineGqlNode` function.

## TEST PLAN
1. Run the test suite located in `builder.test.ts` to ensure all tests pass and validate the expected behavior of the GraphQL builder.
2. Verify that fields, relations, and mutations are correctly defined and stored by checking the assertions in the test cases.
3. Ensure that the builder handles nullable fields and custom mutations as specified in the test.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/647).
* #651
* #650
* #649
* #648
* __->__ #647