### PR TITLE
Enhance e2e test and add iso command test for BFF

### DIFF
--- a/apps/boltFoundry/__tests__/e2e/home.test.e2e.ts
+++ b/apps/boltFoundry/__tests__/e2e/home.test.e2e.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import {
   navigateTo,
   setupE2ETest,
@@ -39,6 +39,11 @@ Deno.test("Home page loads successfully", async () => {
       bodyText && bodyText.length > 0,
       true,
       "Page body should not be empty",
+    );
+
+    assert(
+      bodyText?.includes("Bolt Foundry"),
+      "Page should contain 'Bolt Foundry'... probably erroring otherwise",
     );
 
     // Take screenshot after test has completed successfully

--- a/infra/bff/__tests__/iso.test.ts
+++ b/infra/bff/__tests__/iso.test.ts
@@ -1,0 +1,20 @@
+#! /usr/bin/env -S bff test
+/**
+ * infra/bff/friends/__tests__/IsoCommand.test.ts
+ * Verifies that “bff iso” (Isograph code-gen) succeeds.
+ */
+
+import { assertEquals } from "@std/assert";
+import { isoCommand } from "infra/bff/friends/iso.bff.ts";
+
+/**
+ * When invoked without options the helper exports the same numeric exit-code
+ * that the actual CLI would return, so a simple equality assertion is enough.
+ *
+ *   0 → success
+ *   ≠0 → compiler error (test fails)
+ */
+Deno.test("bff iso exits with code 0", async () => {
+  const exitCode = await isoCommand([]);
+  assertEquals(exitCode, 0);
+});


### PR DESCRIPTION

## SUMMARY
This commit enhances the end-to-end test for the home page by adding an additional assertion to check if the page contains the text "Bolt Foundry". This ensures that the page is loading the expected content, reducing the chance of silent failures when the page structure changes unexpectedly. Additionally, a new test file `iso.test.ts` is added under `infra/bff/__tests__/` to verify that the `bff iso` command, which is related to Isograph code generation, exits with a code of 0. This test confirms that the command runs successfully without any compiler errors, ensuring stability and reliability of the code generation process.

## TEST PLAN
1. Run the enhanced end-to-end test for the home page to ensure it passes with the new assertion.
2. Execute the new `iso.test.ts` to verify that the `bff iso` command exits with code 0, indicating success.
3. Review the test results to confirm no regressions or errors are introduced with these changes.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/676).
* #681
* #678
* #679
* __->__ #676