### PR TITLE
Add dry run mode for contact creation endpoint

### DIFF
--- a/apps/contacts/server/routes.ts
+++ b/apps/contacts/server/routes.ts
@@ -77,6 +77,27 @@ export async function registerRoutes(app: Express): Promise<Server> {
       console.log("Validating contact data");
       const validatedData = insertContactSchema.parse(req.body);
 
+      // Check for dry run mode (email ending with .dryrun@example.com)
+      const isDryRun = validatedData.email && 
+        /\.dryrun@example\.com$/.test(validatedData.email);
+
+      if (isDryRun) {
+        console.log("Dry run detected - skipping database save");
+        // Return a simulated response without saving to database
+        return res.status(200).json({
+          id: 0,
+          name: validatedData.name,
+          email: validatedData.email,
+          company: validatedData.company || null,
+          notes: validatedData.notes || null,
+          contacted: false,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          emailSentAt: null,
+          dryRun: true
+        });
+      }
+      
       console.log(
         "Creating new contact with data:",
         JSON.stringify(validatedData),


### PR DESCRIPTION

## SUMMARY
This commit introduces a dry run mode to the contact creation endpoint in `routes.ts`. When a contact is submitted with an email address ending in `.dryrun@example.com`, the server will recognize it as a dry run request. In this mode, the contact data is validated, but the information is not stored in the database. Instead, a simulated success response is sent back to the client with the contact details and an additional `dryRun` flag set to `true`. This feature allows testing of the endpoint without affecting the actual data in the database.

## TEST PLAN
1. Submit a contact creation request with a valid email ending in `.dryrun@example.com`.
   - Verify that the request logs "Dry run detected - skipping database save".
   - Ensure the response status is 200 and includes the correct contact data with `dryRun: true`.
2. Submit a contact creation request with a regular email.
   - Verify that the contact is processed and stored in the database as usual.
   - Ensure the response does not include the `dryRun` flag.
3. Check edge cases such as missing email or invalid schema to ensure validation still applies.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/682).
* #680
* #675
* __->__ #682