### PR TITLE
Add GitHub PR management tools to BFF CLI

### DIFF
--- a/infra/bff/friends/docs/pr-comments.md
+++ b/infra/bff/friends/docs/pr-comments.md
@@ -1,0 +1,155 @@
+# PR Comments and Review Threads Commands
+
+This documentation covers the GitHub PR-related commands in the BFF CLI.
+
+## pr-comments
+
+Fetches and displays all comments from a GitHub pull request.
+
+### Usage
+
+```bash
+# Fetch comments from PR linked to current branch
+bff pr-comments
+
+# Fetch comments from a specific PR
+bff pr-comments 763
+```
+
+### What it displays
+
+- PR description
+- General PR comments
+- PR reviews (with state: APPROVED, COMMENTED, etc.)
+- Code review comments (inline comments on specific files/lines)
+
+### Example output
+
+```
+=== PR Description ===
+Add support for edge relationships between BfPerson and BfOrganization nodes...
+
+=== PR Comments ===
+(No comments found)
+
+=== PR Reviews ===
+[randallb at 5/16/2025, 4:27:46 PM]
+State: COMMENTED
+Looks generally good.
+----------------------------------------
+
+=== Code Review Comments ===
+File: apps/bfDb/builders/graphql/__tests__/makeGqlBuilder.test.ts
+----------------------------------------
+[randallb at 5/16/2025, 4:19:07 PM]
+apps/bfDb/builders/graphql/__tests__/makeGqlBuilder.test.ts:129
+Let's double check to make sure we're consistent here.
+----------------------------------------
+```
+
+## pr-threads
+
+Lists review threads on a GitHub pull request, showing which are resolved and
+unresolved.
+
+### Usage
+
+```bash
+# List threads from PR linked to current branch
+bff pr-threads
+
+# List threads from a specific PR
+bff pr-threads 763
+```
+
+### What it displays
+
+- Unresolved threads (displayed first)
+- Resolved threads
+- File path and line number for each thread
+- All comments in each thread
+- Instructions on how to resolve each unresolved thread
+
+### Example output
+
+```
+=== Review Threads for PR #763 ===
+
+=== Unresolved Threads ===
+
+Thread PRRT_kwDONzx_xs5QFyJ_ - 🔴 UNRESOLVED
+File: apps/bfDb/builders/graphql/__tests__/makeGqlBuilder.test.ts:129
+----------------------------------------
+randallb at 5/16/2025, 4:19:07 PM
+Let's double check to make sure we're consistent here.
+----------------------------------------
+To resolve: bff pr-resolve 763 PRRT_kwDONzx_xs5QFyJ_
+
+=== Summary ===
+Total threads: 12
+Unresolved: 12
+Resolved: 0
+```
+
+## pr-resolve
+
+Resolves a specific review thread on a GitHub pull request.
+
+### Usage
+
+```bash
+bff pr-resolve PR_NUMBER THREAD_ID
+```
+
+### Example
+
+```bash
+bff pr-resolve 763 PRRT_kwDONzx_xs5QFyJ_
+```
+
+### Requirements
+
+- Requires write permissions to the repository
+- Specifically needs Repository Permissions > Contents set to Read and Write
+  access
+- Must be authenticated with GitHub CLI (`gh auth login`)
+
+### How it works
+
+1. Uses GitHub's GraphQL API to execute the `resolveReviewThread` mutation
+2. Requires the review thread ID (not just the comment ID)
+3. Thread IDs can be found using the `bff pr-threads` command
+
+### Common errors
+
+- "Failed to resolve review thread" - Check authentication and permissions
+- "Invalid thread ID" - Use `bff pr-threads` to get valid thread IDs
+
+## Workflow example
+
+1. View comments on a PR:
+   ```bash
+   bff pr-comments 763
+   ```
+
+2. List review threads to see what needs resolution:
+   ```bash
+   bff pr-threads 763
+   ```
+
+3. Resolve specific threads:
+   ```bash
+   bff pr-resolve 763 PRRT_kwDONzx_xs5QFyJ_
+   ```
+
+4. Verify resolution:
+   ```bash
+   bff pr-threads 763
+   ```
+
+## Technical details
+
+- These commands use the GitHub CLI (`gh`) for API access
+- pr-comments uses REST API endpoints
+- pr-threads and pr-resolve use GraphQL API
+- All commands automatically detect the repository from Sapling configuration

