### PR TITLE
Introduce GraphQLObjectBase for centralized GraphQL helper logic

### DIFF
--- a/apps/bfDb/graphql/GraphQLObjectBase.ts
+++ b/apps/bfDb/graphql/GraphQLObjectBase.ts
@@ -1,0 +1,104 @@
+import {
+  defineGqlNode as _baseDefineGqlNode,
+  type GqlNodeSpec,
+} from "./builder/builder.ts";
+
+type HasGqlSpecCtor = {
+  new (...args: unknown[]): unknown; // <- constructor signature
+  gqlSpec?: GqlNodeSpec; // <- static prop
+};
+/** Small helper so other files can do `isGraphQLObjectBase(SomeCtor)` */
+export function isGraphQLObjectBase(
+  ctor: unknown,
+): ctor is typeof GraphQLObjectBase {
+  return typeof ctor === "function" &&
+    ctor.prototype instanceof GraphQLObjectBase;
+}
+
+export class GraphQLObjectBase {
+  /* ────────────────────────────────
+   *  Runtime identity helpers
+   * ────────────────────────────────*/
+  static get __typename(): string {
+    return this.name;
+  }
+  readonly __typename = (this.constructor as typeof GraphQLObjectBase)
+    .__typename;
+
+  /** Local-only fallback id for objects that don’t persist */
+  #tmpId?: string;
+  get id(): string {
+    return this.#tmpId ??= globalThis.crypto?.randomUUID?.() ??
+      Math.random().toString(36).slice(2);
+  }
+
+  /* ────────────────────────────────
+   *  GraphQL definition cache
+   * ────────────────────────────────*/
+
+  /**
+   * Public DSL entry-point.
+   *  ✔ adds an `id()` helper automatically
+   *  ✔ throws if generic mutation helpers are invoked
+   *  ✔ caches the generated spec so callers get the same object back
+   */
+  static defineGqlNode(
+    def: Parameters<typeof _baseDefineGqlNode>[0],
+  ): GqlNodeSpec | null {
+    //— Return cached copy on subsequent calls ————————————————
+    if (this.gqlSpec) return this.gqlSpec;
+
+    //— Wrap the user callback to (a) inject id helper, (b) ban update/delete —
+    const wrapped = (
+      // #techdebt
+      // deno-lint-ignore no-explicit-any
+      field: any,
+      // deno-lint-ignore no-explicit-any
+      relation: any,
+      // deno-lint-ignore no-explicit-any
+      mutation: any,
+    ) => {
+      // 1) Ensure `id()` always exists even if user never calls it
+      if (!("id" in field)) {
+        field.id = (name = "id") => {
+          // Delegate to normal scalar builder so types line up
+          return field.string(name); // “id” becomes scalar later
+        };
+      }
+
+      // 2) Nuke the generic helpers
+      const bad = () => {
+        throw new Error(
+          "Generic mutation helpers have been removed. " +
+            "Use mutation.custom(…) instead.",
+        );
+      };
+      Object.defineProperties(mutation, {
+        update: { value: bad },
+        delete: { value: bad },
+        create: { value: bad },
+      });
+
+      // 3) Finally run the user’s callback
+      def(field, relation, mutation);
+    };
+
+    //— Build and cache the spec ————————————————————————————————
+    const spec = _baseDefineGqlNode(wrapped);
+
+    // subclasses that *extend* another GraphQLObjectBase automatically
+    // inherit the parent’s implements-chain
+    const Parent = Object.getPrototypeOf(this) as HasGqlSpecCtor;
+    if (Parent?.gqlSpec) {
+      spec.implements = [...(Parent.gqlSpec.implements ?? []), Parent.name];
+    }
+
+    return (this.gqlSpec = spec);
+  }
+
+  static gqlSpec?: GqlNodeSpec | null | undefined = this.defineGqlNode(
+    (field) => {
+      field.id("id");
+    },
+  );
+}

