### PR TITLE
Remove unused getCurrentViewerApiKey function

### DIFF
--- a/apps/collector/collector.ts
+++ b/apps/collector/collector.ts
@@ -8,10 +8,6 @@ import { trackLlmEvent } from "apps/collector/llm-event-tracker.ts";
 
 const logger = getLogger(import.meta);
 
-function getCurrentViewerApiKey() {
-  return Deno.env.get("APPS_COLLECTOR_STANIFY_POSTHOG_API_KEY") ?? "anon";
-}
-
 // Define routes for the collector service
 function registerCollectorRoutes(): Map<string, Handler> {
   const routes = new Map<string, Handler>();
@@ -36,9 +32,8 @@ function registerCollectorRoutes(): Map<string, Handler> {
         payload = await req.json();
         logger.info("Received Bolt Foundry request for ", bfApiKey);
         logger.debug("Received data:", payload);
-        const currentViewerApiKey = getCurrentViewerApiKey();
         appPosthog?.capture({
-          distinctId: currentViewerApiKey,
+          distinctId: bfApiKey,
           event: "collector:ingest",
         });
         await trackLlmEvent(payload, userPosthog);


### PR DESCRIPTION
## SUMMARY
The `getCurrentViewerApiKey` function has been removed from the `collector.ts` file as it was no longer needed. Previously, this function was used to fetch an API key from the environment variables, defaulting to "anon" if not set. The code now directly uses `bfApiKey` as the `distinctId` when capturing events with `appPosthog`, making the `getCurrentViewerApiKey` function redundant. This change simplifies the code by eliminating unnecessary function calls and environment variable dependencies.

## TEST PLAN
1. Ensure the application builds successfully without errors.
2. Verify that the collector service runs without issues.
3. Test the `collector:ingest` event capturing to confirm it uses `bfApiKey` as the `distinctId`.
4. Check logs to ensure no references to `getCurrentViewerApiKey` are executed or cause errors.

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/655)
<!-- GitContextEnd -->