--- a/infra/bff/friends/docs/pr-details.md
+++ b/infra/bff/friends/docs/pr-details.md
@@ -1,0 +1,42 @@
+# bff pr-details
+
+Get detailed information about a GitHub PR.
+
+## Usage
+
+```bash
+bff pr-details <PR_NUMBER>
+```
+
+## Examples
+
+```bash
+# Get details for PR #123
+bff pr-details 123
+```
+
+## Output
+
+The command displays:
+
+- PR title, number, and state
+- Author and timestamps (created, updated, merged)
+- Branch information
+- URL
+- Description/body
+- Statistics (comments, reviews, commits, changed files, additions, deletions)
+- Review status
+
+## Requirements
+
+- GitHub CLI (`gh`) must be installed and authenticated
+- The repository must be linked to a GitHub repository
+- Valid PR number must be provided
+
+## Authentication
+
+If you receive an authentication error, run:
+
+```bash
+gh auth login
+```

--- a/infra/bff/friends/pr-details.bff.ts
+++ b/infra/bff/friends/pr-details.bff.ts
@@ -1,0 +1,148 @@
+#! /usr/bin/env -S bff
+
+// infra/bff/friends/pr-details.bff.ts
+import { register } from "infra/bff/bff.ts";
+import { runShellCommandWithOutput } from "infra/bff/shellBase.ts";
+import { getLogger } from "packages/logger/logger.ts";
+
+const logger = getLogger(import.meta);
+
+/**
+ * Fetches detailed information about a GitHub PR
+ */
+export async function prDetailsCommand(options: string[]): Promise<number> {
+  // Check if PR number is provided
+  const prNumber = options[0];
+  if (!prNumber) {
+    logger.error("Please provide a PR number (e.g., bff pr-details 123)");
+    return 1;
+  }
+
+  logger.info(`Fetching details for PR #${prNumber}...`);
+
+  // First, get the repository URL from Sapling
+  const { stdout: repoUrlOutput, code: repoUrlCode } =
+    await runShellCommandWithOutput([
+      "sl",
+      "paths",
+      "--template",
+      "{url}",
+    ]);
+
+  if (repoUrlCode !== 0 || !repoUrlOutput.trim()) {
+    logger.error("Failed to get repository URL from Sapling");
+    return 1;
+  }
+
+  // Parse the repo URL to get owner and repo name
+  const repoUrl = repoUrlOutput.trim();
+  const urlMatch = repoUrl.match(/github\.com\/([^\/]+)\/([^\/]+)/);
+
+  if (!urlMatch) {
+    logger.error(`Could not parse repo URL from Sapling: ${repoUrl}`);
+    return 1;
+  }
+
+  // Extract owner and repo, and remove .git suffix if present
+  const [, owner, repoWithGit] = urlMatch;
+  const repo = repoWithGit.replace(/\.git$/, "");
+  logger.info(`Using repository: ${owner}/${repo}`);
+
+  // Use GitHub API to fetch PR details
+  const { stdout: prDetailsOutput, code: prDetailsCode } =
+    await runShellCommandWithOutput([
+      "gh",
+      "api",
+      `repos/${owner}/${repo}/pulls/${prNumber}`,
+      "--jq",
+      ".",
+    ]);
+
+  if (prDetailsCode !== 0) {
+    logger.error("Failed to fetch PR details from GitHub");
+    // Check if gh CLI is authenticated
+    const { code: authCode } = await runShellCommandWithOutput([
+      "gh",
+      "auth",
+      "status",
+    ]);
+    if (authCode !== 0) {
+      logger.error(
+        "GitHub CLI not authenticated. Try running 'gh auth login' first",
+      );
+    }
+    return 1;
+  }
+
+  try {
+    const prData = JSON.parse(prDetailsOutput);
+
+    // Print PR information in a formatted way
+    console.log("\n=== PR Details ===");
+    console.log(`Title: ${prData.title}`);
+    console.log(`Number: #${prData.number}`);
+    console.log(`State: ${prData.state}`);
+    console.log(`Author: ${prData.user.login}`);
+    console.log(`Created: ${new Date(prData.created_at).toLocaleString()}`);
+    console.log(`Updated: ${new Date(prData.updated_at).toLocaleString()}`);
+
+    if (prData.merged_at) {
+      console.log(`Merged: ${new Date(prData.merged_at).toLocaleString()}`);
+    }
+
+    console.log(`\nBranches: ${prData.head.ref} -> ${prData.base.ref}`);
+    console.log(`URL: ${prData.html_url}`);
+
+    console.log("\n=== Description ===");
+    console.log(prData.body || "(No description provided)");
+
+    console.log("\n=== Stats ===");
+    console.log(`Comments: ${prData.comments}`);
+    console.log(`Review Comments: ${prData.review_comments}`);
+    console.log(`Commits: ${prData.commits}`);
+    console.log(`Changed Files: ${prData.changed_files}`);
+    console.log(`Additions: +${prData.additions}`);
+    console.log(`Deletions: -${prData.deletions}`);
+
+    // Fetch reviews
+    const { stdout: reviewsOutput, code: reviewsCode } =
+      await runShellCommandWithOutput([
+        "gh",
+        "api",
+        `repos/${owner}/${repo}/pulls/${prNumber}/reviews`,
+        "--jq",
+        ".",
+      ]);
+
+    if (reviewsCode === 0 && reviewsOutput.trim()) {
+      const reviews = JSON.parse(reviewsOutput);
+      console.log("\n=== Reviews ===");
+      if (reviews.length === 0) {
+        console.log("(No reviews yet)");
+      } else {
+        for (const review of reviews) {
+          console.log(
+            `- ${review.user.login}: ${review.state} (${
+              new Date(review.submitted_at).toLocaleString()
+            })`,
+          );
+          if (review.body) {
+            console.log(`  "${review.body}"`);
+          }
+        }
+      }
+    }
+
+    return 0;
+  } catch (error) {
+    logger.error("Failed to parse PR details", error);
+    console.error("Failed to parse PR details");
+    return 1;
+  }
+}
+
+register(
+  "pr-details",
+  "Get detailed information about a GitHub PR",
+  prDetailsCommand,
+);