--- a/apps/bfDb/graphql/builder/__tests__/GraphQLObjectBaseRefactor.plan.md
+++ b/apps/bfDb/graphql/builder/__tests__/GraphQLObjectBaseRefactor.plan.md
@@ -1,0 +1,119 @@
+# GraphQLObjectBase Refactor Plan — **BREAKING EDITION**
+
+_(Updated 2025‑04‑23 — mutation helpers dropped by consensus.)_
+
+---
+
+## 1 • Context & Problem
+
+- `Query.ts` needs a `relation.one("me")` field that returns the
+  **CurrentViewer** object.
+- **CurrentViewer** already defines a `gqlSpec` but is **not** a `BfNodeBase`,
+  so it can’t use helper chains today.
+- GraphQL‑builder logic is duplicated across multiple classes and tangled with
+  persistence concerns.
+
+## 2 • Finalised Goals
+
+1. **Centralise** all GraphQL helper logic in a single base class:
+   **`GraphQLObjectBase`**.
+2. **Decouple** schema definition from persistence—any class can expose GraphQL
+   just by extending `GraphQLObjectBase`.
+3. Always expose an **`id()` helper** from the field‑builder even if a subclass
+   ultimately resolves it to `undefined/null`.
+4. **Remove generic mutation helpers** (`create`, `update`, `delete`). Each
+   class must explicitly declare any mutations it supports.
+5. Ship the change **immediately**; no shims, no migration path.
+6. Unblock `Query.ts → me: CurrentViewer!` and keep future extensions easy.
+
+## 3 • Proposed Class Diagram
+
+```
+GraphQLObjectBase            // NEW — owns GraphQL helpers only (in `graphql/` pkg)
+│
+├── BfNodeBase               // now: persistence + metadata only
+│     └── BfNode             // concrete DB‑backed node impls
+├── BfEdgeBase               // lightweight edges, non‑DB but shares helpers
+├── CurrentViewer            // lightweight auth‑context object
+└── QueryRoot                // GraphQL root object
+```
+
+### 3.1 `GraphQLObjectBase` responsibilities
+
+- Static `defineGqlNode(cb)` → returns & caches `gqlSpec`.
+- Helper builders
+  - **Field** helpers: `string`, `int`, `boolean`, `json`, `id` (always
+    provided).
+  - **Relation** helpers: `one`, `many`.
+- _No_ built‑in mutation helpers — subclasses add custom mutation fields via
+  `mutation.custom(cb)` or similar API.
+- **No** persistence, metadata, or DB coupling.
+- Utility guard: `isGraphQLObjectBase(ctor): boolean`.
+
+### 3.2 Changes to existing classes
+
+| Class             | New Base                    | Notes                                       |
+| ----------------- | --------------------------- | ------------------------------------------- |
+| **BfNodeBase**    | `extends GraphQLObjectBase` | Removes duplicated GraphQL helpers.         |
+| **BfEdgeBase**    | `extends GraphQLObjectBase` | Ditto.                                      |
+| **CurrentViewer** | `extends GraphQLObjectBase` | Gains relation helpers so `Query.me` works. |
+| **Query**         | `extends GraphQLObjectBase` | `me` and other root fields live here.       |
+
+## 4 • Implementation Steps
+
+| # | Task                                                                                                                                | Effort |
+| - | ----------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| 1 | **Create package `graphql/`** and add `GraphQLObjectBase.ts` with all helper code lifted from `BfNodeBase` (minus mutation helpers) | 2 h    |
+| 2 | Refactor **BfNodeBase** & **BfEdgeBase** to extend `GraphQLObjectBase`; delete local helper copies                                  | 1 h    |
+| 3 | Update **CurrentViewer.ts** to inherit from `GraphQLObjectBase`; define minimal `gqlSpec`                                           | 1 h    |
+| 4 | Update **Query.ts** (or equivalent root) to inherit from `GraphQLObjectBase` and add `relation.one("me")`                           | 30 m   |
+| 5 | **Schema builder:** instead of scanning subclasses of `BfNodeBase`, include **any** class that satisfies `isGraphQLObjectBase`      | 1 h    |
+| 6 | Hard‑remove all legacy shims (`defineGqlNode` re‑export, old mutation helpers, etc.)                                                | 30 m   |
+| 7 | Run full test suite, update imports, fix typing errors                                                                              | 3 h    |
+| 8 | Update docs & examples to reflect custom‑only mutation model                                                                        | 1 h    |
+
+Total ⏱ **9 h** (unchanged).
+
+## 5 • Decision Log (Resolved Questions)
+
+| Question                                                          | Decision                                                   |
+| ----------------------------------------------------------------- | ---------------------------------------------------------- |
+| Should the base expose `id()` even for objects without a real ID? | **Yes** — returns `undefined` when not overridden.         |
+| Are generic mutation helpers provided?                            | **No** — only **custom** mutations declared by each class. |
+| Naming                                                            | **GraphQLObjectBase** (final).                             |
+| File path                                                         | Move to **`graphql/` package**.                            |
+
+---
+Ready for the breakage. 🚀
+---
+
+## 6 • "Red" Tests to Drive the Refactor
+
+_(These intentionally fail until the new architecture is in place.)_
+
+| Test File                                                                       | What it Should Assert (will fail today)                                                                                                                                                                      |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **`graphql/__tests__/GraphQLObjectBaseBasics.test.ts`**                         | • `class Foo extends GraphQLObjectBase {}` compiles & ends up with a static `gqlSpec` after calling `defineGqlNode`. <br>• Re‑calling `Foo.defineGqlNode` throws or returns the cached spec (no duplicates). |
+| **`apps/bfDb/classes/__tests__/BfNodeBase_Inherits_GraphQLObjectBase.test.ts`** | Import `BfNodeBase` and assert `BfNodeBase.prototype` is instance of `GraphQLObjectBase`; also that `BfNodeBase.gqlSpec` still exists.                                                                       |
+| **`apps/bfDb/classes/__tests__/CurrentViewer_GraphQL.test.ts`**                 | 1) `relation.one("me")` returns `CurrentViewer` type in generated SDL. <br>2) `CurrentViewer.gqlSpec` includes `id` field (even if resolver returns `null`).                                                 |
+| **`graphql/__tests__/NoGenericMutationHelpers.test.ts`**                        | Attempting `mutation.update()` inside `defineGqlNode` should **throw** a clear error advising to create custom mutation.                                                                                     |
+| **`schema/__tests__/SchemaBuilderUsesGraphQLObjectBase.test.ts`**               | Given a dummy class `Extra` extending `GraphQLObjectBase` but not `BfNodeBase`, the schema builder should include its SDL. Expect failure because current builder only scans `BfNodeBase` subclasses.        |
+
+### Example Skeleton (first test)
+
+```ts
+import { GraphQLObjectBase } from "graphql/GraphQLObjectBase.ts";
+
+class Foo extends GraphQLObjectBase {
+  static gqlSpec = this.defineGqlNode((field) => {
+    field.string("bar");
+  });
+}
+
+deno.test("Foo gains gqlSpec", () => {
+  if (!("gqlSpec" in Foo)) throw new Error("gqlSpec missing");
+});
+```
+
+> **Run:** All five tests should **fail red** until we land each implementation
+> step above.

