### PR TITLE
Introduce GraphQL Builder Migration Plan and Initial Implementation

### DIFF
--- a/apps/bfDb/CircularNodeExample.ts
+++ b/apps/bfDb/CircularNodeExample.ts
@@ -1,0 +1,19 @@
+import { BfNode, type InferProps } from "apps/bfDb/classes/BfNode.ts";
+
+export class BfExamplePerson
+  extends BfNode<InferProps<typeof BfExamplePerson>> {
+  static override gqlSpec = this.defineGqlNode((gql) =>
+    gql
+      .string("email")
+      .string("name")
+  );
+
+  static override bfNodeSpec = this.defineBfNode((node) =>
+    node
+      .string("email")
+      .string("name")
+      .one("primaryOrg", () =>
+        // if you do a runtime import, you avoid circular dependencies but still get type safety
+        import("apps/bfDb/__fixtures__/Nodes.ts").then((m) => m.BfExampleOrg))
+  );
+}

--- a/apps/bfDb/__fixtures__/Nodes.ts
+++ b/apps/bfDb/__fixtures__/Nodes.ts
@@ -1,8 +1,5 @@
 import { BfNode, type InferProps } from "apps/bfDb/classes/BfNode.ts";
-
-/* -------------------------------------------------------------------------- */
-/*  Organisation                                                              */
-/* -------------------------------------------------------------------------- */
+import { BfExamplePerson } from "apps/bfDb/CircularNodeExample.ts";
 
 export class BfExampleOrg extends BfNode<InferProps<typeof BfExampleOrg>> {
   static override gqlSpec = this.defineGqlNode((gql) =>
@@ -19,10 +16,6 @@ export class BfExampleOrg extends BfNode<InferProps<typeof BfExampleOrg>> {
   );
 }
 
-/* -------------------------------------------------------------------------- */
-/*  Pet                                                                       */
-/* -------------------------------------------------------------------------- */
-
 export class BfExamplePet extends BfNode<InferProps<typeof BfExamplePet>> {
   static override gqlSpec = this.defineGqlNode((gql) =>
     gql
@@ -34,24 +27,5 @@ export class BfExamplePet extends BfNode<InferProps<typeof BfExamplePet>> {
       .string("name")
       .string("type")
       .one("vetHospital", () => BfExampleOrg)
-  );
-}
-
-/* -------------------------------------------------------------------------- */
-/*  Person                                                                    */
-/* -------------------------------------------------------------------------- */
-
-export class BfExamplePerson
-  extends BfNode<InferProps<typeof BfExamplePerson>> {
-  static override gqlSpec = this.defineGqlNode((gql) =>
-    gql
-      .string("email")
-      .string("name")
-  );
-
-  static override bfNodeSpec = this.defineBfNode((node) =>
-    node
-      .string("email")
-      .string("name")
   );
 }

--- a/apps/bfDb/builders/bfDb/makeFieldBuilder.ts
+++ b/apps/bfDb/builders/bfDb/makeFieldBuilder.ts
@@ -1,3 +1,4 @@
+/* FieldBuilder.ts – promise-friendly, no intersection tricks */
 import type {
   AnyBfNodeCtor,
   Cardinality,
@@ -9,17 +10,18 @@ import {
   makeRelationBuilder,
   type RelationBuilder as EdgeRelationBuilder,
 } from "./makeRelationBuilder.ts";
-/* ────────────────────────────────────────────────────────────────────────── */
-/*  FIELD BUILDER                                                            */
-/* ────────────────────────────────────────────────────────────────────────── */
 
+type SyncOrAsync<T> = T | Promise<T>; // ——— helper
+
+/* ─────────────────────────────────────────────────────────────── */
+/*  FIELD BUILDER                                                 */
+/* ─────────────────────────────────────────────────────────────── */
 export type FieldBuilder<
   // deno-lint-ignore ban-types
   F extends Record<string, FieldSpec> = {},
   // deno-lint-ignore ban-types
   R extends Record<string, RelationSpec> = {},
 > = {
-  /* scalars */
   string<N extends string>(
     name: N,
   ): FieldBuilder<F & { [K in N]: { kind: "string" } }, R>;
@@ -28,34 +30,14 @@ export type FieldBuilder<
     name: N,
   ): FieldBuilder<F & { [K in N]: { kind: "number" } }, R>;
 
-  /* outbound relations */
   one: RelationAdder<"out", "one", F, R>;
-  many: RelationAdder<"out", "many", F, R>;
 
-  /* inbound helper (fixture-style) */
-  in<
-    N extends string,
-    // deno-lint-ignore ban-types
-    EdgeP extends Record<string, FieldSpec> = {},
-    C extends Cardinality = Cardinality,
-  >(
-    name: N,
-    build: (b: EdgeRelationBuilder<EdgeP>) => EdgeRelationBuilder<EdgeP, C>,
-  ): FieldBuilder<
-    F,
-    & R
-    & {
-      [K in N]: RelationSpec<C> & {
-        direction: "in";
-        props: EdgeP;
-      };
-    }
-  >;
-  /* raw spec */
   readonly _spec: { fields: F; relations: R };
 };
 
-/* relation-adder ---------------------------------------------------------- */
+/* ─────────────────────────────────────────────────────────────── */
+/*  RELATION-ADDER                                                */
+/* ─────────────────────────────────────────────────────────────── */
 type RelationAdder<
   D extends Direction,
   C extends Cardinality,
@@ -63,29 +45,30 @@ type RelationAdder<
   R extends Record<string, RelationSpec>,
 > = <
   N extends string,
-  T extends AnyBfNodeCtor,
-  EB extends EdgeRelationBuilder = EdgeRelationBuilder, // 🆕
+  // deno-lint-ignore no-explicit-any
+  TargetFn extends () => SyncOrAsync<any>, // ① one broad type
+  Resolved extends AnyBfNodeCtor = Awaited<ReturnType<TargetFn>>, // ② constrain here
+  EB extends EdgeRelationBuilder = EdgeRelationBuilder,
 >(
   name: N,
-  target: () => T,
-  edge?: (e: EdgeRelationBuilder) => EB, // 🆕
+  target: TargetFn, // no intersection
+  edge?: (e: EdgeRelationBuilder) => EB,
 ) => FieldBuilder<
   F,
   & R
   & {
     [K in N]: RelationSpec<C> & {
       direction: D;
-      target: () => T;
+      target: () => SyncOrAsync<Resolved>;
       // deno-lint-ignore ban-types
-      props: EB extends EdgeRelationBuilder<infer EP> ? EP : {}; // 🆕
+      props: EB extends EdgeRelationBuilder<infer EP> ? EP : {};
     };
   }
 >;
 
-/* ────────────────────────────────────────────────────────────────────────── */
-/*  FACTORY                                                                  */
-/* ────────────────────────────────────────────────────────────────────────── */
-
+/* ─────────────────────────────────────────────────────────────── */
+/*  FACTORY                                                       */
+/* ─────────────────────────────────────────────────────────────── */
 export function makeFieldBuilder<
   // deno-lint-ignore ban-types
   F extends Record<string, FieldSpec> = {},
@@ -94,40 +77,33 @@ export function makeFieldBuilder<
 >(
   out = { fields: {} as F, relations: {} as R },
 ): FieldBuilder<F, R> {
-  /* helper that creates a **new** builder with fresh generics */
   const next = <
     NF extends Record<string, FieldSpec>,
     NR extends Record<string, RelationSpec>,
   >(o: { fields: NF; relations: NR }): FieldBuilder<NF, NR> =>
     makeFieldBuilder(o);
 
-  /* scalar helpers */
   const string = <N extends string>(name: N) =>
-    next({
-      ...out,
-      fields: { ...out.fields, [name]: { kind: "string" } },
-    });
+    next({ ...out, fields: { ...out.fields, [name]: { kind: "string" } } });
 
   const number = <N extends string>(name: N) =>
-    next({
-      ...out,
-      fields: { ...out.fields, [name]: { kind: "number" } },
-    });
+    next({ ...out, fields: { ...out.fields, [name]: { kind: "number" } } });
 
-  /* outbound relations */
   const addRel =
     <D extends Direction, C extends Cardinality>(direction: D, card: C) =>
     <
       N extends string,
-      T extends AnyBfNodeCtor,
-      EB extends EdgeRelationBuilder = EdgeRelationBuilder, // 🆕
+      // deno-lint-ignore no-explicit-any
+      TargetFn extends () => SyncOrAsync<any>,
+      Resolved extends AnyBfNodeCtor = Awaited<ReturnType<TargetFn>>,
+      EB extends EdgeRelationBuilder = EdgeRelationBuilder,
     >(
       name: N,
-      target: () => T,
-      edge?: (e: EdgeRelationBuilder) => EB, // 🆕
+      target: TargetFn,
+      edge?: (e: EdgeRelationBuilder) => EB,
     ) => {
       // deno-lint-ignore ban-types
-      type EP = EB extends EdgeRelationBuilder<infer P> ? P : {}; // 🆕
+      type EP = EB extends EdgeRelationBuilder<infer P> ? P : {};
       const props: EP = edge
         ? edge(makeRelationBuilder())._spec.props as EP
         : {} as EP;
@@ -146,41 +122,10 @@ export function makeFieldBuilder<
       });
     };
 
-  /* inbound helper */
-  const inbound = <
-    N extends string,
-    EdgeP extends Record<string, FieldSpec>,
-    C extends Cardinality,
-  >(
-    name: N,
-    build: (b: EdgeRelationBuilder<EdgeP>) => EdgeRelationBuilder<EdgeP, C>,
-  ) => {
-    const rb = build(makeRelationBuilder<EdgeP>());
-    const { cardinality, target, props } = rb._spec;
-    return next({
-      ...out,
-      relations: {
-        ...out.relations,
-        [name]: {
-          direction: "in",
-          cardinality,
-          target,
-          props,
-        } as RelationSpec & { props: EdgeP },
-      },
-    });
-  };
-
   return {
-    /* scalars */
     string,
     number,
-    /* outbound */
     one: addRel("out", "one"),
-    many: addRel("out", "many"),
-    /* inbound */
-    in: inbound,
-    /* spec exposer */
     _spec: out,
   } as FieldBuilder<F, R>;
 }

