### PR TITLE
Enhance builder tests with expanded mutation and relation checks

### DIFF
--- a/apps/bfDb/graphql/builder/__tests__/builder.test.ts
+++ b/apps/bfDb/graphql/builder/__tests__/builder.test.ts
@@ -1,52 +1,177 @@
 #! /usr/bin/env -S bff test
 
-import { defineGqlNode, Direction } from "apps/bfDb/graphql/builder/builder.ts"; // adjust path
-import { assertEquals, assertExists } from "@std/assert";
+import { defineGqlNode, Direction } from "apps/bfDb/graphql/builder/builder.ts";
+import { assertEquals, assertExists, assertStringIncludes } from "@std/assert";
 import { BfNode } from "apps/bfDb/coreModels/BfNode.ts";
+import { specToNexusObject } from "apps/bfDb/graphql/builder/fromSpec.ts";
+import { makeSchema } from "nexus";
+import { printSchema } from "graphql";
 
-Deno.test("defineGqlNode – full DSL", () => {
+/* -------------------------------------------------------------------------- */
+/*  Dummy node classes for relation targets                                   */
+/* -------------------------------------------------------------------------- */
+
+type AccountProps = { balance: number };
+type PersonProps = { firstName: string; lastName: string };
+
+class AccountNode extends BfNode<AccountProps> {
+  static override gqlSpec = this.defineGqlNode((field) => {
+    field.float("balance");
+  });
+}
+
+class PersonNode extends BfNode<PersonProps> {
+  static override gqlSpec = this.defineGqlNode((field) => {
+    field.string("firstName");
+    field.string("lastName");
+  });
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Payload types                                                              */
+/* -------------------------------------------------------------------------- */
+
+type GreetPayload = { greeting: string };
+type NameListPayload = { names: string[] };
+type MaybeNameListPayload = { maybeNames: string[] } | null;
+type ViewerPersonPayload = { person: InstanceType<typeof PersonNode> };
+type AllNamesPayload = { allNames: string[] };
+type FollowersConnPayload = {
+  followers: { edges: Array<{ node: InstanceType<typeof PersonNode> }> };
+};
+
+/* -------------------------------------------------------------------------- */
+/*  Comprehensive builder DSL test                                            */
+/* -------------------------------------------------------------------------- */
+
+Deno.test("defineGqlNode – rich returns DSL with order‑agnostic nullable/list", () => {
   const spec = defineGqlNode((field, relation, mutation) => {
+    /* ── scalar fields ─────────────────────────────────────────────── */
     field.id("id");
     field.string("name");
     field.nullable.int("age");
-    field.boolean(
-      "isFollowedByViewer",
-      { viewerId: "id" },
-      () => true,
-    );
 
-    relation.one("account", () => BfNode);
-    relation.many.in("followers", () => BfNode);
-    relation.one.in("likedByViewer", () => BfNode);
+    field.boolean("isFollowedByPerson", {
+      args: (arg) => arg.id("followerId"),
+      resolve: () => true,
+    });
 
-    mutation.update()
-      .delete()
-      .custom(
-        "greet",
-        { to: "string" },
-        (src, { to }) => `hi ${to}, I'm ${src.props.name}`,
-      );
+    /* ── relations ─────────────────────────────────────────────────── */
+    relation.one("account", () => AccountNode);
+    relation.many.in("followers", () => PersonNode);
+    relation.one.in("likedByViewer", () => PersonNode);
+
+    /* ── mutations ─────────────────────────────────────────────────── */
+    mutation.update().delete();
+
+    // Scalar payload with implicit key { value }
+    mutation.custom("hello", {
+      args: (a) => a.string("name"),
+      returns: (r) => r.string(),
+      resolve: (_src, { name }): { value: string } => ({
+        value: `hello ${name}`,
+      }),
+    });
+
+    // Object payload
+    mutation.custom("viewer", {
+      args: () => ({}),
+      returns: (r) => r.object(PersonNode, "person"),
+      resolve: (src): ViewerPersonPayload => ({
+        person: src as InstanceType<typeof PersonNode>,
+      }),
+    });
+
+    // List payload + nullable wrapper (list → nullable order)
+    mutation.custom("listNames", {
+      args: () => ({}),
+      returns: (r) => r.list.string("names").nullable(),
+      resolve: (): NameListPayload | null => ({ names: [] }),
+    });
+
+    // Same nullable list but declared nullable → list order
+    mutation.custom("maybeNames", {
+      args: () => ({}),
+      returns: (r) => r.nullable.list.string("maybeNames"),
+      resolve: (): MaybeNameListPayload => ({ maybeNames: ["x", "y"] }),
+    });
+
+    // Non‑nullable list payload
+    mutation.custom("allNames", {
+      args: () => ({}),
+      returns: (r) => r.list.string("allNames"),
+      resolve: (): AllNamesPayload => ({ allNames: ["a", "b"] }),
+    });
+
+    // Collection (connection) payload
+    mutation.custom("followersConnection", {
+      args: () => ({}),
+      returns: (r) => r.collection(PersonNode, "followers"),
+      resolve: (): FollowersConnPayload => ({ followers: { edges: [] } }),
+    });
+
+    // Original greet example with explicit key
+    mutation.custom("greet", {
+      args: (a) => a.string("to"),
+      returns: (r) => r.string("greeting"),
+      resolve: (src, { to }): GreetPayload => ({
+        greeting: `hi ${to}, I'm ${src.props.name}`,
+      }),
+    });
   });
 
-  // ------------------------------------------------------------------
-  //  Field store checks
-  // ------------------------------------------------------------------
+  /* ── basic field checks ──────────────────────────────────────────── */
   assertExists(spec.field.id);
   assertEquals(spec.field.age.nullable, true);
-  assertEquals(spec.field.isFollowedByViewer.args?.viewerId, "id");
+  assertEquals(spec.field.isFollowedByPerson.args?.followerId, "id");
 
-  // ------------------------------------------------------------------
-  //  Relation store checks
-  // ------------------------------------------------------------------
-  assertEquals(spec.relation.account.direction, Direction.OUT);
-  assertEquals(spec.relation.followers.many, true);
+  /* ── relation checks ─────────────────────────────────────────────── */
+  assertEquals(spec.relation.account.target(), AccountNode);
+  assertEquals(spec.relation.followers.target(), PersonNode);
+  assertEquals(spec.relation.likedByViewer.target(), PersonNode);
   assertEquals(spec.relation.followers.direction, Direction.IN);
 
-  // ------------------------------------------------------------------
-  //  Mutation spec checks
-  // ------------------------------------------------------------------
-  assertEquals(spec.mutation.standard.update, true);
-  assertEquals(spec.mutation.standard.delete, true);
-  assertEquals(spec.mutation.customs.length, 1);
-  assertEquals(spec.mutation.customs[0].name, "greet");
+  /* ── custom mutation output specs ─────────────────────────────────- */
+  const byName = Object.fromEntries(
+    spec.mutation.customs.map((m) => [m.name, m]),
+  );
+  assertEquals(byName.hello.output, { value: "string" } as const);
+  assertEquals(byName.viewer.output, { person: () => PersonNode } as const);
+  assertEquals(
+    byName.listNames.output,
+    { names: { list: true, of: "string", nullable: true } } as const,
+  );
+  assertEquals(
+    byName.maybeNames.output,
+    { maybeNames: { list: true, of: "string", nullable: true } } as const,
+  );
+  assertEquals(
+    byName.allNames.output,
+    { allNames: { list: true, of: "string" } } as const,
+  );
+  assertEquals(
+    byName.followersConnection.output,
+    { followers: { connection: true, node: () => PersonNode } } as const,
+  );
+  assertEquals(byName.greet.output, { greeting: "string" } as const);
+});
+
+/* -------------------------------------------------------------------------- */
+/*  SDL checks for the standard update helper                                 */
+/* -------------------------------------------------------------------------- */
+
+Deno.test("specToNexusObject – update mutation args", () => {
+  const spec = defineGqlNode((field, _rel, mutation) => {
+    field.id("id");
+    field.string("name");
+    mutation.update();
+  });
+
+  const Dummy = specToNexusObject("UpdDummy", spec);
+  const schema = makeSchema({ types: [Dummy] });
+  const sdl = printSchema(schema);
+
+  assertStringIncludes(sdl, "updateUpdDummy");
+  assertStringIncludes(sdl, "id: ID");
+  assertStringIncludes(sdl, "params: JSON");
 });

--- a/apps/boltFoundry/docs/0.1/project-plan.md
+++ b/apps/boltFoundry/docs/0.1/project-plan.md
@@ -2,62 +2,71 @@
 
 ---
 
-## Next Action:
+## Current Status
 
-Begin **Phase A – Data‑Model & GraphQL Contract**:
-
-1. Add `domain` prop to `BfOrganization` (JSON schema + migration).
-2. Create `OrganizationRole` enum (`OWNER`, `ADMIN`, `MEMBER`).
-3. Implement `BfEdgeOrganizationMember` edge class.
-4. Add `loginWithGoogle(token: String!): AuthPayload` to the GraphQL schema.
-
-Once these backend pieces compile and unit tests pass, proceed to Phase B to
-implement the resolver logic.
-
-[📄 ChatGPT Canvas](https://chatgpt.com/canvas/shared/680670148f188191a1cd20b4910e3453)
+| Phase                                                  | Status             | Notes                                                                                               |
+| ------------------------------------------------------ | ------------------ | --------------------------------------------------------------------------------------------------- |
+| **Phase A – Data‑Model & GraphQL Contract**            | ✅ **Completed**   | Schema changes compile, GraphQL contract in place, unit tests pass                                  |
+| **Phase B – Backend Auth Implementation**              | ⏳ **In Progress** | `verifyLogin` helper exists; resolver wiring & session cookie work underway; red tests guiding work |
+| **Phase C – Frontend Skeleton & Mutation Integration** | 🔜 **Not Started** |                                                                                                     |
+| **Phase D – Protected Route Guard**                    | 🔜 **Not Started** |                                                                                                     |
+| **Phase E – Testing & QA**                             | 🔜 **Not Started** |                                                                                                     |
 
 ---
 
-## 1 Goals & Scope
+## Next Action
+
+Continue **Phase B – Backend Auth Implementation**:
+
+1. Finish `loginWithGoogle(token)` resolver in **`AuthRoot`**.
+2. Generate & set signed JWT (`bf_session` HttpOnly cookie).
+3. Teach `createContext()` to parse cookie and load viewer.
+4. Turn failing red tests green.
+
+(Once backend auth flows work end‑to‑end, move on to Phase C.)
+
+---
+
+## 1 Goals & Scope
 
 - Authenticate visitors exclusively via **Sign‑in with Google** using **Google
-  Identity Services (GIS)**, which automatically leverages **FedCM** in Chrome.
+  Identity Services (GIS)**, automatically leveraging **FedCM** in Chrome.
 - `/login` route shows a Google sign‑in button (and One‑Tap prompt when
   permitted).
 - Protected pages redirect to `/login` when session missing.
 
-## 2 Success Criteria
+---
+
+## 2 Success Criteria
 
 - GIS One‑Tap or button flow yields an ID‑token that logs the user in.
 - Browser shows FedCM account‑chooser dialog in Chrome ≥108; other browsers fall
   back to GIS legacy flow.
 - Session persisted via secure HttpOnly cookie; logout clears it.
 
-## 3 Architecture Notes
+---
+
+## 3 Architecture Notes
 
 - **Data model update**:
-
   - Add **`domain: string`** prop to `BfOrganization` (see note about
-    BfConsistencyRule)
+    `BfConsistencyRule`).
   - Define an **`OrganizationRole`** enum (`OWNER`, `ADMIN`, `MEMBER`) and
     introduce **`BfEdgeOrganizationMember`** (extends `BfEdge`) with props
     `{ role: OrganizationRole, joinedAt: Date }`. This edge connects `BfPerson`
     → `BfOrganization` and enforces one membership per org/person.
-
 - **Frontend**: use the GIS JS SDK (`accounts.id.initialize`). Pass
   `use_fedcm_for_prompt: true` so Chrome uses FedCM automatically.
-
 - **GraphQL**: single mutation `loginWithGoogle(token: String!): AuthPayload`.
+- **Backend**: verify ID‑token signature & audience and ensure the `hd`
+  (hosted‑domain) claim exists and is _not_ `gmail.com` (i.e. only
+  Google Workspace), then create/fetch `BfPerson` and issue JWT session cookie.
 
-- **Backend**: verify ID‑token signature & audience and ensure the ****`hd`****
-  (hosted‑domain) claim exists and is _****not****_ ****`gmail.com`**** (i.e.
-  only Google Workspace), then create/fetch `BfPerson` and issue JWT session
-  **`cookie.`** (i.e. only Google Workspace), then create/fetch`BfPerson\` and
-  issue JWT session cookie.
+---
 
-## 4 Work Breakdown (Backend → Frontend)
+## 4 Work Breakdown (Backend → Frontend)
 
-### Phase A – Data‑Model & GraphQL Contract
+### Phase A – Data‑Model & GraphQL Contract — **✅ Completed**
 
 1. **Schema changes**
    - Add `domain: string` prop to `BfOrganization` (unique, indexed).
@@ -69,7 +78,7 @@ implement the resolver logic.
    - Add `loginWithGoogle(token: String!): AuthPayload` where
      `AuthPayload { viewer: BfCurrentViewer!, success: Boolean!, errors: [AuthError!] }`.
 
-### Phase B – Backend Auth Implementation
+### Phase B – Backend Auth Implementation — **⏳ In Progress**
 
 1. **Resolver** `loginWithGoogle(token)`
    - Verify ID‑token (Google certs, audience).
@@ -84,7 +93,7 @@ implement the resolver logic.
 2. **Context** `createContext()`
    - Parse/verify cookie, load viewer (`BfCurrentViewerLoggedIn` or LoggedOut).
 
-### Phase C – Frontend Skeleton & Mutation Integration
+### Phase C – Frontend Skeleton & Mutation Integration — **🔜 Not Started**
 
 1. **Utilities & Components**
    - `useGoogleSignIn` hook (lazy GIS loader via ref).
@@ -93,58 +102,29 @@ implement the resolver logic.
 3. **Entrypoint & Router**
    - `loginEntrypoint.ts` prefetches `me`.
    - Add `"/login"` to `isographAppRoutes`.
-   - **Add ****`/logout`**** route**:
-     ```ts
-     appRoutes.set("/logout", (req) => {
-       // update to clear the cookie
-     });
-     ```
-     The action clears the `bf_session` cookie, invalidates the store (viewer
-     becomes LoggedOut), and redirects to home.
-4. **Mutation success handler**\*\*
-   - `loginEntrypoint.ts` prefetches `me`.
-   - Add `"/login"` to `isographAppRoutes`.
-5. **Mutation success handler**
+   - **Add `/logout` route** (server‑only; clears cookie and redirects).
+4. **Mutation success handler** – invalidate store and redirect to `login_next`.
 
-```ts
-commit({ token }, {
-  onComplete() {
-    isographEnvironment.commitUpdate((s) => s.invalidateStore());
-    const cookies = Object.fromEntries(
-      document.cookie.split("; ").map((c) => c.split("=")),
-    );
-    let next = decodeURIComponent(cookies.login_next ?? "/") as string;
-    if (!next.startsWith("/")) next = "/";
-    document.cookie = "login_next=; Max-Age=0; path=/; SameSite=Lax";
-    router.replace(next);
-  },
-});
-```
-
-### Phase D – Protected Route Guard
+### Phase D – Protected Route Guard — **🔜 Not Started**
 
 - Mark routes with `requiresAuth`.
-- In router guard: if unauthenticated
-  ```ts
-  const currentPath = location.pathname + location.search;
-  if (currentPath.startsWith("/")) {
-    document.cookie = `login_next=${
-      encodeURIComponent(currentPath)
-    }; Max-Age=300; path=/; SameSite=Lax`;
-  }
-  navigate("/login");
-  ```
+- Router guard redirects unauthenticated users to `/login` and stores
+  `login_next` cookie.
 
-### Phase E – Testing & QA
+### Phase E – Testing & QA — **🔜 Not Started**
 
 - **Unit**: token verification, workspace filter, org creation, edge write.
 - **E2E**: Chrome FedCM happy path, Firefox fallback, guard → redirect → return
   flow.
 
+---
+
 ## 5 Analytics & Telemetry
 
 - `$pageview` for `/login` (PostHog).
 - Events: `login start`, `login success`, `login failure`, `logout`.
+
+---
 
 ## 6 Risks & Mitigations
 
@@ -154,8 +134,73 @@ commit({ token }, {
 | Non‑Chrome browsers | GIS automatically falls back to iframe/redirect; we test regularly. |
 | Token spoofing      | Always verify JWT with Google certs server‑side.                    |
 
+---
+
 ## 7 Out‑of‑Scope
 
 - Email/password auth
 - Multi‑factor auth
 - Additional SSO providers
+
+---
+
+## 8 Future Work – `BfConsistencyRule`
+
+Because node props are stored as JSON blobs, current schema changes cannot
+declare database‑level constraints such as unique indexes. A dedicated
+**`BfConsistencyRule`** mechanism would let us express and enforce invariants in
+application code:
+
+| Rule type                 | Example                                                                              | Enforcement strategy                                                                     |
+| ------------------------- | ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| **Uniqueness**            | `BfOrganization.domain` must be unique                                               | Pre‑insert query + transactional edge creation; background job audits & fixes conflicts. |
+| **Referential integrity** | A `BfEdgeOrganizationMember` must reference existing `BfPerson` and `BfOrganization` | Hook in edge factory; nightly checker.                                                   |
+| **Custom predicates**     | `BfPerson.email` domain must match linked org domain                                 | Validator function attached to rule.                                                     |
+
+`BfConsistencyRule` objects could be registered on startup; each provides:
+
+```ts
+{
+  id: "org-domain-unique",
+  description: "Organization domains must be globally unique",
+  check(): Promise<Violation[]>,
+  fix?(violation: Violation): Promise<void>,
+}
+```
+
+During writes, fast in‑process checks run; a background worker periodically runs
+full scans, reports violations, and optionally auto‑fixes where safe.
+
+---
+
+## 9 Future Work – `BfPrivacyPolicy`
+
+To manage fine‑grained **authorization** inside the graph we’ll introduce a
+declarative **`BfPrivacyPolicy`** system. Each node class can register a
+`privacyPolicy` object that receives the `currentViewer`, requested `field`, and
+node instance, and returns `ALLOW`, `DENY`, or `PARTIAL`.
+
+```ts
+export const BfOrganizationPrivacy: BfPrivacyPolicy = {
+  canView(node, viewer) {
+    // Owners and admins can view all fields
+    if (viewer.edgeTo(node)?.role !== OrganizationRole.MEMBER) return "ALLOW";
+    // members can’t see billingEmail or apiKeys
+    return "PARTIAL";
+  },
+  canEdit(node, viewer) {
+    return viewer.edgeTo(node)?.role === OrganizationRole.OWNER
+      ? "ALLOW"
+      : "DENY";
+  },
+};
+```
+
+- **Integration point**: GraphQL resolvers call `privacyPolicy.canView` before
+  returning each field; violations throw `BfErrorNotAuthorized`.
+- **Schema helper**: builder DSL can accept `@private` directive for per‑field
+  policy hooks.
+- **Testing**: static analyzer runs across sample viewers to ensure no policy
+  gaps.
+
+---


### PR DESCRIPTION

## SUMMARY
This commit significantly expands the test coverage for the GraphQL builder. New dummy node classes `AccountNode` and `PersonNode` have been introduced to test relation targets. The test now covers a wider array of builder features, including scalar fields, relations, and complex mutations with various return types. The test ensures that nullable and list return types work in a flexible order. Additionally, a new test has been added to verify SDL generation for the standard update mutation.

Key changes include:
- Added dummy node classes for `AccountNode` and `PersonNode`.
- Expanded mutation tests to cover scalar payloads, object payloads, list payloads, nullable lists, and collection payloads.
- Updated relation tests to verify correct relation targets.
- Added comprehensive checks for mutation return types and SDL generation for update mutations.

## TEST PLAN
1. Run the updated test suite to ensure all tests pass.
2. Verify that the test outputs match the expected results for various field, relation, and mutation combinations.
3. Confirm that the SDL checks for `updateUpdDummy` mutation include the correct fields and types.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/667).
* #668
* __->__ #667
* #665