### PR TITLE
Add port availability check and config-based headless mode

### DIFF
--- a/infra/testing/e2e/setup.ts
+++ b/infra/testing/e2e/setup.ts
@@ -2,6 +2,7 @@ import { type Browser, launch, type Page } from "puppeteer-core";
 import { getLogger } from "packages/logger/logger.ts";
 import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
+import { getConfigurationVariable } from "packages/get-configuration-var/get-configuration-var.ts";
 
 const logger = getLogger(import.meta);
 
@@ -20,7 +21,9 @@ export async function setupE2ETest(options: {
   headless?: boolean;
 } = {}): Promise<E2ETestContext> {
   const baseUrl = options.baseUrl || "http://localhost:8000";
-  const headless = options.headless !== false;
+  const headless = options.headless !== false ? true : getConfigurationVariable(
+    "BF_E2E_HEADLESS",
+  ) != "false";
 
   logger.info(`Starting e2e test with baseUrl: ${baseUrl}`);
 


### PR DESCRIPTION

## SUMMARY
This commit introduces a utility function `waitForPort` in `e2e.bff.ts` to ensure that the server is ready and available on a specified port before proceeding with tests. This replaces the previous fixed wait time, improving reliability in different environments. Additionally, in `setup.ts`, the headless mode for end-to-end tests can now be configured using the `BF_E2E_HEADLESS` environment variable, allowing greater flexibility for test executions.

## TEST PLAN
1. Run the end-to-end tests and verify that the server starts correctly and tests execute without premature failures.
2. Modify the `BF_E2E_HEADLESS` environment variable to `false` and ensure that the tests run in non-headless mode.
3. Test the `waitForPort` function by starting the server on a different port and observe the timeout warning in logs.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/674).
* #676
* __->__ #674