### PR TITLE
Refactor GraphQL type generation into dedicated BFF command

### DIFF
--- a/infra/bff/friends/build.bff.ts
+++ b/infra/bff/friends/build.bff.ts
@@ -477,9 +477,9 @@ export async function build(args: Array<string>): Promise<number> {
     return contentResult;
   }
 
-  if (debug) logMemoryUsage("before graphql server");
-  const result = await sh("./apps/bfDb/graphql/graphqlServer.ts");
-  if (debug) logMemoryUsage("after graphql server");
+  if (debug) logMemoryUsage("before graphql types");
+  const result = await runShellCommand(["bff", "genGqlTypes"]);
+  if (debug) logMemoryUsage("after graphql types");
 
   if (result) return result;
   if (result && waitForFail) {

--- a/infra/bff/friends/genGqlTypes.bff.ts
+++ b/infra/bff/friends/genGqlTypes.bff.ts
@@ -1,0 +1,58 @@
+#! /usr/bin/env -S bff
+
+import { register } from "infra/bff/bff.ts";
+import { getLogger } from "packages/logger/logger.ts";
+import { makeSchema } from "nexus";
+import { schemaOptions } from "apps/bfDb/graphql/graphqlServer.ts";
+
+const logger = getLogger(import.meta);
+
+export function generateGqlTypes() {
+  makeSchema({
+    ...schemaOptions,
+    types: { ...schemaOptions.types },
+    contextType: {
+      module: import.meta.resolve("apps/bfDb/graphql/graphqlContext.ts")
+        .replace(
+          "file://",
+          "",
+        ),
+      export: "Context",
+    },
+    formatTypegen: (content, type) => {
+      if (type === "schema") {
+        return `### @generated \n${content}`;
+      } else {
+        return `/* @generated */\n// deno-lint-ignore-file\n${
+          content.replace(/(["'])(\.+\/[^"']+)\1/g, "$1$2.ts$1")
+        }`;
+      }
+    },
+    outputs: {
+      schema: new URL(
+        import.meta.resolve(`apps/bfDb/graphql/__generated__/schema.graphql`),
+      ).pathname,
+      typegen: new URL(
+        import.meta.resolve(`apps/bfDb/graphql/__generated__/_nexustypes.ts`),
+      ).pathname,
+    },
+  });
+}
+
+export function genGqlTypes(_: string[]): number {
+  try {
+    logger.info("Generating GraphQL schema and types...");
+    generateGqlTypes();
+    logger.info("✅ GraphQL types generated");
+    return 0;
+  } catch (err) {
+    logger.error("GraphQL type generation failed", err);
+    return 1;
+  }
+}
+
+register(
+  "genGqlTypes",
+  "Generate GraphQL schema and nexus types",
+  genGqlTypes,
+);


### PR DESCRIPTION
Extract GraphQL schema and type generation logic from graphqlServer.ts into a new
genGqlTypes BFF command for better modularity and reusability.

Changes:
- Created infra/bff/friends/genGqlTypes.bff.ts with standalone type generation
- Updated graphqlServer.ts to export schemaOptions and use genGqlTypes function
- Modified build.bff.ts to use bff genGqlTypes instead of running server file
- Added proper error handling and logging to the new command

Test plan:
1. Run bff genGqlTypes to verify it generates types correctly
2. Run bff build to ensure the build process still works
3. Check that generated GraphQL types are unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/787)
<!-- GitContextEnd -->