### PR TITLE
Add type-safe and runtime tests for bfDb node and field builders

### DIFF
--- a/apps/bfDb/builders/bfDb/__tests__/defineBfNode.test.ts
+++ b/apps/bfDb/builders/bfDb/__tests__/defineBfNode.test.ts
@@ -1,0 +1,44 @@
+#! /usr/bin/env -S bff test
+/**
+ * defineBfNode – type-safety *and* runtime smoke-tests
+ */
+
+import { assertEquals } from "@std/assert";
+import { defineBfNode } from "../defineBfNode.ts";
+import type { PropsFromFieldSpec } from "../makeFieldBuilder.ts";
+
+/* -------------------------------------------------------------------------- */
+/*  Compile-time assertions                                                   */
+/* -------------------------------------------------------------------------- */
+
+const spec = defineBfNode((f) =>
+  f
+    .string("name")
+    .number("age")
+);
+
+type FieldMap = typeof spec.fields;
+type ExpectedMap = {
+  name: { kind: "string" };
+  age: { kind: "number" };
+};
+const fieldCheck: ExpectedMap = {} as FieldMap;
+
+type Props = PropsFromFieldSpec<FieldMap>;
+const ok: Props = { name: "Alice", age: 30 };
+// @ts-expect-error – “email” not declared
+const bad: Props = { name: "Bob", age: 22, email: "x@y.z" };
+void ok;
+void bad;
+void fieldCheck;
+
+/* -------------------------------------------------------------------------- */
+/*  Runtime assertion                                                         */
+/* -------------------------------------------------------------------------- */
+
+Deno.test("defineBfNode exposes its field map at runtime", () => {
+  assertEquals(spec.fields, {
+    name: { kind: "string" },
+    age: { kind: "number" },
+  });
+});

--- a/apps/bfDb/builders/bfDb/__tests__/makeFieldBuilder.test.ts
+++ b/apps/bfDb/builders/bfDb/__tests__/makeFieldBuilder.test.ts
@@ -1,0 +1,45 @@
+#! /usr/bin/env -S bff test
+/**
+ * makeFieldBuilder – type-safety *and* runtime smoke-tests
+ */
+
+import { assertEquals } from "@std/assert";
+import {
+  makeFieldBuilder,
+  type PropsFromFieldSpec,
+} from "../makeFieldBuilder.ts";
+import type { FieldSpec } from "../makeFieldBuilder.ts";
+
+/* -------------------------------------------------------------------------- */
+/*  Compile-time assertions                                                   */
+/* -------------------------------------------------------------------------- */
+
+const target: Record<string, FieldSpec> = {}; // <- will hold runtime data
+const builder = makeFieldBuilder(target) // <- pass the target map in
+  .string("email")
+  .number("age");
+
+type Spec = typeof builder._spec;
+type ExpectSpec = {
+  email: { kind: "string" };
+  age: { kind: "number" };
+};
+
+// ✅ should compile
+const _typeCheck: ExpectSpec = {} as Spec;
+
+type Props = PropsFromFieldSpec<Spec>;
+const okProps: Props = { email: "a@example.com", age: 42 };
+// @ts-expect-error – “foo” isn’t declared
+okProps.foo = "bar";
+
+/* -------------------------------------------------------------------------- */
+/*  Runtime assertion                                                         */
+/* -------------------------------------------------------------------------- */
+
+Deno.test("makeFieldBuilder mutates the supplied target map", () => {
+  assertEquals(target, {
+    email: { kind: "string" },
+    age: { kind: "number" },
+  });
+});

--- a/apps/bfDb/classes/BfNode.ts
+++ b/apps/bfDb/classes/BfNode.ts
@@ -14,7 +14,6 @@ import { storage } from "apps/bfDb/storage/storage.ts";
 import type { JSONValue } from "apps/bfDb/bfDb.ts";
 import { BfErrorNodeNotFound } from "apps/bfDb/classes/BfErrorsBfNode.ts";
 import { getLogger } from "packages/logger/logger.ts";
-import { defineGqlNode } from "apps/bfDb/builders/graphql/builder.ts";
 import { generateUUID } from "lib/generateUUID.ts";
 
 const logger = getLogger(import.meta);
@@ -78,8 +77,8 @@ export abstract class BfNode<TProps extends PropsBase = {}>
   protected _savedProps: TProps;
   protected _metadata: BfMetadata;
   readonly currentViewer: CurrentViewer;
-  static override gqlSpec? = defineGqlNode((i) => i.id("id"));
-  static bfNodeSpec = defineBfNode((i) => i);
+  static override gqlSpec? = this.defineGqlNode((i) => i.id("id"));
+  static bfNodeSpec = this.defineBfNode((i) => i);
   static defineBfNode<
     F extends Record<string, FieldSpec>,
     R = unknown,

--- a/apps/bfDb/graphql/graphqlContext.ts
+++ b/apps/bfDb/graphql/graphqlContext.ts
@@ -8,8 +8,6 @@ import type { BfNode } from "apps/bfDb/classes/BfNode.ts";
 import { setLoginSuccessHeaders } from "apps/bfDb/graphql/utils/graphqlContextUtils.ts";
 import type { BfGid } from "lib/types.ts";
 
-// import { setLoginSuccessHeaders } from "apps/bfDb/graphql/utils/graphqlContextUtils.ts";
-
 const logger = getLogger(import.meta);
 
 export type BfGraphqlContext = {


### PR DESCRIPTION
## SUMMARY
This commit introduces new test files to ensure both compile-time and runtime correctness for the `defineBfNode` and `makeFieldBuilder` functions in the bfDb module. The tests include:

1. **defineBfNode.test.ts**:
   - Added compile-time assertions to validate the types generated by `defineBfNode`.
   - Added runtime tests using Deno to check that the field map is correctly exposed.

2. **makeFieldBuilder.test.ts**:
   - Added compile-time assertions to verify the types generated from `makeFieldBuilder`.
   - Added runtime tests to confirm the target map is properly mutated.

Additionally, a minor refactor in `BfNode.ts` updated the usage of `defineGqlNode` and `defineBfNode` methods to be called on `this` to ensure proper context. The `BfNode.test.ts` file was updated to include new sample nodes for testing and proper type-safety checks with compile-time assertions and runtime behavior tests.

Unused imports were removed from `graphqlContext.ts` to clean up the code.

## TEST PLAN
Run the following command to execute the tests:
```bash
./apps/bfDb/builders/bfDb/__tests__/defineBfNode.test.ts
./apps/bfDb/builders/bfDb/__tests__/makeFieldBuilder.test.ts
./apps/bfDb/classes/__tests__/BfNode.test.ts
```

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/728)
<!-- GitContextEnd -->