--- a/apps/bfDb/builders/graphql/makeGqlBuilder.ts
+++ b/apps/bfDb/builders/graphql/makeGqlBuilder.ts
@@ -1,0 +1,147 @@
+import type { GraphQLResolveInfo, GraphQLInputType } from "graphql";
+import type { Connection, ConnectionArguments } from "graphql-relay";
+import type { BfGraphqlContext } from "apps/bfDb/graphql/graphqlContext.ts";
+import type { AnyBfNodeCtor } from "apps/bfDb/builders/bfDb/types.ts";
+
+type ThisNode = InstanceType<AnyBfNodeCtor>;
+
+type MaybePromise<T> = T | Promise<T>;
+
+/** Generic placeholder for a mutation's payload */
+type NMutationPayload = Record<string, unknown>;
+
+type ArgsBuilder = {
+  string(name: string): ArgsBuilder;
+  int(name: string): ArgsBuilder;
+  float(name: string): ArgsBuilder;
+  boolean(name: string): ArgsBuilder;
+  id(name: string): ArgsBuilder;
+};
+
+export interface GqlBuilder<R extends Record<string, unknown> = Record<string, unknown>> {
+  string<N extends string>(
+    name: N,
+    opts?: {
+      args?: (ab: ArgsBuilder) => Record<string, GraphQLInputType>;
+      resolve?: (
+        root: ThisNode,
+        args: Record<string, unknown>,
+        ctx: BfGraphqlContext,
+        info: GraphQLResolveInfo
+      ) => MaybePromise<string>;
+    }
+  ): GqlBuilder;
+
+  int<N extends string>(
+    name: N,
+    opts?: {
+      args?: (ab: ArgsBuilder) => Record<string, GraphQLInputType>;
+      resolve?: (
+        root: ThisNode,
+        args: Record<string, unknown>,
+        ctx: BfGraphqlContext,
+        info: GraphQLResolveInfo
+      ) => MaybePromise<number>;
+    }
+  ): GqlBuilder;
+
+  boolean<N extends string>(
+    name: N,
+    opts?: {
+      args?: (ab: ArgsBuilder) => Record<string, GraphQLInputType>;
+      resolve?: (
+        root: ThisNode,
+        args: Record<string, unknown>,
+        ctx: BfGraphqlContext,
+        info: GraphQLResolveInfo
+      ) => MaybePromise<boolean>;
+    }
+  ): GqlBuilder;
+
+  id<N extends string>(
+    name: N,
+    opts?: {
+      args?: (ab: ArgsBuilder) => Record<string, GraphQLInputType>;
+      resolve?: (
+        root: ThisNode,
+        args: Record<string, unknown>,
+        ctx: BfGraphqlContext,
+        info: GraphQLResolveInfo
+      ) => MaybePromise<string>;
+    }
+  ): GqlBuilder;
+
+  object<N extends keyof R & string>(name: N, opts?: {
+    args?: (ab: ArgsBuilder) => Record<string, GraphQLInputType>;
+    resolve?: (
+      root: ThisNode,
+      args: Record<string, unknown>,
+      ctx: BfGraphqlContext,
+      info: GraphQLResolveInfo
+    ) => MaybePromise<R[N]>
+  }): GqlBuilder;
+
+  connection<N extends keyof R & string>(
+    name: N,
+    opts?: {
+      additionalArgs?: (ab: ArgsBuilder) => Record<string, GraphQLInputType>;
+      resolve?: (
+        root: ThisNode,
+        args: ConnectionArguments & Record<string, unknown>,
+        ctx: BfGraphqlContext,
+        info: GraphQLResolveInfo
+      ) => MaybePromise<Connection<ThisNode>>;
+    }
+  ): GqlBuilder;
+
+  mutation<N extends string>(
+    name: N,
+    opts?: {
+      args?: (ab: ArgsBuilder) => Record<string, GraphQLInputType>;
+      resolve?: (
+        root: ThisNode,
+        args: Record<string, unknown>,
+        ctx: BfGraphqlContext,
+        info: GraphQLResolveInfo
+      ) => MaybePromise<NMutationPayload>;
+    }
+  ): GqlBuilder;
+
+  _spec: {
+    fields: Record<string, unknown>;
+    relations: Record<string, unknown>;
+  };
+}
+
+export function makeGqlBuilder(): GqlBuilder {
+  // Initial implementation scaffold
+  const builder: GqlBuilder = {
+    string(_name, _opts) {
+      return this;
+    },
+    int(_name, _opts) {
+      return this;
+    },
+    boolean(_name, _opts) {
+      return this;
+    },
+    id(_name, _opts) {
+      return this;
+    },
+    object(_name, _opts) {
+      return this;
+    },
+    connection(_name, _opts) {
+      return this;
+    },
+    mutation(_name, _opts) {
+      return this;
+    },
+    _spec: {
+      fields: {},
+      relations: {}
+    }
+  };
+
+  return builder;
+}

