### PR TITLE
refactor: Extract GraphQL configuration into separate modules

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -19,7 +19,14 @@
       "Bash(grep:*)",
       "Bash(bff check:*)",
       "Bash(bff pr-details:*)",
-      "Bash(bff merge:*)"
+      "Bash(bff merge:*)",
+      "Bash(sl status:*)",
+      "Bash(sl diff:*)",
+      "Bash(bff genGqlTypes:*)",
+      "Bash(bff build:*)",
+      "Bash(sl add:*)",
+      "Bash(bff test:*)",
+      "Bash(bff lint:*)"
     ],
     "deny": []
   }

--- a/apps/bfDb/graphql/__tests__/TestType.test.ts
+++ b/apps/bfDb/graphql/__tests__/TestType.test.ts
@@ -7,7 +7,7 @@
 import { assert } from "@std/assert";
 import { makeSchema } from "nexus";
 import { printSchema } from "graphql";
-import { loadGqlTypes } from "../graphqlServer.ts";
+import { loadGqlTypes } from "../loadGqlTypes.ts";
 
 function buildTestSchema(): string {
   const schema = makeSchema({ types: { ...loadGqlTypes() } });

--- a/apps/bfDb/graphql/graphqlServer.ts
+++ b/apps/bfDb/graphql/graphqlServer.ts
@@ -1,10 +1,9 @@
 #! /usr/bin/env -S deno run --allow-write --allow-read --allow-env
 
-import { connectionPlugin, makeSchema } from "nexus";
+import { makeSchema } from "nexus";
 import { createYoga } from "graphql-yoga";
 
 import { createContext } from "apps/bfDb/graphql/graphqlContext.ts";
-import type { SchemaConfig } from "nexus/dist/builder.js";
 import { getLogger } from "packages/logger/logger.ts";
 // Let's create our own loadModelTypes function
 // import { loadModelTypes } from "apps/bfDb/builders/graphql/loadSpecs.ts";
@@ -15,79 +14,8 @@ logger.setLevel(logger.levels.DEBUG);
 // Import our GraphQL builder tools - imported only for types but not used directly yet
 import type { makeGqlSpec as _makeGqlSpec } from "apps/bfDb/builders/graphql/makeGqlSpec.ts";
 import type { gqlSpecToNexus as _gqlSpecToNexus } from "apps/bfDb/builders/graphql/gqlSpecToNexus.ts";
-import { objectType, queryType } from "nexus";
 import { generateGqlTypes } from "infra/bff/friends/genGqlTypes.bff.ts";
-
-/**
- * Loads GraphQL types using our new builder pattern.
- * This will eventually load all node types in the system.
- */
-export function loadGqlTypes() {
-  // Create a test GraphQL type directly with Nexus to verify schema generation
-  const TestType = objectType({
-    name: "TestType",
-    definition(t) {
-      t.string("name");
-      t.nonNull.id("id");
-      t.boolean("isActive");
-      t.int("count");
-    },
-  });
-
-  // Create a query type that returns our test type
-  const Query = queryType({
-    definition(t) {
-      // Test field
-      t.field("test", {
-        type: "TestType",
-        resolve: () => ({
-          id: "test-123",
-          name: "Test Object",
-          isActive: true,
-          count: 42,
-        }),
-      });
-
-      // Health check
-      t.nonNull.boolean("ok", {
-        resolve: () => true,
-      });
-    },
-  });
-
-  // Return the types
-  return {
-    Query,
-    TestType,
-  };
-}
-
-export const schemaOptions: SchemaConfig = {
-  // Use our new loadGqlTypes function
-  types: { ...loadGqlTypes() },
-  features: {
-    abstractTypeStrategies: {
-      __typename: true,
-    },
-  },
-  plugins: [
-    connectionPlugin({
-      validateArgs: (args) => {
-        if (args.first == null && args.last == null) {
-          args.first = 10;
-        }
-        return args;
-      },
-      extendConnection: {
-        count: {
-          type: "Int",
-          requireResolver: false,
-        },
-      },
-      includeNodesField: true,
-    }),
-  ],
-};
+import { schemaOptions } from "./schemaConfig.ts";
 
 export const schema = makeSchema(schemaOptions);
 

--- a/apps/bfDb/graphql/loadGqlTypes.ts
+++ b/apps/bfDb/graphql/loadGqlTypes.ts
@@ -1,0 +1,45 @@
+import { objectType, queryType } from "nexus";
+
+/**
+ * Loads GraphQL types using our new builder pattern.
+ * This will eventually load all node types in the system.
+ */
+export function loadGqlTypes() {
+  // Create a test GraphQL type directly with Nexus to verify schema generation
+  const TestType = objectType({
+    name: "TestType",
+    definition(t) {
+      t.string("name");
+      t.nonNull.id("id");
+      t.boolean("isActive");
+      t.int("count");
+    },
+  });
+
+  // Create a query type that returns our test type
+  const Query = queryType({
+    definition(t) {
+      // Test field
+      t.field("test", {
+        type: "TestType",
+        resolve: () => ({
+          id: "test-123",
+          name: "Test Object",
+          isActive: true,
+          count: 42,
+        }),
+      });
+
+      // Health check
+      t.nonNull.boolean("ok", {
+        resolve: () => true,
+      });
+    },
+  });
+
+  // Return the types
+  return {
+    Query,
+    TestType,
+  };
+}

--- a/apps/bfDb/graphql/schemaConfig.ts
+++ b/apps/bfDb/graphql/schemaConfig.ts
@@ -1,0 +1,30 @@
+import { connectionPlugin } from "nexus";
+import type { SchemaConfig } from "nexus/dist/builder.js";
+import { loadGqlTypes } from "./loadGqlTypes.ts";
+
+export const schemaOptions: SchemaConfig = {
+  // Use our new loadGqlTypes function
+  types: { ...loadGqlTypes() },
+  features: {
+    abstractTypeStrategies: {
+      __typename: true,
+    },
+  },
+  plugins: [
+    connectionPlugin({
+      validateArgs: (args) => {
+        if (args.first == null && args.last == null) {
+          args.first = 10;
+        }
+        return args;
+      },
+      extendConnection: {
+        count: {
+          type: "Int",
+          requireResolver: false,
+        },
+      },
+      includeNodesField: true,
+    }),
+  ],
+};

--- a/infra/bff/friends/genGqlTypes.bff.ts
+++ b/infra/bff/friends/genGqlTypes.bff.ts
@@ -3,7 +3,7 @@
 import { register } from "infra/bff/bff.ts";
 import { getLogger } from "packages/logger/logger.ts";
 import { makeSchema } from "nexus";
-import { schemaOptions } from "apps/bfDb/graphql/graphqlServer.ts";
+import { schemaOptions } from "apps/bfDb/graphql/schemaConfig.ts";
 
 const logger = getLogger(import.meta);
 


### PR DESCRIPTION
Split the GraphQL server configuration into dedicated modules for better organization
and maintainability:

- Move `loadGqlTypes` function to `loadGqlTypes.ts`
- Move `schemaOptions` to `schemaConfig.ts`
- Update imports to reflect new structure
- Update genGqlTypes to import directly from schemaConfig

Changes:
- Created apps/bfDb/graphql/loadGqlTypes.ts
- Created apps/bfDb/graphql/schemaConfig.ts
- Modified apps/bfDb/graphql/graphqlServer.ts
- Modified infra/bff/friends/genGqlTypes.bff.ts
- Modified apps/bfDb/graphql/__tests__/TestType.test.ts

Test plan:
1. Run `bff test apps/bfDb/graphql/__tests__/TestType.test.ts` - all tests pass
2. Run `bff build` - build succeeds
3. Run `bff lint` and `bff check` - no issues

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/788)
<!-- GitContextEnd -->