### PR TITLE
Add tests for BfPerson login scenarios and new error class

### DIFF
--- a/apps/bfDb/classes/BfErrorNode.ts
+++ b/apps/bfDb/classes/BfErrorNode.ts
@@ -7,3 +7,9 @@ export class BfErrorNodeNotFound extends BfErrorNode {
     super(message);
   }
 }
+
+export class BfErrorOrganizationNotAllowed extends BfErrorNode {
+  constructor(message = "Organization not allowed") {
+    super(message);
+  }
+}

--- a/apps/bfDb/models/__tests__/BfPerson.test.ts
+++ b/apps/bfDb/models/__tests__/BfPerson.test.ts
@@ -1,0 +1,108 @@
+#! /usr/bin/env -S bff test
+
+// -----------------------------------------------------------------------------
+// @ts-nocheck – Red test
+// -----------------------------------------------------------------------------
+
+import { withIsolatedDb } from "apps/bfDb/bfDb.ts";
+import { assertEquals, assertExists, assertRejects } from "@std/assert";
+import { BfCurrentViewer } from "apps/bfDb/classes/BfCurrentViewer.ts";
+import { BfPerson } from "apps/bfDb/models/BfPerson.ts";
+import { BfOrganization } from "apps/bfDb/models/BfOrganization.ts";
+import { BfErrorOrganizationNotAllowed } from "apps/bfDb/classes/BfErrorNode.ts";
+
+/**
+ * Build a minimal mock of the Google ID‑token payload we care about for Phase A
+ */
+function mockGooglePayload(email: string) {
+  return {
+    email,
+    email_verified: true,
+    hd: email.split("@")[1], // hosted domain
+    sub: "google-oauth-user-id",
+    given_name: "Test",
+    family_name: "User",
+    picture: "https://example.com/avatar.png",
+  };
+}
+
+Deno.test(
+  "googleLogin › returns existing user when they already exist",
+  async () => {
+    await withIsolatedDb(async () => {
+      const cv = BfCurrentViewer
+        .__DANGEROUS_USE_IN_SCRIPTS_ONLY__createLoggedIn(
+          import.meta,
+          "test",
+          "test",
+        );
+
+      // Seed an existing person in the DB
+      const existing = await BfPerson.__DANGEROUS__createUnattached(cv, {
+        email: "alice@example.com",
+        name: "Alice Example",
+      });
+
+      // Attempt login with same email – should return the same person
+      const person = await BfPerson.verifyLogin(
+        cv,
+        "alice@example.com",
+        mockGooglePayload("alice@example.com"),
+      );
+
+      assertEquals(person.metadata.bfGid, existing.metadata.bfGid);
+    });
+  },
+);
+
+Deno.test(
+  "googleLogin › first‑time login creates a Person *and* an Organization",
+  async () => {
+    await withIsolatedDb(async () => {
+      const cv = BfCurrentViewer
+        .__DANGEROUS_USE_IN_SCRIPTS_ONLY__createLoggedIn(
+          import.meta,
+          "test",
+          "test",
+        );
+
+      const email = "newuser@boltfoundry.io";
+
+      const person = await BfPerson.verifyLogin(
+        cv,
+        email,
+        mockGooglePayload(email),
+      );
+
+      // Person exists
+      assertExists(person.metadata.bfGid);
+
+      // Person should own exactly one org on first login
+      const orgs = await person.queryTargets(BfOrganization);
+      assertEquals(orgs.length, 1);
+      assertExists(orgs[0].metadata.bfGid);
+    });
+  },
+);
+
+Deno.test(
+  "googleLogin › rejects sign‑in when the e‑mail domain is not allowed",
+  async () => {
+    await withIsolatedDb(async () => {
+      const cv = BfCurrentViewer
+        .__DANGEROUS_USE_IN_SCRIPTS_ONLY__createLoggedIn(
+          import.meta,
+          "test",
+          "test",
+        );
+
+      const badEmail = "nogmail@gmail.com";
+
+      await assertRejects(
+        async () =>
+          await BfPerson.verifyLogin(cv, badEmail, mockGooglePayload(badEmail)),
+        BfErrorOrganizationNotAllowed,
+      );
+    });
+  },
+);

--- a/apps/bfDb/testUtils/testViewers.ts
+++ b/apps/bfDb/testUtils/testViewers.ts
@@ -1,0 +1,1 @@
+export const anonViewer = {};

