### PR TITLE
Add tests for Google login flow and update dependencies

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -18,6 +18,7 @@
     "jsr:@std/assert@^1.0.11": "1.0.13",
     "jsr:@std/assert@^1.0.12": "1.0.13",
     "jsr:@std/assert@~0.213.1": "0.213.1",
+    "jsr:@std/async@^1.0.12": "1.0.12",
     "jsr:@std/async@^1.0.9": "1.0.10",
     "jsr:@std/bytes@0.223": "0.223.0",
     "jsr:@std/bytes@^1.0.2": "1.0.5",
@@ -229,6 +230,7 @@
     "npm:wouter@^3.3.5": "3.6.0_react@18.3.1",
     "npm:ws@^8.18.0": "8.18.1",
     "npm:zod-validation-error@^3.4.0": "3.4.0_zod@3.24.1",
+    "npm:zod@3": "3.24.1",
     "npm:zod@^3.23.8": "3.24.1",
     "npm:zod@^3.24.1": "3.24.1"
   },
@@ -290,7 +292,10 @@
       "integrity": "642893c6bef95fbcc1358b6ba2c536d3c3a68d48d8436e229d11f3100ed8be7d"
     },
     "@openai/openai@4.96.1": {
-      "integrity": "f94b17f7db1530c203effe73b70ee0d2b49ddfde68307d556a1a34f8006f8200"
+      "integrity": "f94b17f7db1530c203effe73b70ee0d2b49ddfde68307d556a1a34f8006f8200",
+      "dependencies": [
+        "npm:zod@3"
+      ]
     },
     "@simplewebauthn/browser@13.1.0": {
       "integrity": "b8e767b4291e0289dc97ac49a0dfe241ef998a7f8d53988a37d87c1eb297d1d7"
@@ -330,6 +335,9 @@
     },
     "@std/async@1.0.10": {
       "integrity": "2ff1b1c7d33d1416159989b0f69e59ec7ee8cb58510df01e454def2108b3dbec"
+    },
+    "@std/async@1.0.12": {
+      "integrity": "d1bfcec459e8012846fe4e38dfc4241ab23240ecda3d8d6dfcf6d81a632e803d"
     },
     "@std/bytes@0.223.0": {
       "integrity": "84b75052cd8680942c397c2631318772b295019098f40aac5c36cead4cba51a8"
@@ -506,7 +514,7 @@
       "integrity": "9bdd4ac07cb13e7594ac30e90f6ceef7254ac83a9aeaa089be0008f33aab5cd4",
       "dependencies": [
         "jsr:@std/assert@^1.0.10",
-        "jsr:@std/async",
+        "jsr:@std/async@^1.0.9",
         "jsr:@std/data-structures",
         "jsr:@std/fs@^1.0.9",
         "jsr:@std/internal@^1.0.5",
@@ -517,6 +525,7 @@
       "integrity": "12b3db12d34f0f385a26248933bde766c0f8c5ad8b6ab34d4d38f528ab852f48",
       "dependencies": [
         "jsr:@std/assert@^1.0.12",
+        "jsr:@std/async@^1.0.12",
         "jsr:@std/data-structures",
         "jsr:@std/fs@^1.0.16",
         "jsr:@std/internal@^1.0.6",


### PR DESCRIPTION

## SUMMARY
This commit introduces new tests related to the Google login flow and updates some dependencies in the `deno.lock` file. Specifically, two new tests have been added to verify the behavior when a user signs in with Google. The first test checks that the `currentViewer` returns "LoggedIn" after a simulated Google login, while the second test is an end-to-end test that simulates the entire login process, including stubbing Google endpoints and checking for expected UI changes.

Additionally, updates were made to the `deno.lock` file, which include adding and modifying dependencies such as `@std/async` and `zod`. These changes ensure that the project correctly handles the new functionality and maintains compatibility with the current library versions.

## TEST PLAN
1. Run all unit tests in `apps/bfDb/classes/__tests__/CurrentViewer.test.ts` to ensure the new test for `currentViewer` passes.
2. Execute the end-to-end tests in `apps/boltFoundry/__tests__/e2e/loginPage.test.e2e.ts` to verify the Google login flow works as expected.
3. Validate that the project's dependencies are correctly resolved and do not introduce any issues by running the application and executing existing test suites.