--- a/infra/bff/friends/pr-resolve.bff.ts
+++ b/infra/bff/friends/pr-resolve.bff.ts
@@ -1,0 +1,140 @@
+#! /usr/bin/env -S bff
+
+// infra/bff/friends/pr-resolve.bff.ts
+import { register } from "infra/bff/bff.ts";
+import { runShellCommandWithOutput } from "infra/bff/shellBase.ts";
+import { getLogger } from "packages/logger/logger.ts";
+
+const logger = getLogger(import.meta);
+
+/**
+ * Resolves a review thread on a GitHub PR using GraphQL
+ */
+export async function prResolveCommand(options: string[]): Promise<number> {
+  // Check if PR number and thread ID were provided as arguments
+  if (options.length < 2) {
+    logger.error("Missing required arguments");
+    logger.info("Usage: bff pr-resolve PR_NUMBER THREAD_ID");
+    logger.info("To list threads: bff pr-threads PR_NUMBER");
+    return 1;
+  }
+
+  const prNumber = options[0];
+  const threadId = options[1];
+
+  if (!/^\d+$/.test(prNumber)) {
+    logger.error("Invalid PR number: " + prNumber);
+    return 1;
+  }
+
+  logger.info(`Resolving thread ${threadId} on PR #${prNumber}...`);
+
+  // Get the repository URL from Sapling
+  const { stdout: repoUrlOutput, code: repoUrlCode } =
+    await runShellCommandWithOutput([
+      "sl",
+      "paths",
+      "--template",
+      "{url}",
+    ]);
+
+  if (repoUrlCode !== 0 || !repoUrlOutput.trim()) {
+    logger.error("Failed to get repository URL from Sapling");
+    return 1;
+  }
+
+  // Parse the repo URL to get owner and repo name
+  const repoUrl = repoUrlOutput.trim();
+  const urlMatch = repoUrl.match(/github\.com\/([^\/]+)\/([^\/]+)/);
+
+  if (!urlMatch) {
+    logger.error(`Could not parse repo URL from Sapling: ${repoUrl}`);
+    return 1;
+  }
+
+  // Extract owner and repo, and remove .git suffix if present
+  const [, owner, repoWithGit] = urlMatch;
+  const repo = repoWithGit.replace(/\.git$/, "");
+  logger.info(`Using repository: ${owner}/${repo}`);
+
+  // Create the GraphQL mutation to resolve the thread
+  const mutation = `
+    mutation ResolveReviewThread($threadId: ID!) {
+      resolveReviewThread(input: { threadId: $threadId }) {
+        thread {
+          id
+          isResolved
+        }
+      }
+    }
+  `;
+
+  // Execute the GraphQL mutation using gh CLI
+  const { stdout: mutationResult, code: mutationCode } =
+    await runShellCommandWithOutput([
+      "gh",
+      "api",
+      "graphql",
+      "-f",
+      `query=${mutation}`,
+      "-f",
+      `threadId=${threadId}`,
+    ]);
+
+  if (mutationCode !== 0) {
+    logger.error("Failed to resolve review thread");
+    logger.debug("GraphQL error:", mutationResult);
+
+    // Check if gh CLI is authenticated
+    const { code: authCode } = await runShellCommandWithOutput([
+      "gh",
+      "auth",
+      "status",
+    ]);
+    if (authCode !== 0) {
+      logger.error(
+        "GitHub CLI not authenticated. Try running 'gh auth login' first",
+      );
+    } else {
+      logger.error(
+        "Make sure you have write permissions to the repository",
+      );
+      logger.error(
+        "You need Repository Permissions > Contents set to Read and Write access",
+      );
+    }
+    return 1;
+  }
+
+  try {
+    const result = JSON.parse(mutationResult);
+    if (result.data?.resolveReviewThread?.thread?.isResolved) {
+      logger.info("Successfully resolved review thread");
+      return 0;
+    } else {
+      logger.error("Failed to resolve review thread");
+      logger.debug("Result:", result);
+      return 1;
+    }
+  } catch (error) {
+    logger.error("Failed to parse mutation result", error);
+    logger.debug("Raw result:", mutationResult);
+    return 1;
+  }
+}
+
+register(
+  "pr-resolve",
+  "Resolve a review thread on a GitHub PR",
+  prResolveCommand,
+  [
+    {
+      option: "PR_NUMBER",
+      description: "The pull request number",
+    },
+    {
+      option: "THREAD_ID",
+      description: "The review thread ID to resolve",
+    },
+  ],
+);

