### PR TITLE
Fix warmSecrets failing on missing secrets

### DIFF
--- a/packages/get-configuration-var/__tests__/get-configuration-var.test.ts
+++ b/packages/get-configuration-var/__tests__/get-configuration-var.test.ts
@@ -87,3 +87,9 @@ Deno.test("Unknown key resolves only via ENV", async () => {
   assertEquals(val, "env‑value");
   Deno.env.delete(UNKNOWN_KEY);
 });
+
+Deno.test("warmSecrets does not throw for unknown keys", async () => {
+  await warmSecrets([UNKNOWN_KEY]);
+  const val = await getSecret(UNKNOWN_KEY);
+  assertEquals(val, undefined);
+});


### PR DESCRIPTION
## Summary
- prevent warmSecrets from throwing when op inject fails
- test warmSecrets with unknown key

## Testing
- `deno --version` *(fails: command not found)*
- `bff ci` *(fails: command not found)*

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/781)
<!-- GitContextEnd -->