### PR TITLE
Integrate PostHog and Enhance AutoRefresh with Promises

### DIFF
--- a/apps/boltFoundry/server/components/ServerRenderedPage.tsx
+++ b/apps/boltFoundry/server/components/ServerRenderedPage.tsx
@@ -83,7 +83,14 @@ export function ServerRenderedPage(
           } else {
             // can't rehydrate yet.
             console.warn("Rehydration fail");
-          }`,
+          }
+          !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init me ys Ss gs ws capture je Di xs register register_once register_for_session unregister unregister_for_session Rs getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey canRenderSurveyAsync identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty Is ks createPersonProfile Ps bs opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing $s debug Es getPageViewId captureTraceFeedback captureTraceMetric".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+          if (__ENVIRONMENT__.POSTHOG_API_KEY) {
+            posthog.init(__ENVIRONMENT__.POSTHOG_API_KEY, {
+                api_host: 'https://us.i.posthog.com',
+            })
+          }
+          `,
           }}
         />
       </body>

--- a/apps/web/web.tsx
+++ b/apps/web/web.tsx
@@ -11,7 +11,7 @@ import { startAutoRefresh } from "packages/get-configuration-var/get-configurati
 
 const _logger = getLogger(import.meta);
 
-startAutoRefresh();
+await startAutoRefresh();
 
 export type Handler = (
   request: Request,


### PR DESCRIPTION
## SUMMARY
This commit introduces several key changes across the codebase:

1. **PostHog Integration**: Added a script to initialize PostHog analytics in `ServerRenderedPage.tsx`. The script ensures PostHog is only initialized if the `POSTHOG_API_KEY` is available in the environment. This integration helps in tracking user interactions and gaining insights into user behavior.

2. **startAutoRefresh Enhancement**: Updated the `startAutoRefresh` function in `get-configuration-var.ts` to return a promise. This change involves wrapping the initial secret refresh calls in a `Promise.allSettled`, ensuring that the auto-refresh process can be awaited. Additionally, the function now returns an object that includes promise capabilities, allowing for better async handling.

3. **Await startAutoRefresh**: Modified the call to `startAutoRefresh` in `web.tsx` to use `await`, ensuring that the auto-refresh setup completes before proceeding. This ensures that the application waits for the initialization process, reducing the risk of race conditions.

4. **Environment Variable Support**: Added `XDG_CONFIG_HOME` and `XDG_DATA_HOME` to the list of recognized configuration variables in `get-configuration-var.ts`. This expands the capability to read additional configuration paths, enhancing the application's flexibility in different environments.

These updates aim to improve the application's analytics capabilities and reliability in handling asynchronous operations.

## TEST PLAN
1. Ensure the application builds successfully with `npm run build`.
2. Verify that the PostHog script loads correctly in the browser when `POSTHOG_API_KEY` is set.
3. Check that calling `startAutoRefresh` does not lead to unhandled promise rejections.
4. Run automated tests to confirm no regressions using:
   ```bash
   ./run-tests.sh
   ```
5. Manually inspect that the application starts without errors and that configuration variables are correctly recognized.

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/716)
<!-- GitContextEnd -->