### PR TITLE
Migrate Waitlist to new GraphQL builder pattern

### DIFF
--- a/apps/bfDb/graphql/__generated__/_nexustypes.ts
+++ b/apps/bfDb/graphql/__generated__/_nexustypes.ts
@@ -43,6 +43,11 @@ export interface NexusGenScalars {
 }
 
 export interface NexusGenObjects {
+  JoinWaitlistPayload: { // root type
+    message?: string | null; // String
+    success: boolean; // Boolean!
+  }
+  Mutation: {};
   Query: {};
   TestType: { // root type
     count?: number | null; // Int
@@ -50,6 +55,7 @@ export interface NexusGenObjects {
     isActive?: boolean | null; // Boolean
     name?: string | null; // String
   }
+  Waitlist: {};
 }
 
 export interface NexusGenInterfaces {
@@ -63,6 +69,13 @@ export type NexusGenRootTypes = NexusGenObjects
 export type NexusGenAllTypes = NexusGenRootTypes & NexusGenScalars
 
 export interface NexusGenFieldTypes {
+  JoinWaitlistPayload: { // field return type
+    message: string | null; // String
+    success: boolean; // Boolean!
+  }
+  Mutation: { // field return type
+    joinWaitlist: NexusGenRootTypes['JoinWaitlistPayload'] | null; // JoinWaitlistPayload
+  }
   Query: { // field return type
     ok: boolean; // Boolean!
     test: NexusGenRootTypes['TestType'] | null; // TestType
@@ -73,9 +86,19 @@ export interface NexusGenFieldTypes {
     isActive: boolean | null; // Boolean
     name: string | null; // String
   }
+  Waitlist: { // field return type
+    id: string | null; // ID
+  }
 }
 
 export interface NexusGenFieldTypeNames {
+  JoinWaitlistPayload: { // field return type name
+    message: 'String'
+    success: 'Boolean'
+  }
+  Mutation: { // field return type name
+    joinWaitlist: 'JoinWaitlistPayload'
+  }
   Query: { // field return type name
     ok: 'Boolean'
     test: 'TestType'
@@ -86,9 +109,19 @@ export interface NexusGenFieldTypeNames {
     isActive: 'Boolean'
     name: 'String'
   }
+  Waitlist: { // field return type name
+    id: 'ID'
+  }
 }
 
 export interface NexusGenArgTypes {
+  Mutation: {
+    joinWaitlist: { // args
+      company: string; // String!
+      email: string; // String!
+      name: string; // String!
+    }
+  }
 }
 
 export interface NexusGenAbstractTypeMembers {

--- a/apps/bfDb/graphql/__generated__/schema.graphql
+++ b/apps/bfDb/graphql/__generated__/schema.graphql
@@ -3,6 +3,15 @@
 ### Do not make changes to this file directly
 
 
+type JoinWaitlistPayload {
+  message: String
+  success: Boolean!
+}
+
+type Mutation {
+  joinWaitlist(company: String!, email: String!, name: String!): JoinWaitlistPayload
+}
+
 type Query {
   ok: Boolean!
   test: TestType
@@ -13,4 +22,8 @@ type TestType {
   id: ID!
   isActive: Boolean
   name: String
+}
+
+type Waitlist {
+  id: ID
 }

--- a/apps/bfDb/graphql/roots/Waitlist.ts
+++ b/apps/bfDb/graphql/roots/Waitlist.ts
@@ -1,4 +1,3 @@
-import { defineGqlNode } from "apps/bfDb/builders/graphql/builder.ts";
 import { getLogger } from "packages/logger/logger.ts";
 import { getConfigurationVariable } from "@bolt-foundry/get-configuration-var";
 import { GraphQLObjectBase } from "apps/bfDb/graphql/GraphQLObjectBase.ts";
@@ -6,64 +5,64 @@ import { GraphQLObjectBase } from "apps/bfDb/graphql/GraphQLObjectBase.ts";
 const logger = getLogger(import.meta);
 
 export class Waitlist extends GraphQLObjectBase {
-  static override gqlSpec = defineGqlNode((_f, _rel, mutation) => {
-    mutation.custom("join", {
-      args: (a) => {
-        a.string("email");
-        a.string("name");
-        a.string("company");
-      },
-      returns: (r) => {
-        r.boolean("success");
-        r.string("message");
-      },
-      async resolve(_src, { email, name, company }) {
-        try {
-          const apiKey = getConfigurationVariable("WAITLIST_API_KEY");
-          if (!apiKey) {
-            logger.error("WAITLIST_API_KEY environment variable is not set");
+  static override gqlSpec = this.defineGqlNode((gql) =>
+    gql
+      .id("id")
+      .mutation("joinWaitlist", {
+        args: (a) =>
+          a
+            .nonNull.string("email")
+            .nonNull.string("name")
+            .nonNull.string("company"),
+        returns: "JoinWaitlistPayload",
+        async resolve(_src, { email, name, company }) {
+          try {
+            const apiKey = getConfigurationVariable("WAITLIST_API_KEY");
+            if (!apiKey) {
+              logger.error("WAITLIST_API_KEY environment variable is not set");
+              return {
+                success: false,
+                message: "Server configuration error",
+              };
+            }
+
+            const slug = getConfigurationVariable("REPL_SLUG");
+            const baseUrl =
+              getConfigurationVariable("NODE_ENV") === "production"
+                ? `https://${slug}.replit.app`
+                : "http://localhost:8000";
+
+            const joinWaitlistResponse = await fetch(
+              `${baseUrl}/contacts-cms`,
+              {
+                method: "POST",
+                headers: {
+                  "x-api-key": apiKey,
+                  "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                  name: name,
+                  email: email,
+                  company: company,
+                }),
+              },
+            );
+
+            const responseData = await joinWaitlistResponse.json();
+            logger.debug("Response", responseData);
+
+            return {
+              success: responseData.success !== false,
+              message: responseData.message || null,
+            };
+          } catch (error) {
+            logger.error("Error joining waitlist", error);
             return {
               success: false,
-              message: "Server configuration error",
+              message: "Failed to join waitlist",
             };
           }
-
-          const slug = getConfigurationVariable("REPL_SLUG");
-          const baseUrl = getConfigurationVariable("NODE_ENV") === "production"
-            ? `https://${slug}.replit.app`
-            : "http://localhost:8000";
-
-          const joinWaitlistResponse = await fetch(
-            `${baseUrl}/contacts-cms`,
-            {
-              method: "POST",
-              headers: {
-                "x-api-key": apiKey,
-                "Content-Type": "application/json",
-              },
-              body: JSON.stringify({
-                name: name,
-                email: email,
-                company: company,
-              }),
-            },
-          );
-
-          const responseData = await joinWaitlistResponse.json();
-          logger.debug("Response", responseData);
-
-          return {
-            success: responseData.success !== false,
-            message: responseData.message || null,
-          };
-        } catch (error) {
-          logger.error("Error joining waitlist", error);
-          return {
-            success: false,
-            message: "Failed to join waitlist",
-          };
-        }
-      },
-    });
-  });
+        },
+      })
+  );
 }

--- a/apps/bfDb/graphql/schemaConfig.ts
+++ b/apps/bfDb/graphql/schemaConfig.ts
@@ -4,7 +4,7 @@ import { loadGqlTypes } from "./loadGqlTypes.ts";
 
 export const schemaOptions: SchemaConfig = {
   // Use our new loadGqlTypes function
-  types: { ...loadGqlTypes() },
+  types: loadGqlTypes(),
   features: {
     abstractTypeStrategies: {
       __typename: true,


### PR DESCRIPTION

Load Waitlist type using gqlSpecToNexus with temporary string returns.

Changes:
- Update Waitlist to use this.defineGqlNode with new builder pattern
- Add Waitlist and JoinWaitlistPayload to loadGqlTypes
- Fix schema configuration to properly spread types
- Update GraphQL schema with Waitlist type and joinWaitlist mutation

Test plan:
1. Run bff genGqlTypes - verify schema includes Mutation type
2. Check schema.graphql has joinWaitlist mutation
3. Run bff lint and bff check to ensure code quality
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/791).
* #792
* __->__ #791