### PR TITLE
Add extra caching debug info

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,15 @@ jobs:
           echo "Symlinks in current directory:"
           find . -maxdepth 3 -type l -ls || true
 
+      - name: Show computed cache key
+        run: echo "Computed cache key: deno-${{ runner.os }}-${{ hashFiles('**/deno.json*', '**/package.json', '**/deno.lock') }}"
+
       # 1️⃣ RESTORE
       - name: Restore Deno / vendored / node cache
         id: cache-deno
         uses: actions/cache/restore@v4
+        env:
+          ACTIONS_CACHE_DEBUG: true
         with:
           path: |
             vendor


### PR DESCRIPTION
## Summary
- show computed cache key
- enable verbose cache output for restore step

## Testing
- `git status --short`

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/796)
<!-- GitContextEnd -->