### PR TITLE
Add PostHog analytics tracking to BFF commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
           cd $GITHUB_WORKSPACE
           # Use the cached profile for the development shell
           nix develop . --impure --profile /tmp/nix-shell-cache/profile --command bash -c "
-            bff ci -g
+            bff ci -g --include-bolt-foundry
           "
 
       - name: Upload test screenshots

--- a/infra/bff/bff.ts
+++ b/infra/bff/bff.ts
@@ -1,4 +1,6 @@
 #! /usr/bin/env -S deno run -A
+import { trackBffCommand } from "./posthogTracker.ts";
+
 type BffCommand = (options: Array<string>) => number | Promise<number>;
 
 type Friend = {
@@ -22,20 +24,22 @@ function wordWrap(str: string, maxWidth: number) {
 friendMap.set("help", {
   description: "Prints this help message.",
   options: [],
-  command: () => {
-    let commands = Array.from(friendMap.entries());
+  command: async (cmdOptions) => {
+    const startTime = performance.now();
+    try {
+      let commands = Array.from(friendMap.entries());
 
-    // Sort the commands alphabetically.
-    commands = commands.sort((a, b) => a[0].localeCompare(b[0]));
+      // Sort the commands alphabetically.
+      commands = commands.sort((a, b) => a[0].localeCompare(b[0]));
 
-    // Compute the maximum length of command names.
-    const longestNameLength = commands.reduce(
-      (max, [name]) => Math.max(max, name.length),
-      0,
-    );
+      // Compute the maximum length of command names.
+      const longestNameLength = commands.reduce(
+        (max, [name]) => Math.max(max, name.length),
+        0,
+      );
 
-    // deno-lint-ignore no-console
-    console.log(`bff: Your bolt foundry best friend forever.
+      // deno-lint-ignore no-console
+      console.log(`bff: Your bolt foundry best friend forever.
 
       This is a task runner meant to make it simpler to develop our app and company.
 
@@ -44,18 +48,25 @@ friendMap.set("help", {
 
       Friends:
         ${
-      commands.map(([name, { description }]) =>
-        (`${name.padEnd(longestNameLength + 5)} ${description}`).padEnd(80, " ")
-      ).join("\n        ")
-    }
+        commands.map(([name, { description }]) =>
+          (`${name.padEnd(longestNameLength + 5)} ${description}`).padEnd(
+            80,
+            " ",
+          )
+        ).join("\n        ")
+      }
 
       ${
-      wordWrap(
-        `To add a friend, create a file in the "bff/friends" directory that ends with ".bff.ts" and export a function that takes an array of strings as its first argument and a string as its second argument. The first argument is the list of options passed to the friend. The second argument is the current working directory. The function should return a promise that resolves when the friend is done running.\n\n`,
-        80,
-      )
-    }`);
-    return 0;
+        wordWrap(
+          `To add a friend, create a file in the "bff/friends" directory that ends with ".bff.ts" and export a function that takes an array of strings as its first argument and a string as its second argument. The first argument is the list of options passed to the friend. The second argument is the current working directory. The function should return a promise that resolves when the friend is done running.\n\n`,
+          80,
+        )
+      }`);
+      return 0;
+    } finally {
+      const duration = performance.now() - startTime;
+      await trackBffCommand("help", cmdOptions, true, duration);
+    }
   },
 });
 
@@ -65,5 +76,24 @@ export function register(
   command: BffCommand,
   options = [],
 ) {
-  friendMap.set(name, { description, options, command });
+  // Wrap the command with analytics tracking
+  const wrappedCommand: BffCommand = async (cmdOptions) => {
+    const startTime = performance.now();
+    let success = true;
+    let exitCode = 0;
+
+    try {
+      exitCode = await command(cmdOptions);
+      success = exitCode === 0;
+      return exitCode;
+    } catch (error) {
+      success = false;
+      throw error;
+    } finally {
+      const duration = performance.now() - startTime;
+      await trackBffCommand(name, cmdOptions, success, duration);
+    }
+  };
+
+  friendMap.set(name, { description, options, command: wrappedCommand });
 }

--- a/infra/bff/friends/ci.bff.ts
+++ b/infra/bff/friends/ci.bff.ts
@@ -258,10 +258,18 @@ function parseDenoFmtOutput(fullOutput: string) {
 // 3. Build step
 // ----------------------------------------------------------------------------
 
-async function runBuildStep(useGithub: boolean): Promise<number> {
+async function runBuildStep(
+  useGithub: boolean,
+  args: string[],
+): Promise<number> {
   logger.info("Running bff build");
+  // Include bolt-foundry in CI builds if the flag is passed
+  const buildArgs = args.includes("--include-bolt-foundry")
+    ? ["bff", "build", "--include-bolt-foundry"]
+    : ["bff", "build"];
+
   const { code } = await runShellCommandWithOutput(
-    ["bff", "build"],
+    buildArgs,
     {},
     /* useSpinner */ true,
     /* silent */ useGithub,
@@ -354,7 +362,7 @@ async function ciCommand(options: string[]) {
   const installResult = await runInstallStep(useGithub);
 
   // 2) Build step
-  const buildResult = await runBuildStep(useGithub);
+  const buildResult = await runBuildStep(useGithub, options);
 
   // 3) Lint (with or without JSON mode)
   const lintResult = await runLintStep(useGithub);

--- a/infra/bff/friends/land.bff.ts
+++ b/infra/bff/friends/land.bff.ts
@@ -86,11 +86,12 @@ export async function land(): Promise<number> {
     return installResult;
   }
 
-  // Build BFF
-  logger.info("Building BFF...");
+  // Build BFF with bolt-foundry package
+  logger.info("Building BFF with bolt-foundry package...");
   const buildResult = await runShellCommand([
     "bff",
     "build",
+    "--include-bolt-foundry",
   ]);
 
   if (buildResult !== 0) {

--- a/infra/bff/posthogTracker.ts
+++ b/infra/bff/posthogTracker.ts
@@ -1,0 +1,123 @@
+import { getLogger } from "packages/logger/logger.ts";
+import { getConfigurationVariable } from "@bolt-foundry/get-configuration-var";
+import { PostHog } from "posthog-node";
+
+const logger = getLogger(import.meta);
+
+let posthogClient: PostHog | null = null;
+
+/**
+ * Initialize the PostHog client if not already initialized
+ */
+export function initPosthog(): PostHog | null {
+  if (posthogClient) {
+    return posthogClient;
+  }
+
+  const posthogApiKey = getConfigurationVariable(
+    "APPS_INTERNALBF_POSTHOG_API_KEY",
+  );
+
+  if (!posthogApiKey) {
+    logger.debug("PostHog API key not found, analytics disabled");
+    return null;
+  }
+
+  try {
+    posthogClient = new PostHog(posthogApiKey, {
+      host: "https://us.i.posthog.com",
+    });
+    logger.debug("PostHog client initialized successfully");
+    return posthogClient;
+  } catch (error) {
+    logger.error("Failed to initialize PostHog client", error);
+    return null;
+  }
+}
+
+/**
+ * Track a BFF command execution
+ * @param command The name of the command
+ * @param options Command options/arguments
+ * @param success Whether the command executed successfully
+ * @param duration Duration in milliseconds
+ */
+export async function trackBffCommand(
+  command: string,
+  options: string[] = [],
+  success = true,
+  duration = 0,
+): Promise<void> {
+  try {
+    const client = initPosthog();
+    if (!client) {
+      return;
+    }
+
+    let userLogin = "unknown";
+    const userFilePath = "tmp/user.json";
+
+    // Check if user.json exists
+    try {
+      let userJson: { login?: string } = {};
+      try {
+        // Try to read the user file if it exists
+        const userFileContent = await Deno.readTextFile(userFilePath);
+        userJson = JSON.parse(userFileContent);
+      } catch (_fileError) {
+        // File doesn't exist or couldn't be read, fetch from GitHub API
+        logger.debug("User file not found, fetching from GitHub API");
+        const command = new Deno.Command("gh", {
+          args: ["api", "user"],
+          stdout: "piped",
+        });
+
+        const process = command.spawn();
+        const { stdout, code } = await process.output();
+
+        if (!code) {
+          const decoder = new TextDecoder();
+          const userData = decoder.decode(stdout);
+
+          // Save the user data to file
+          await Deno.writeTextFile(userFilePath, userData);
+
+          // Parse the user data
+          userJson = JSON.parse(userData);
+        }
+      }
+
+      // Extract login from user data
+      if (userJson && userJson.login) {
+        userLogin = userJson.login;
+        logger.debug(`Using GitHub login for tracking: ${userLogin}`);
+      }
+    } catch (userError) {
+      logger.debug("Error getting GitHub user info", userError);
+    }
+
+    const distinctId = userLogin;
+
+    client.capture({
+      distinctId,
+      event: `bff ${command} executed`,
+      properties: {
+        command,
+        options: options.join(" "),
+        arguments_count: options.length,
+        success,
+        duration_ms: duration,
+        os: Deno.build.os,
+        hostname: Deno.hostname(),
+        github_user: userLogin,
+      },
+    });
+
+    await client.flush();
+    await client.shutdown();
+    logger.debug(`Tracked BFF command: ${command}`);
+  } catch (error) {
+    // Don't let analytics errors affect BFF functionality
+    logger.debug("Error tracking BFF command", error);
+  }
+}


### PR DESCRIPTION

## SUMMARY
This commit introduces analytics tracking for BFF (Bolt Foundry Friend) commands using PostHog. The `help` command and other BFF commands are now wrapped to log their execution details such as command name, options, success status, and execution duration. A new module `posthogTracker.ts` was added to handle the initialization and tracking logic. This includes reading user details from a local file or fetching from the GitHub API if necessary, and sending the captured data to PostHog. The analytics are designed not to interfere with the normal operation of the BFF commands, ensuring robust command execution.

## TEST PLAN
1. Ensure the PostHog API key is configured correctly in the environment.
2. Run the BFF `help` command and verify that it executes without errors.
3. Check the PostHog dashboard to confirm that the `help` command execution is logged with correct details.
4. Test the execution of other BFF commands and verify they are also tracked correctly.
5. Simulate failure scenarios (e.g., invalid command) and ensure that the tracking correctly logs these as unsuccessful executions.
6. Check the system logs for any errors related to PostHog tracking to ensure the robustness of the tracking implementation.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/653).
* __->__ #653
* #652