### PR TITLE
Add failing tests for builder validation

### DIFF
--- a/apps/bfDb/builders/graphql/__tests__/gqlBuilderValidation.test.ts
+++ b/apps/bfDb/builders/graphql/__tests__/gqlBuilderValidation.test.ts
@@ -1,0 +1,19 @@
+#! /usr/bin/env -S bff test
+import { assertThrows } from "@std/assert";
+import { gqlSpecToNexus } from "../gqlSpecToNexus.ts";
+import { BfPerson } from "../../../nodeTypes/BfPerson.ts";
+
+Deno.test(
+  "gqlSpecToNexus validates relations against bfNodeSpec",
+  () => {
+    // BfPerson defines a memberOf relation in its GraphQL spec
+    // but BfPerson.bfNodeSpec currently lacks this relation.
+    // Once validation is implemented, converting this spec should throw.
+    assertThrows(
+      () => {
+        gqlSpecToNexus(BfPerson.gqlSpec, "BfPerson");
+      },
+      Error,
+    );
+  },
+);

--- a/apps/bfDb/graphql/__tests__/builderIntegration.test.ts
+++ b/apps/bfDb/graphql/__tests__/builderIntegration.test.ts
@@ -1,0 +1,18 @@
+#! /usr/bin/env -S bff test
+
+import { assert } from "@std/assert";
+import { makeSchema } from "nexus";
+import { printSchema } from "graphql";
+import { loadGqlTypes } from "../graphqlServer.ts";
+
+Deno.test("graphqlServer loads node types via builder", () => {
+  const schema = makeSchema({ types: { ...loadGqlTypes() } });
+  const sdl = printSchema(schema);
+
+  // Once the builder integration is complete, BfPerson should be included
+  // as a GraphQL type in the schema.
+  assert(
+    sdl.includes("type BfPerson"),
+    "Schema should include BfPerson when builder integration is implemented",
+  );
+});


### PR DESCRIPTION
## Summary
- add failing test for missing relation validation
- add failing test for GraphQL builder integration

## Testing
- `npx bff f` *(fails: request to https://registry.npmjs.org/bff failed)*

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/783)
<!-- GitContextEnd -->