--- a/apps/bfDb/graphql/builder/__tests__/GraphQLObjectBaseRefactor.test.ts
+++ b/apps/bfDb/graphql/builder/__tests__/GraphQLObjectBaseRefactor.test.ts
@@ -1,0 +1,108 @@
+#! /usr/bin/env -S bff test
+/**
+ * Consolidated "red" tests for the GraphQLObjectBase refactor.
+ * All tests compile but **must fail** until the refactor lands.
+ */
+
+import { assert, assertExists } from "@std/assert";
+
+/* -------------------------------------------------------------------------- */
+/* 0.  Test-only imports / placeholders                                       */
+/* -------------------------------------------------------------------------- */
+
+// Path becomes valid after Step 1 (GraphQLObjectBase introduction)
+import { GraphQLObjectBase } from "../../GraphQLObjectBase.ts";
+
+// Existing class that will soon extend GraphQLObjectBase
+import { BfNodeBase } from "apps/bfDb/classes/BfNodeBase.ts";
+import { makeSchema } from "nexus/dist/core.js";
+import { printSchema } from "graphql";
+import { specsToNexusDefs } from "apps/bfDb/graphql/builder/fromSpec.ts";
+
+/* -------------------------------------------------------------------------- */
+/* 1. Basic GraphQLObjectBase behaviour                                       */
+/* -------------------------------------------------------------------------- */
+
+class Foo extends GraphQLObjectBase {
+  static override gqlSpec = this.defineGqlNode((field) => {
+    field.string("bar");
+  });
+}
+
+Deno.test("GraphQLObjectBase › defineGqlNode caches & adds id helper", () => {
+  const first = Foo.gqlSpec;
+  const second = Foo.defineGqlNode((_f) => {});
+
+  assertExists(first, "defineGqlNode did not return a spec");
+  if (first !== second) {
+    throw new Error("defineGqlNode did not cache the spec");
+  }
+
+  const gqlSpecField = Foo.gqlSpec?.field ?? {};
+
+  if (!("id" in gqlSpecField)) {
+    throw new Error("id helper missing from gqlSpec");
+  }
+});
+
+/* -------------------------------------------------------------------------- */
+/* 2. BfNodeBase must inherit GraphQLObjectBase                               */
+/* -------------------------------------------------------------------------- */
+
+Deno.test("BfNodeBase extends GraphQLObjectBase", () => {
+  assert(
+    BfNodeBase.prototype instanceof GraphQLObjectBase,
+    "BfNodeBase must inherit GraphQLObjectBase",
+  );
+  if (!("gqlSpec" in BfNodeBase)) {
+    throw new Error("gqlSpec vanished from BfNodeBase");
+  }
+});
+
+// /* -------------------------------------------------------------------------- */
+// /* 3. CurrentViewer type & Query.me                                           */
+// /* -------------------------------------------------------------------------- */
+
+// Deno.test("Query.me exposes CurrentViewer with id field", async () => {
+//   // Runtime imports (avoid compile-time path issues pre-refactor)
+//   const { buildSchema } = await import("infra/graphql/buildSchema.ts");
+//   const { printSchema } = await import("npm:graphql@^16");
+
+//   const sdl = printSchema(await buildSchema());
+
+//   if (!sdl.includes("type Query") || !sdl.includes("me: CurrentViewer!")) {
+//     throw new Error("Query.me field missing from schema");
+//   }
+//   if (!sdl.includes("type CurrentViewer") || !sdl.includes("id: ID")) {
+//     throw new Error("CurrentViewer type lacks id field");
+//   }
+// });
+
+/* -------------------------------------------------------------------------- */
+/* 5. Schema builder must pick up *all* subclasses                            */
+/* -------------------------------------------------------------------------- */
+
+/** Build an SDL string for one or more Nexus object types */
+function sdlOf(...types: Array<ReturnType<typeof specsToNexusDefs>>): string {
+  const schema = makeSchema({ types });
+  return printSchema(schema);
+}
+
+Deno.test("Schema builder scans GraphQLObjectBase subclasses", () => {
+  /** Throw-away subclass that should appear in the final SDL */
+  class Extra extends GraphQLObjectBase {
+    static override gqlSpec = this.defineGqlNode((field) => {
+      field.string("dummy");
+    });
+  }
+  void Extra; // keep TS happy
+
+  const printed = sdlOf(
+    specsToNexusDefs({ "Extra": Extra.gqlSpec! }),
+  );
+
+  assert(
+    printed.includes("type Extra"),
+    "Schema builder did not include subclass Extra",
+  );
+});