--- a/apps/bfDb/docs/nextgqlbuilder.md
+++ b/apps/bfDb/docs/nextgqlbuilder.md
@@ -1,0 +1,222 @@
+# GraphQL Builder Migration Plan
+
+## Overview
+
+We’re replacing the legacy three‑helper GraphQL DSL with a **single‑argument
+builder** that mirrors the `bfNodeSpec` field builder. This is a full break from
+existing code; everything will migrate to the new API.
+
+```ts
+static override gqlSpec = this.defineGqlNode(gql =>
+  gql
+    // default lookup (props ➜ getter)
+    .string("name")
+    // scalar with custom resolver + args
+    .int("age", {
+      args: (a) => a.int("inc"),
+      resolve: (root, { inc = 0 }) => root.props.age + inc,
+    })
+    .boolean("isActive")
+    .id("id")
+    .object("primaryOrg")
+    .connection("teams", {
+    additionalArgs: (a) => a.boolean("includeArchived"),
+  })
+    .mutation("invite", {
+    args: (a) => a.string("email")
+    // no custom resolver needed – defaults to root.invite()
+  })
+);
+```
+
+---
+### Quick-Start Checklist
+
+1. **Remove** legacy builders and run `deno check` – expect node compilation errors.
+2. **Convert** one node’s `gqlSpec` to the new fluent builder.
+3. **Run tests**; once green, continue mass migration.
+---
+
+## Step‑by‑Step Roll‑Out
+
+### 0  Document the DSL (this file)
+
+- Record the fluent API, examples, and design constraints.
+
+### 1  Scaffold the New Builder
+
+**Type aliases** (declare once in `makeGqlBuilder.ts`):
+
+```ts
+type ThisNode = InstanceType<typeof CurrentClass>;
+
+type PageInfo = {
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor?: string;
+  endCursor?: string;
+};
+
+type RelayConnection<T> = {
+  edges: { node: T; cursor: string }[];
+  pageInfo: PageInfo;
+};
+
+type MaybePromise<T> = T | Promise<T>;
+
+/** Generic placeholder for a mutation's payload */
+type NMutationPayload = Record<string, unknown>;
+```
+
+**File layout**
+
+- `apps/bfDb/builders/graphql/makeGqlBuilder.ts` – core builder
+- `apps/bfDb/graphql/__generated__/graphqlBuilderBarrel.ts` – **barrel
+  export**&#x20;
+
+#### Helper signatures
+
+```ts
+// Scalar
+.string<N extends string>(
+  name: N,
+  opts?: {
+    args?: (ab: ArgsBuilder) => Record<string, GraphQLInputType>;
+    resolve?: (
+      root: ThisNode,
+      args: any,
+      ctx: Ctx,
+      info: GraphQLResolveInfo
+    ) => MaybePromise<string | number | boolean | null>;
+  }
+): GqlBuilder;
+```
+
+_Default scalar resolver order_
+
+1. `root.props[name]` (if present)
+2. `root[name]` getter or method (invoked with `args, ctx, info` if a function)
+
+```ts
+// Relations
+.object<N extends keyof R & string>(name: N): GqlBuilder;
+
+.connection<N extends keyof R & string>(
+  name: N,
+  opts?: {
+    additionalArgs?: (ab: ArgsBuilder) => Record<string, GraphQLInputType>;
+    resolve?: (
+      root: ThisNode,
+      args: any,
+      ctx: Ctx,
+      info: GraphQLResolveInfo
+    ) => MaybePromise<RelayConnection<any>>;
+  }
+): GqlBuilder;
+
+// Mutations
+// Mutations
+.mutation<N extends string>(
+  name: N,
+  opts?: {
+    args?: (ab: ArgsBuilder) => Record<string, GraphQLInputType>;
+    /** Optional resolver override. If omitted, defaults to calling root[name](args, ctx, info). */
+    resolve?: (
+      root: any,
+      args: any,
+      ctx: Ctx,
+      info: GraphQLResolveInfo
+    ) => MaybePromise<NMutationPayload>;
+  }
+): GqlBuilder;
+```
+
+### 2  Rewrite `defineGqlNode`
+
+- Accept only `(gql) => …`.
+- Delete legacy overloads.
+
+### 3  Purge Old Utilities & Tests 
+
+- Remove `makeGqlFieldBuilder.ts`, `makeGqlRelationBuilder.ts`, and dependent
+  tests.
+- Repo should compile except for node classes.
+
+### 4  Convert One Example Node
+
+- Pick `BfExamplePerson.ts`.
+- Fix type errors until single file compiles.
+
+### 5  Validate Relations
+
+- In `object/connection`, look up `thisNode.bfNodeSpec.relations[name]`.
+- Throw at build‑time if missing or wrong cardinality.
+
+### 6  Generate Runtime GraphQL Types
+
+> **How Yoga/Nexus executes node instances**
+>
+> 1. **Schema creation time** – The builder’s spec is transformed into standard
+>    `GraphQLObjectType`s (or Nexus `objectType()` calls). At runtime Yoga is
+>    dealing with a normal, static schema.
+> 2. **Resolver contract** – Each field’s resolver simply returns what the
+>    _next_ resolver expects:
+>    - **Scalars** → bare JS values (`string`, `number`, `boolean`) or a Promise
+>      thereof.
+>    - **Objects/Connections** → we return a rich **`bfDb`**\*\* node
+>      instance\*\* (for objects) or a `RelayConnection<T>` (for connections).
+>      These become the `root` in the child resolvers.
+> 3. **No extra serialization** – GraphQL never attempts to stringify the entire
+>    node; it just calls the next resolver for each requested child field.
+> 4. **Fallback works with POJOs too** – If a resolver returns a plain JSON
+>    object instead of a node, prop‑first lookup still succeeds; only the
+>    method/ getter fallback is bypassed.
+> 5. **Mutations** – When no custom resolver is supplied, Yoga calls
+>    `root[name](args, ctx, info)`; whatever that returns must match the payload
+>    type declared in the schema.
+
+- Map `spec.fields` & `spec.rels` to `GraphQLObjectType`.
+
+- **Scalar / Connection / Mutation resolution & arguments**
+
+  - **Scalars** attach `args` builder output directly on the field config.
+  - **Objects / Connections** attach `additionalArgs` output (for connections)
+    plus the default pagination args, and default resolver returns
+    `root.relations[name]` if `opts.resolve` is not supplied.
+  - **Mutations** attach `args` output as the mutation's argument map. Defaults
+    to calling `root[name](args, ctx, info)` when `resolve` is omitted.
+
+  - **Scalars** (detailed):
+
+    1. If `opts.resolve` provided ⇒ use it.
+    2. Else read `root.props[name]` (if present).
+    3. Else look for a getter/method `root[name]` and invoke with
+       `(args, ctx, info)` if it’s a function.
+
+**Relation helpers** build `object` or `connection` fields automatically with
+correct args (default pagination + `additionalArgs`). Support Relay-style
+connections.
+
+### 7  Mass‑Convert Remaining Nodes
+
+- Search/replace helpers, update relation calls.
+- Compile and fix typos.
+
+### 8  Write Red Tests for the New API
+
+- Snapshot builder output.
+- Integration: introspect schema for one node.
+
+### 9  Delete Dead Code & Update Docs
+
+- Rip out any remaining references to the legacy API.
+- Update README and internal docs.
+
+---
+
+## Immediate Next Steps
+
+1. **Implement Step 1** — create `makeGqlBuilder.ts` skeleton that compiles.
+2. **Push PR** for early review before moving to Steps 2‑3.
+
+Feel free to edit, reorder, or comment inline as we refine the plan.


### PR DESCRIPTION

This commit introduces a comprehensive plan for migrating the GraphQL builder to a
new single-argument fluent builder pattern that mirrors the BfNodeSpec field builder.

Changes:
- Add detailed nextgqlbuilder.md with step-by-step migration plan
- Create initial makeGqlBuilder.ts scaffold with type definitions
- Define interfaces for the new builder pattern

This is part 1 of the multi-phase implementation outlined in the migration plan.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/736).
* #758
* #757
* #756
* #755
* #754
* #753
* #752
* #751
* #750
* #749
* #748
* #747
* #746
* #745
* #744
* #743
* #742
* #741
* #740
* #739
* #738
* #737
* __->__ #736
* #735