### PR TITLE
Remove separate PostHog API key for production apps

### DIFF
--- a/apps/boltFoundry/__generated__/configKeys.ts
+++ b/apps/boltFoundry/__generated__/configKeys.ts
@@ -1,7 +1,7 @@
 /* @generated */
 // Source vault: "c7qk6vxetcikihgccsc2p7d37q"
 // Public tag  : "bolt-foundry-frontend-public"  (6 keys)
-// Private tag : "bolt-foundry-backend-private" (28 keys)
+// Private tag : "bolt-foundry-backend-private" (27 keys)
 
 export const PUBLIC_CONFIG_KEYS = [
   "APPS_INTERNALBF_POSTHOG_API_KEY",
@@ -13,7 +13,6 @@ export const PUBLIC_CONFIG_KEYS = [
 ] as const;
 
 export const PRIVATE_CONFIG_KEYS = [
-  "APPS_COLLECTOR_POSTHOG_API_KEY",
   "ASSEMBLY_AI_KEY",
   "BF_CACHE_ENV",
   "BF_CACHE_TTL_SEC",

--- a/apps/collector/collector.ts
+++ b/apps/collector/collector.ts
@@ -1,6 +1,9 @@
 #! /usr/bin/env -S deno run --allow-net=0.0.0.0,us.i.posthog.com --allow-env --watch
 
-import { getConfigurationVariable } from "@bolt-foundry/get-configuration-var";
+import {
+  getConfigurationVariable,
+  startAutoRefresh,
+} from "@bolt-foundry/get-configuration-var";
 import { getLogger } from "packages/logger/logger.ts";
 import type { Handler } from "apps/web/web.tsx";
 import { handleRequest } from "apps/web/handlers/mainHandler.ts";
@@ -9,12 +12,14 @@ import { trackLlmEvent } from "apps/collector/llm-event-tracker.ts";
 
 const logger = getLogger(import.meta);
 
+await startAutoRefresh();
+
 // Define routes for the collector service
 function registerCollectorRoutes(): Map<string, Handler> {
   const routes = new Map<string, Handler>();
   let appPosthog: PostHog | null = null;
   const appPosthogApiKey = getConfigurationVariable(
-    "APPS_COLLECTOR_POSTHOG_API_KEY",
+    "POSTHOG_API_KEY",
   );
   if (appPosthogApiKey) {
     appPosthog = new PostHog(appPosthogApiKey);


### PR DESCRIPTION

## SUMMARY
This commit removes the "APPS_COLLECTOR_POSTHOG_API_KEY" from the `PRIVATE_CONFIG_KEYS` in `configKeys.ts`, indicating a shift to using a unified PostHog API key for production applications. The key previously dedicated to the `collector` app is replaced with the generic "POSTHOG_API_KEY" in `collector.ts`. Additionally, automatic configuration variable refresh is introduced by calling `startAutoRefresh()` at the start of `collector.ts`. These changes align with the decision to consolidate PostHog usage across production apps, reducing complexity and potential misconfigurations.

## TEST PLAN
1. Verify that `configKeys.ts` no longer references "APPS_COLLECTOR_POSTHOG_API_KEY".
2. Check that `collector.ts` initializes the PostHog client using the new "POSTHOG_API_KEY".
3. Ensure that `startAutoRefresh()` is called successfully without errors.
4. Run the application and validate that PostHog events are being sent correctly.
5. Confirm no other parts of the application break due to the removed API key.