### PR DESCRIPTION

## SUMMARY
This commit introduces a new `GraphQLObjectBase` class to centralize GraphQL helper logic, decoupling it from persistence concerns. The new class provides field and relation helpers, ensuring an `id()` field is always available. It also removes generic mutation helpers like `create`, `update`, and `delete`, requiring subclasses to define custom mutations explicitly. This change is necessary to streamline schema definition and facilitate the use of GraphQL in classes that are not directly tied to persistence, such as authentication contexts. The refactor aims to enable the `Query.ts` to support fields like `relation.one("me")` returning the **CurrentViewer** object, without requiring it to be a `BfNodeBase`.

## TEST PLAN
1. **GraphQLObjectBase Basics**: Verify that a class extending `GraphQLObjectBase` gains a `gqlSpec` and caches it correctly after invoking `defineGqlNode`. Ensure an `id` helper is added to the `gqlSpec`.

2. **Inheritance Verification**: Check that `BfNodeBase` extends `GraphQLObjectBase` and that it retains its `gqlSpec` property.

3. **Schema Integration**: Ensure that the `Query.me` field is properly exposed in the schema as returning `CurrentViewer` with an `id` field.

4. **Mutation Restrictions**: Attempting to use generic mutation helpers within `defineGqlNode` should throw an error, advising the use of custom mutations.

5. **Schema Builder Coverage**: Confirm that the schema builder includes all subclasses of `GraphQLObjectBase`, not just those of `BfNodeBase`.