--- a/apps/boltFoundry/docs/0.1/project-plan.md
+++ b/apps/boltFoundry/docs/0.1/project-plan.md
@@ -1,0 +1,150 @@
+# Bolt Foundry – Google‑Only Login Route Plan
+
+---
+
+## Next Action:
+
+Begin **Phase A – Data‑Model & GraphQL Contract**:
+
+1. Add `domain` prop to `BfOrganization` (JSON schema + migration).
+2. Create `OrganizationRole` enum (`OWNER`, `ADMIN`, `MEMBER`).
+3. Implement `BfEdgeOrganizationMember` edge class.
+4. Add `loginWithGoogle(token: String!): AuthPayload` to the GraphQL schema.
+
+Once these backend pieces compile and unit tests pass, proceed to Phase B to
+implement the resolver logic.
+
+[📄 ChatGPT Canvas](https://chatgpt.com/canvas/shared/680670148f188191a1cd20b4910e3453)
+
+---
+
+## 1 Goals & Scope
+
+- Authenticate visitors exclusively via **Sign‑in with Google** using **Google
+  Identity Services (GIS)**, which automatically leverages **FedCM** in Chrome.
+- `/login` route shows a Google sign‑in button (and One‑Tap prompt when
+  permitted).
+- Protected pages redirect to `/login` when session missing.
+
+## 2 Success Criteria
+
+- GIS One‑Tap or button flow yields an ID‑token that logs the user in.
+- Browser shows FedCM account‑chooser dialog in Chrome ≥108; other browsers fall
+  back to GIS legacy flow.
+- Session persisted via secure HttpOnly cookie; logout clears it.
+
+## 3 Architecture Notes
+
+- **Data model update**:
+
+  - Add **`domain: string`** prop to `BfOrganization` (see note about
+    BfConsistencyRule)
+  - Define an **`OrganizationRole`** enum (`OWNER`, `ADMIN`, `MEMBER`) and
+    introduce **`BfEdgeOrganizationMember`** (extends `BfEdge`) with props
+    `{ role: OrganizationRole, joinedAt: Date }`. This edge connects `BfPerson`
+    → `BfOrganization` and enforces one membership per org/person.
+
+- **Frontend**: use the GIS JS SDK (`accounts.id.initialize`). Pass
+  `use_fedcm_for_prompt: true` so Chrome uses FedCM automatically.
+
+- **GraphQL**: single mutation `loginWithGoogle(token: String!): AuthPayload`.
+
+- **Backend**: verify ID‑token signature & audience **and ensure the `hd`
+  (hosted‑domain) claim exists and is _not_ `gmail.com`** (i.e. only
+  Google Workspace), then create/fetch `BfPerson` and issue JWT session
+  cookie.`** (i.e. only Google Workspace), then create/fetch`BfPerson` and issue
+  JWT session cookie.
+
+## 4 Work Breakdown (Backend → Frontend)
+
+### Phase A – Data‑Model & GraphQL Contract
+
+1. **Schema changes**
+   - Add `domain: string` prop to `BfOrganization` (unique, indexed).
+   - Add `OrganizationRole` enum (`OWNER`, `ADMIN`, `MEMBER`).
+   - Introduce `BfEdgeOrganizationMember` (extends `BfEdge`) with props
+     `{ role: OrganizationRole, joinedAt: Date }` (unique on
+     `personId+organizationId`).
+2. **Mutation definition**
+   - Add `loginWithGoogle(token: String!): AuthPayload` where
+     `AuthPayload { viewer: BfCurrentViewer!, success: Boolean!, errors: [AuthError!] }`.
+
+### Phase B – Backend Auth Implementation
+
+1. **Resolver** `loginWithGoogle(token)`
+   - Verify ID‑token (Google certs, audience).
+   - Reject if `hd` missing or `gmail.com`.
+   - **Org logic**:
+     - Derive `domain = hd`.
+     - If org exists → create `BfEdgeOrganizationMember`
+       `{ role: OrganizationRole.MEMBER, joinedAt: now }`.
+     - Else create `BfOrganization { name: domain, domain }` → edge
+       `{ role: OrganizationRole.OWNER, joinedAt: now }`.
+   - Issue signed JWT, set `bf_session` (`HttpOnly; SameSite=Lax; Secure`).
+2. **Context** `createContext()`
+   - Parse/verify cookie, load viewer (`BfCurrentViewerLoggedIn` or LoggedOut).
+
+### Phase C – Frontend Skeleton & Mutation Integration
+
+1. **Utilities & Components**
+   - `useGoogleSignIn` hook (lazy GIS loader via ref).
+   - `SignInWithGoogleButton` component.
+2. **LoginPage** (`iso` component) with auto redirect if already logged in.
+3. **Entrypoint & Router**
+   - `loginEntrypoint.ts` prefetches `me`.
+   - Add `"/login"` to `isographAppRoutes`.
+4. **Mutation success handler**
+
+```ts
+commit({ token }, {
+  onComplete() {
+    isographEnvironment.commitUpdate((s) => s.invalidateStore());
+    const cookies = Object.fromEntries(
+      document.cookie.split("; ").map((c) => c.split("=")),
+    );
+    let next = decodeURIComponent(cookies.login_next ?? "/") as string;
+    if (!next.startsWith("/")) next = "/";
+    document.cookie = "login_next=; Max-Age=0; path=/; SameSite=Lax";
+    router.replace(next);
+  },
+});
+```
+
+### Phase D – Protected Route Guard
+
+- Mark routes with `requiresAuth`.
+- In router guard: if unauthenticated
+  ```ts
+  const currentPath = location.pathname + location.search;
+  if (currentPath.startsWith("/")) {
+    document.cookie = `login_next=${
+      encodeURIComponent(currentPath)
+    }; Max-Age=300; path=/; SameSite=Lax`;
+  }
+  navigate("/login");
+  ```
+
+### Phase E – Testing & QA
+
+- **Unit**: token verification, workspace filter, org creation, edge write.
+- **E2E**: Chrome FedCM happy path, Firefox fallback, guard → redirect → return
+  flow.
+
+## 5 Analytics & Telemetry
+
+- `$pageview` for `/login` (PostHog).
+- Events: `login start`, `login success`, `login failure`, `logout`.
+
+## 6 Risks & Mitigations
+
+| Risk                | Mitigation                                                          |
+| ------------------- | ------------------------------------------------------------------- |
+| FedCM UX changes    | Keep GIS SDK updated; it shields breaking changes.                  |
+| Non‑Chrome browsers | GIS automatically falls back to iframe/redirect; we test regularly. |
+| Token spoofing      | Always verify JWT with Google certs server‑side.                    |
+
+## 7 Out‑of‑Scope
+
+- Email/password auth
+- Multi‑factor auth
+- Additional SSO providers

--- a/apps/boltFoundry/docs/0.1/project-plan.md
+++ b/apps/boltFoundry/docs/0.1/project-plan.md
@@ -49,11 +49,11 @@ implement the resolver logic.
 
 - **GraphQL**: single mutation `loginWithGoogle(token: String!): AuthPayload`.
 
-- **Backend**: verify ID‑token signature & audience **and ensure the `hd`
-  (hosted‑domain) claim exists and is _not_ `gmail.com`** (i.e. only
-  Google Workspace), then create/fetch `BfPerson` and issue JWT session
-  cookie.`** (i.e. only Google Workspace), then create/fetch`BfPerson` and issue
-  JWT session cookie.
+- **Backend**: verify ID‑token signature & audience and ensure the ****`hd`****
+  (hosted‑domain) claim exists and is _****not****_ ****`gmail.com`**** (i.e.
+  only Google Workspace), then create/fetch `BfPerson` and issue JWT session
+  **`cookie.`** (i.e. only Google Workspace), then create/fetch`BfPerson\` and
+  issue JWT session cookie.
 
 ## 4 Work Breakdown (Backend → Frontend)
 
@@ -93,7 +93,18 @@ implement the resolver logic.
 3. **Entrypoint & Router**
    - `loginEntrypoint.ts` prefetches `me`.
    - Add `"/login"` to `isographAppRoutes`.
-4. **Mutation success handler**
+   - **Add ****`/logout`**** route**:
+     ```ts
+     appRoutes.set("/logout", (req) => {
+       // update to clear the cookie
+     });
+     ```
+     The action clears the `bf_session` cookie, invalidates the store (viewer
+     becomes LoggedOut), and redirects to home.
+4. **Mutation success handler**\*\*
+   - `loginEntrypoint.ts` prefetches `me`.
+   - Add `"/login"` to `isographAppRoutes`.
+5. **Mutation success handler**
 
 ```ts
 commit({ token }, {

--- a/apps/boltFoundry/docs/backlog.md
+++ b/apps/boltFoundry/docs/backlog.md
@@ -1,0 +1,56 @@
+## 8 Future Work – `BfConsistencyRule`
+
+Because node props are stored as JSON blobs, current schema changes cannot
+declare database‑level constraints such as unique indexes. A dedicated
+**`BfConsistencyRule`** mechanism would let us express and enforce invariants in
+application code:
+
+| Rule type                 | Example                                                                              | Enforcement strategy                                                                     |
+| ------------------------- | ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| **Uniqueness**            | `BfOrganization.domain` must be unique                                               | Pre‑insert query + transactional edge creation; background job audits & fixes conflicts. |
+| **Referential integrity** | A `BfEdgeOrganizationMember` must reference existing `BfPerson` and `BfOrganization` | Hook in edge factory; nightly checker.                                                   |
+| **Custom predicates**     | `BfPerson.email` domain must match linked org domain                                 | Validator function attached to rule.                                                     |
+
+`BfConsistencyRule` objects could be registered on startup; each provides:
+
+```ts
+{
+  id: 'org-domain-unique',
+  description: 'Organization domains must be globally unique',
+  check(): Promise<Violation[]>,
+  fix?(violation: Violation): Promise<void>,
+}
+```
+
+During writes, fast in‑process checks run; a background worker periodically runs
+full scans, reports violations, and optionally auto‑fixes where safe.
+
+## 9 Future Work – `BfPrivacyPolicy`
+
+To manage fine‑grained **authorization** inside the graph we’ll introduce a
+declarative **`BfPrivacyPolicy`** system. Each node class can register a
+`privacyPolicy` object that receives the `currentViewer`, requested `field`, and
+node instance, and returns `ALLOW`, `DENY`, or `PARTIAL`.
+
+```ts
+export const BfOrganizationPrivacy: BfPrivacyPolicy = {
+  canView(node, viewer) {
+    // Owners and admins can view all fields
+    if (viewer.edgeTo(node)?.role !== OrganizationRole.MEMBER) return "ALLOW";
+    // members can’t see billingEmail or apiKeys
+    return "PARTIAL";
+  },
+  canEdit(node, viewer) {
+    return viewer.edgeTo(node)?.role === OrganizationRole.OWNER
+      ? "ALLOW"
+      : "DENY";
+  },
+};
+```
+
+- **Integration point**: GraphQL resolvers call `privacyPolicy.canView` before
+  returning each field; violations throw `BfErrorNotAuthorized`.
+- **Schema helper**: builder DSL can accept `@private` directive for per‑field
+  policy hooks.
+- **Testing**: static analyzer runs across sample viewers to ensure no policy
+  gaps.

--- a/infra/bff/friends/ai.bff.ts
+++ b/infra/bff/friends/ai.bff.ts
@@ -429,7 +429,7 @@ export async function aiCommit(args: string[]): Promise<number> {
   // Write the generated commit message to a temporary file in the project's tmp directory
   logger.info("OpenAI generated a commit message, opening in editor...");
   const tmpDir = "tmp";
-  const tmpFileName = `commit_message_${Date.now()}.txt`;
+  const tmpFileName = `commit_message_${Date.now()}.md`;
   const tmpFile = `${tmpDir}/${tmpFileName}`;
   const fullMessage = `${title}\n\n${message}`;
   await Deno.writeTextFile(tmpFile, fullMessage);


### PR DESCRIPTION

## SUMMARY
This commit introduces a new error class, `BfErrorOrganizationNotAllowed`, to handle situations where an organization is not permitted. Additionally, it adds a test suite for the `BfPerson` model to ensure correct behavior during Google login scenarios. These scenarios include returning an existing user, creating a new user and organization on first-time login, and rejecting sign-in attempts with unauthorized email domains. A utility for creating anonymous viewers is also introduced.

## TEST PLAN
1. Run all tests in `BfPerson.test.ts` to verify:
   - Existing users are returned correctly during login.
   - New users and associated organizations are created on first login.
   - Sign-in is rejected for email domains that are not allowed.
2. Ensure the new error class `BfErrorOrganizationNotAllowed` is properly thrown and caught in relevant test scenarios.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/658).
* #662
* __->__ #658
* #661
* #657