### PR TITLE
Add undefined case test for getSecret

### DIFF
--- a/packages/get-configuration-var/__tests__/get-configuration-var.test.ts
+++ b/packages/get-configuration-var/__tests__/get-configuration-var.test.ts
@@ -87,3 +87,10 @@ Deno.test("Unknown key resolves only via ENV", async () => {
   assertEquals(val, "env‑value");
   Deno.env.delete(UNKNOWN_KEY);
 });
+
+/* ──────── Unknown key missing from ENV ──────── */
+Deno.test("getSecret() returns undefined when unknown key not in ENV", async () => {
+  Deno.env.delete(UNKNOWN_KEY); // ensure no accidental value
+  const val = await getSecret(UNKNOWN_KEY);
+  assertEquals(val, undefined);
+});


### PR DESCRIPTION
## Summary
- test getSecret with unknown key missing from ENV

## Testing
- `./infra/bin/bff ci` *(fails: `/usr/bin/env: ‘deno’: No such file or directory`)*

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/780)
<!-- GitContextEnd -->