--- a/infra/bff/friends/pr-threads.bff.ts
+++ b/infra/bff/friends/pr-threads.bff.ts
@@ -1,0 +1,269 @@
+#! /usr/bin/env -S bff
+
+// infra/bff/friends/pr-threads.bff.ts
+import { register } from "infra/bff/bff.ts";
+import { runShellCommandWithOutput } from "infra/bff/shellBase.ts";
+import { getLogger } from "packages/logger/logger.ts";
+
+const logger = getLogger(import.meta);
+
+/**
+ * Custom console logger for PR threads that formats and outputs them with better readability
+ */
+const consoleLogger = {
+  header: (text: string) => {
+    // deno-lint-ignore no-console
+    console.log(`\n\x1b[1;36m=== ${text} ===\x1b[0m`);
+  },
+  threadHeader: (text: string, resolved: boolean) => {
+    const color = resolved ? "\x1b[32m" : "\x1b[33m"; // Green for resolved, yellow for unresolved
+    // deno-lint-ignore no-console
+    console.log(`\n${color}${text}\x1b[0m`);
+  },
+  info: (text: string) => {
+    // deno-lint-ignore no-console
+    console.log(`\x1b[90m${text}\x1b[0m`);
+  },
+  error: (text: string) => {
+    // deno-lint-ignore no-console
+    console.log(`\x1b[1;31m${text}\x1b[0m`);
+  },
+  content: (text: string) => {
+    // deno-lint-ignore no-console
+    console.log(`${text}`);
+  },
+  separator: () => {
+    // deno-lint-ignore no-console
+    console.log(`\x1b[90m----------------------------------------\x1b[0m`);
+  },
+};
+
+/**
+ * Lists review threads on a GitHub PR
+ */
+export async function prThreadsCommand(options: string[]): Promise<number> {
+  let prNumber: string;
+
+  // Check if PR number was provided as an argument
+  if (options.length > 0 && /^\d+$/.test(options[0])) {
+    prNumber = options[0];
+    logger.info(`Fetching review threads for PR #${prNumber}...`);
+  } else {
+    logger.info("Fetching review threads from linked GitHub PR...");
+
+    // Get the current PR info directly from Sapling
+    const { stdout: prOutput, code: prCode } = await runShellCommandWithOutput([
+      "sl",
+      "pr",
+      "list",
+      "--limit",
+      "1",
+    ]);
+
+    if (prCode !== 0) {
+      logger.error("Failed to get PR information from Sapling");
+      return 1;
+    }
+
+    // Check if we have any PR data
+    if (!prOutput || !prOutput.trim()) {
+      logger.error("No linked GitHub PR found for current branch", prOutput);
+      logger.info("Usage: bff pr-threads [PR_NUMBER]");
+      return 1;
+    }
+
+    logger.debug("PR output:", prOutput);
+
+    // Find the PR number from the PR output
+    const prRegex = /^(\d+)\s+/; // Match the PR number at the start of the output
+    const prMatch = prOutput.match(prRegex);
+
+    if (!prMatch) {
+      logger.error("Could not extract PR number from Sapling output");
+      logger.debug("Received PR output:", prOutput);
+      return 1;
+    }
+
+    prNumber = prMatch[1];
+    logger.info(`Found linked GitHub PR #${prNumber}`);
+  }
+
+  // Get the repository URL from Sapling
+  const { stdout: repoUrlOutput, code: repoUrlCode } =
+    await runShellCommandWithOutput([
+      "sl",
+      "paths",
+      "--template",
+      "{url}",
+    ]);
+
+  if (repoUrlCode !== 0 || !repoUrlOutput.trim()) {
+    logger.error("Failed to get repository URL from Sapling");
+    return 1;
+  }
+
+  // Parse the repo URL to get owner and repo name
+  const repoUrl = repoUrlOutput.trim();
+  const urlMatch = repoUrl.match(/github\.com\/([^\/]+)\/([^\/]+)/);
+
+  if (!urlMatch) {
+    logger.error(`Could not parse repo URL from Sapling: ${repoUrl}`);
+    return 1;
+  }
+
+  // Extract owner and repo, and remove .git suffix if present
+  const [, owner, repoWithGit] = urlMatch;
+  const repo = repoWithGit.replace(/\.git$/, "");
+  logger.info(`Using repository: ${owner}/${repo}`);
+
+  // Create GraphQL query to fetch review threads
+  const query = `
+    query GetReviewThreads($owner: String!, $repo: String!, $pr: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $pr) {
+          title
+          reviewThreads(first: 100) {
+            nodes {
+              id
+              isResolved
+              isCollapsed
+              path
+              line
+              comments(first: 10) {
+                nodes {
+                  id
+                  body
+                  author {
+                    login
+                  }
+                  createdAt
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  // Execute the GraphQL query using gh CLI
+  const { stdout: queryResult, code: queryCode } =
+    await runShellCommandWithOutput([
+      "gh",
+      "api",
+      "graphql",
+      "-f",
+      `query=${query}`,
+      "-f",
+      `owner=${owner}`,
+      "-f",
+      `repo=${repo}`,
+      "-F",
+      `pr=${prNumber}`,
+    ]);
+
+  if (queryCode !== 0) {
+    logger.error("Failed to fetch review threads");
+    logger.debug("GraphQL error:", queryResult);
+
+    // Check if gh CLI is authenticated
+    const { code: authCode } = await runShellCommandWithOutput([
+      "gh",
+      "auth",
+      "status",
+    ]);
+    if (authCode !== 0) {
+      logger.error(
+        "GitHub CLI not authenticated. Try running 'gh auth login' first",
+      );
+    }
+    return 1;
+  }
+
+  try {
+    const result = JSON.parse(queryResult);
+    const threads = result.data?.repository?.pullRequest?.reviewThreads?.nodes;
+
+    if (!threads) {
+      logger.error("Failed to parse review threads");
+      logger.debug("Result:", result);
+      return 1;
+    }
+
+    consoleLogger.header(`Review Threads for PR #${prNumber}`);
+
+    if (threads.length === 0) {
+      consoleLogger.info("(No review threads found)");
+      return 0;
+    }
+
+    // Group threads by resolved status
+    const resolvedThreads = threads.filter((t: any) => t.isResolved);
+    const unresolvedThreads = threads.filter((t: any) => !t.isResolved);
+
+    // Display unresolved threads first
+    if (unresolvedThreads.length > 0) {
+      consoleLogger.header("Unresolved Threads");
+      for (const thread of unresolvedThreads) {
+        displayThread(thread, false, prNumber);
+      }
+    }
+
+    // Display resolved threads
+    if (resolvedThreads.length > 0) {
+      consoleLogger.header("Resolved Threads");
+      for (const thread of resolvedThreads) {
+        displayThread(thread, true, prNumber);
+      }
+    }
+
+    // Summary
+    consoleLogger.header("Summary");
+    consoleLogger.info(`Total threads: ${threads.length}`);
+    consoleLogger.info(`Unresolved: ${unresolvedThreads.length}`);
+    consoleLogger.info(`Resolved: ${resolvedThreads.length}`);
+
+    return 0;
+  } catch (error) {
+    logger.error("Failed to parse query result", error);
+    logger.debug("Raw result:", queryResult);
+    return 1;
+  }
+}
+
+function displayThread(thread: any, resolved: boolean, prNumber: string) {
+  const status = resolved ? "✅ RESOLVED" : "🔴 UNRESOLVED";
+  const file = thread.path || "(unknown file)";
+  const line = thread.line ? `:${thread.line}` : "";
+
+  consoleLogger.threadHeader(`Thread ${thread.id} - ${status}`, resolved);
+  consoleLogger.info(`File: ${file}${line}`);
+  consoleLogger.separator();
+
+  if (thread.comments?.nodes) {
+    for (const comment of thread.comments.nodes) {
+      const author = comment.author?.login || "(unknown)";
+      const date = new Date(comment.createdAt).toLocaleString();
+      consoleLogger.info(`${author} at ${date}`);
+      consoleLogger.content(comment.body);
+      consoleLogger.separator();
+    }
+  }
+
+  if (!resolved) {
+    consoleLogger.info(`To resolve: bff pr-resolve ${prNumber} ${thread.id}`);
+  }
+}
+
+register(
+  "pr-threads",
+  "List review threads on a GitHub PR",
+  prThreadsCommand,
+  [
+    {
+      option: "[PR_NUMBER]",
+      description:
+        "Optional PR number. If not provided, uses the PR linked to the current branch.",
+    },
+  ],
+);


### PR DESCRIPTION

Implement comprehensive PR tools for GitHub integration:
- pr-details: Get detailed information about a PR
- pr-comments: Fetch and display PR comments
- pr-threads: List review threads
- pr-resolve: Resolve review threads

Changes:
- Created infra/bff/friends/pr-details.bff.ts for PR information
- Created infra/bff/friends/pr-comments.bff.ts for comment retrieval
- Created infra/bff/friends/pr-threads.bff.ts for review thread listing
- Created infra/bff/friends/pr-resolve.bff.ts for thread resolution
- Added documentation for all PR commands
- Integrated with GitHub API using gh CLI

Test plan:
1. Run bff pr-details 763 to view PR details
2. Test bff pr-comments to see comments
3. Use bff pr-threads to list review threads
4. Run bff pr-resolve to resolve a thread

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
