### PR TITLE
Add lint rule to prevent shipping logger.setLevel in PRs

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -40,6 +40,11 @@
       "Bash(sl status:*)",
       "Bash(sl diff:*)",
       "Bash(bff commit:*)"
+      "Bash(gh pr diff:*)",
+      "Bash(ls:*)",
+      "Bash(apps/bfDb/bin/genBarrel.ts)",
+      "Bash(./apps/bfDb/graphql/graphqlServer.ts)",
+      "Bash(deno check:*)"
     ],
     "deny": []
   }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -39,7 +39,7 @@
       "WebFetch(domain:docs.github.com)",
       "Bash(sl status:*)",
       "Bash(sl diff:*)",
-      "Bash(bff commit:*)"
+      "Bash(bff commit:*)",
       "Bash(gh pr diff:*)",
       "Bash(ls:*)",
       "Bash(apps/bfDb/bin/genBarrel.ts)",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,18 @@ bff help
 - Project plans focus on user-centric goals
 - Implementation plans focus on technical details
 
+### Linting
+
+The project uses the Deno linter with custom rules defined in
+`infra/lint/bolt-foundry.ts`:
+
+- `no-env-direct-access`: Prevents direct access to Deno.env, use
+  getConfigurationVariable()
+- `no-bfnodespec-first-static`: Ensures bfNodeSpec is not the first static field
+  in a class
+- `no-logger-set-level`: Prevents accidental commits of logger.setLevel() calls,
+  which should only be used for local debugging
+
 ## Common Workflows
 
 - Running tests for specific modules: `bff test path/to/test.ts`
@@ -145,6 +157,7 @@ bff help
 - Running the development server: `bff dev`
 - Formatting code: `bff format`
 - Generating GraphQL code: `bff iso`
+- Running linter: `bff lint`
 
 ## Version Control
 

--- a/apps/bfDb/builders/graphql/gqlSpecToNexus.ts
+++ b/apps/bfDb/builders/graphql/gqlSpecToNexus.ts
@@ -24,7 +24,6 @@ import type {
 type MaybePromise<T> = T | Promise<T>;
 
 const logger = getLogger(import.meta);
-logger.setLevel(logger.levels.DEBUG);
 
 /**
  * Type definition for an edge relationship specification

--- a/apps/bfDb/graphql/__generated__/_nexustypes.ts
+++ b/apps/bfDb/graphql/__generated__/_nexustypes.ts
@@ -43,6 +43,10 @@ export interface NexusGenScalars {
 }
 
 export interface NexusGenObjects {
+  BfNode: {};
+  CurrentViewer: {};
+  CurrentViewerLoggedIn: {};
+  CurrentViewerLoggedOut: {};
   JoinWaitlistPayload: { // root type
     message?: string | null; // String
     success: boolean; // Boolean!
@@ -69,16 +73,37 @@ export type NexusGenRootTypes = NexusGenObjects
 export type NexusGenAllTypes = NexusGenRootTypes & NexusGenScalars
 
 export interface NexusGenFieldTypes {
+  BfNode: { // field return type
+    id: string | null; // ID
+  }
+  CurrentViewer: { // field return type
+    currentViewer: NexusGenRootTypes['CurrentViewer'] | null; // CurrentViewer
+    id: string | null; // ID
+    orgBfOid: string | null; // String
+    personBfGid: string | null; // String
+  }
+  CurrentViewerLoggedIn: { // field return type
+    currentViewer: NexusGenRootTypes['CurrentViewer'] | null; // CurrentViewer
+    id: string | null; // ID
+    orgBfOid: string | null; // String
+    personBfGid: string | null; // String
+  }
+  CurrentViewerLoggedOut: { // field return type
+    currentViewer: NexusGenRootTypes['CurrentViewer'] | null; // CurrentViewer
+    id: string | null; // ID
+    orgBfOid: string | null; // String
+    personBfGid: string | null; // String
+  }
   JoinWaitlistPayload: { // field return type
     message: string | null; // String
     success: boolean; // Boolean!
   }
   Mutation: { // field return type
     joinWaitlist: NexusGenRootTypes['JoinWaitlistPayload'] | null; // JoinWaitlistPayload
+    loginWithGoogle: NexusGenRootTypes['CurrentViewer'] | null; // CurrentViewer
   }
   Query: { // field return type
-    ok: boolean; // Boolean!
-    test: NexusGenRootTypes['TestType'] | null; // TestType
+    currentViewer: NexusGenRootTypes['CurrentViewer'] | null; // CurrentViewer
   }
   TestType: { // field return type
     count: number | null; // Int
@@ -92,16 +117,37 @@ export interface NexusGenFieldTypes {
 }
 
 export interface NexusGenFieldTypeNames {
+  BfNode: { // field return type name
+    id: 'ID'
+  }
+  CurrentViewer: { // field return type name
+    currentViewer: 'CurrentViewer'
+    id: 'ID'
+    orgBfOid: 'String'
+    personBfGid: 'String'
+  }
+  CurrentViewerLoggedIn: { // field return type name
+    currentViewer: 'CurrentViewer'
+    id: 'ID'
+    orgBfOid: 'String'
+    personBfGid: 'String'
+  }
+  CurrentViewerLoggedOut: { // field return type name
+    currentViewer: 'CurrentViewer'
+    id: 'ID'
+    orgBfOid: 'String'
+    personBfGid: 'String'
+  }
   JoinWaitlistPayload: { // field return type name
     message: 'String'
     success: 'Boolean'
   }
   Mutation: { // field return type name
     joinWaitlist: 'JoinWaitlistPayload'
+    loginWithGoogle: 'CurrentViewer'
   }
   Query: { // field return type name
-    ok: 'Boolean'
-    test: 'TestType'
+    currentViewer: 'CurrentViewer'
   }
   TestType: { // field return type name
     count: 'Int'
@@ -120,6 +166,9 @@ export interface NexusGenArgTypes {
       company: string; // String!
       email: string; // String!
       name: string; // String!
+    }
+    loginWithGoogle: { // args
+      idToken: string; // String!
     }
   }
 }

--- a/apps/bfDb/graphql/__generated__/schema.graphql
+++ b/apps/bfDb/graphql/__generated__/schema.graphql
@@ -3,6 +3,31 @@
 ### Do not make changes to this file directly
 
 
+type BfNode {
+  id: ID
+}
+
+type CurrentViewer {
+  currentViewer: CurrentViewer
+  id: ID
+  orgBfOid: String
+  personBfGid: String
+}
+
+type CurrentViewerLoggedIn {
+  currentViewer: CurrentViewer
+  id: ID
+  orgBfOid: String
+  personBfGid: String
+}
+
+type CurrentViewerLoggedOut {
+  currentViewer: CurrentViewer
+  id: ID
+  orgBfOid: String
+  personBfGid: String
+}
+
 type JoinWaitlistPayload {
   message: String
   success: Boolean!
@@ -10,11 +35,11 @@ type JoinWaitlistPayload {
 
 type Mutation {
   joinWaitlist(company: String!, email: String!, name: String!): JoinWaitlistPayload
+  loginWithGoogle(idToken: String!): CurrentViewer
 }
 
 type Query {
-  ok: Boolean!
-  test: TestType
+  currentViewer: CurrentViewer
 }
 
 type TestType {

--- a/apps/bfDb/graphql/graphqlServer.ts
+++ b/apps/bfDb/graphql/graphqlServer.ts
@@ -8,8 +8,7 @@ import { getLogger } from "packages/logger/logger.ts";
 // Let's create our own loadModelTypes function
 // import { loadModelTypes } from "apps/bfDb/builders/graphql/loadSpecs.ts";
 
-const logger = getLogger(import.meta);
-logger.setLevel(logger.levels.DEBUG);
+const _logger = getLogger(import.meta);
 
 // Import our GraphQL builder tools - imported only for types but not used directly yet
 import type { makeGqlSpec as _makeGqlSpec } from "apps/bfDb/builders/graphql/makeGqlSpec.ts";

--- a/apps/bfDb/graphql/loadGqlTypes.ts
+++ b/apps/bfDb/graphql/loadGqlTypes.ts
@@ -1,12 +1,92 @@
 import { extendType, objectType, queryType } from "nexus";
 import { gqlSpecToNexus } from "apps/bfDb/builders/graphql/gqlSpecToNexus.ts";
-import { Waitlist } from "apps/bfDb/graphql/roots/Waitlist.ts";
+import * as roots from "apps/bfDb/graphql/roots/__generated__/rootObjectsList.ts";
+import * as classes from "apps/bfDb/classes/__generated__/classesList.ts";
+import { getLogger } from "packages/logger/logger.ts";
+
+const logger = getLogger(import.meta);
+logger.setLevel(logger.levels.DEBUG);
 
 /**
  * Loads GraphQL types using our new builder pattern.
  * This will eventually load all node types in the system.
  */
 export function loadGqlTypes() {
+  const types: unknown[] = [];
+  // Update the type to match what Nexus expects
+  // deno-lint-ignore no-explicit-any
+  const mutationExtensions: any[] = [];
+
+  logger.debug("Loading GraphQL types...");
+
+  // Process all root types from the generated barrel file
+  for (const [name, rootClass] of Object.entries(roots)) {
+    logger.debug(`Processing root type: ${name}`);
+    if (rootClass.gqlSpec) {
+      logger.debug(`Found gqlSpec for ${name}`);
+      const nexusTypes = gqlSpecToNexus(rootClass.gqlSpec, name);
+
+      // Add the main type based on the root type
+      if (name === "Query") {
+        logger.debug(`Adding Query type for ${name}`);
+        types.push(queryType(nexusTypes.mainType));
+      } else {
+        logger.debug(`Adding object type for ${name}`);
+        types.push(objectType(nexusTypes.mainType));
+      }
+
+      // Add any payload types
+      if (nexusTypes.payloadTypes) {
+        for (
+          const [typeName, typeDef] of Object.entries(nexusTypes.payloadTypes)
+        ) {
+          logger.debug(`Adding payload type: ${typeName}`);
+          types.push(objectType(typeDef as Parameters<typeof objectType>[0]));
+        }
+      }
+
+      // Collect mutation extensions to add later
+      if (nexusTypes.mutationType) {
+        logger.debug(`Collecting mutation extension for ${name}`);
+        mutationExtensions.push(nexusTypes.mutationType);
+      }
+    } else {
+      logger.debug(`No gqlSpec for ${name}`);
+    }
+  }
+
+  // Process all class types (like CurrentViewer) that have gqlSpecs
+  for (const [name, classType] of Object.entries(classes)) {
+    logger.debug(`Processing class type: ${name}`);
+    // Use type guard to safely check if classType has gqlSpec property
+    if ("gqlSpec" in classType && classType.gqlSpec) {
+      logger.debug(`Found gqlSpec for class ${name}`);
+      const nexusTypes = gqlSpecToNexus(classType.gqlSpec, name);
+
+      // Add the main type
+      logger.debug(`Adding object type for class ${name}`);
+      types.push(objectType(nexusTypes.mainType));
+
+      // Add any payload types
+      if (nexusTypes.payloadTypes) {
+        for (
+          const [typeName, typeDef] of Object.entries(nexusTypes.payloadTypes)
+        ) {
+          logger.debug(`Adding payload type for class: ${typeName}`);
+          types.push(objectType(typeDef as Parameters<typeof objectType>[0]));
+        }
+      }
+
+      // Collect mutation extensions to add later
+      if (nexusTypes.mutationType) {
+        logger.debug(`Collecting mutation extension for class ${name}`);
+        mutationExtensions.push(nexusTypes.mutationType);
+      }
+    } else {
+      logger.debug(`No gqlSpec for class ${name}`);
+    }
+  }
+
   // Create a test GraphQL type directly with Nexus to verify schema generation
   const TestType = objectType({
     name: "TestType",
@@ -18,69 +98,24 @@ export function loadGqlTypes() {
     },
   });
 
-  // Create a query type that returns our test type
-  const Query = queryType({
-    definition(t) {
-      // Test field
-      t.field("test", {
-        type: "TestType",
-        resolve: () => ({
-          id: "test-123",
-          name: "Test Object",
-          isActive: true,
-          count: 42,
-        }),
-      });
+  // Add the test type to the types array
+  logger.debug("Adding TestType");
+  types.push(TestType);
 
-      // Health check
-      t.nonNull.boolean("ok", {
-        resolve: () => true,
-      });
-    },
+  // Add all mutation extensions at the end to avoid duplicate type issues
+  // Nexus will merge these into a single Mutation type
+  if (mutationExtensions.length > 0) {
+    logger.debug(`Adding ${mutationExtensions.length} mutation extensions`);
+    mutationExtensions.forEach((mutationExt) => {
+      types.push(extendType(mutationExt));
+    });
+  }
+
+  logger.debug(`Total types loaded: ${types.length}`);
+  types.forEach((type, index) => {
+    // deno-lint-ignore no-explicit-any
+    logger.debug(`Type ${index}: ${(type as any).name || "unknown"}`);
   });
-
-  // Note: JoinWaitlistPayload is now automatically generated from the returns builder
-
-  // Load the Waitlist type using our new builder
-  const waitlistSpec = Waitlist.gqlSpec;
-  const waitlistNexusTypes = gqlSpecToNexus(waitlistSpec, "Waitlist");
-
-  // Create types from the Nexus definitions
-  const WaitlistType = objectType(waitlistNexusTypes.mainType);
-
-  // Create the payload types
-  const payloadTypeObjects: Record<string, unknown> = {};
-  if (waitlistNexusTypes.payloadTypes) {
-    for (
-      const [typeName, typeDef] of Object.entries(
-        waitlistNexusTypes.payloadTypes,
-      )
-    ) {
-      payloadTypeObjects[typeName] = objectType(
-        typeDef as Parameters<typeof objectType>[0],
-      );
-    }
-  }
-
-  // Create the mutation type if it exists
-  let WaitlistMutation = null;
-  if (waitlistNexusTypes.mutationType) {
-    WaitlistMutation = extendType(waitlistNexusTypes.mutationType);
-  }
-
-  // Return the types - order matters for Nexus!
-  // Return as an array since that's what Nexus expects
-  const types = [
-    Query,
-    TestType,
-    WaitlistType,
-    ...Object.values(payloadTypeObjects),
-  ];
-
-  // Add mutation last (it references the payload types)
-  if (WaitlistMutation) {
-    types.push(WaitlistMutation);
-  }
 
   return types;
 }

--- a/apps/bfDb/graphql/loadGqlTypes.ts
+++ b/apps/bfDb/graphql/loadGqlTypes.ts
@@ -5,7 +5,6 @@ import * as classes from "apps/bfDb/classes/__generated__/classesList.ts";
 import { getLogger } from "packages/logger/logger.ts";
 
 const logger = getLogger(import.meta);
-logger.setLevel(logger.levels.DEBUG);
 
 /**
  * Loads GraphQL types using our new builder pattern.

--- a/apps/bfDb/graphql/roots/Query.ts
+++ b/apps/bfDb/graphql/roots/Query.ts
@@ -1,10 +1,9 @@
 import { GraphQLObjectBase } from "../GraphQLObjectBase.ts";
-import { defineGqlNode } from "apps/bfDb/builders/graphql/builder.ts";
 import { CurrentViewer } from "../../classes/CurrentViewer.ts";
 
 export class Query extends GraphQLObjectBase {
-  static override gqlSpec = defineGqlNode((field) => {
-    field
+  static override gqlSpec = this.defineGqlNode((field) => {
+    return field
       .nonNull
       .object("currentViewer", () => CurrentViewer, {
         resolve: (_src, _args, ctx) => ctx.getCvForGraphql(),

--- a/infra/lint/__tests__/plugin_logger_test.ts
+++ b/infra/lint/__tests__/plugin_logger_test.ts
@@ -1,0 +1,93 @@
+import { assertEquals } from "testing/asserts.ts";
+import { lint } from "deno/lint/mod.ts";
+import boltFoundryPlugin from "../bolt-foundry.ts";
+
+Deno.test("no-logger-set-level rule with logger variable", async () => {
+  const source = `
+  import { getLogger } from "packages/logger/logger.ts";
+  
+  const logger = getLogger(import.meta);
+  logger.setLevel(logger.levels.DEBUG);
+  
+  function someFunction() {
+    console.log("Hello world");
+  }
+  `;
+
+  const result = await lint(source, {
+    rules: {
+      "no-logger-set-level": true,
+    },
+    include: ["**/*.ts"],
+    exclude: [],
+    root: ".",
+    plugins: [boltFoundryPlugin],
+  });
+
+  assertEquals(result.length, 1);
+  assertEquals(result[0].rule, "no-logger-set-level");
+  assertEquals(
+    result[0].message,
+    "Avoid committing logger.setLevel() - this should be managed through environment variables.",
+  );
+});
+
+Deno.test("no-logger-set-level rule with custom logger name but using levels", async () => {
+  const source = `
+  import { getLogger } from "packages/logger/logger.ts";
+  
+  const myCustomLogger = getLogger(import.meta);
+  myCustomLogger.setLevel(myCustomLogger.levels.DEBUG);
+  
+  function someFunction() {
+    console.log("Hello world");
+  }
+  `;
+
+  const result = await lint(source, {
+    rules: {
+      "no-logger-set-level": true,
+    },
+    include: ["**/*.ts"],
+    exclude: [],
+    root: ".",
+    plugins: [boltFoundryPlugin],
+  });
+
+  // Should trigger the lint rule since we're now matching both the variable name
+  // pattern and checking if it's using .levels
+  assertEquals(result.length, 1);
+  assertEquals(result[0].rule, "no-logger-set-level");
+});
+
+Deno.test("no-logger-set-level rule should not trigger for non-logger setLevel calls", async () => {
+  const source = `
+  // Not importing our logger module
+  
+  class SomeClass {
+    constructor() {
+      this.level = 0;
+    }
+    
+    setLevel(level) {
+      this.level = level;
+    }
+  }
+  
+  const instance = new SomeClass();
+  instance.setLevel(5);
+  `;
+
+  const result = await lint(source, {
+    rules: {
+      "no-logger-set-level": true,
+    },
+    include: ["**/*.ts"],
+    exclude: [],
+    root: ".",
+    plugins: [boltFoundryPlugin],
+  });
+
+  // Should not trigger the lint rule since there's no logger import and no .levels usage
+  assertEquals(result.length, 0);
+});

--- a/infra/lint/bolt-foundry.ts
+++ b/infra/lint/bolt-foundry.ts
@@ -103,6 +103,78 @@ const plugin: Deno.lint.Plugin = {
         };
       },
     },
+
+    /* ────────────────────────────────────────────────────────────────────── */
+    /*  3. Prevent logger.setLevel from being committed                      */
+    /* ────────────────────────────────────────────────────────────────────── */
+    "no-logger-set-level": {
+      create(context) {
+        const { sourceCode } = context;
+
+        // Check if this file imports getLogger from our logger package
+        function hasLoggerImport() {
+          return sourceCode.ast.body.some(
+            (n) =>
+              n.type === "ImportDeclaration" &&
+              n.source.value.includes("logger/logger.ts") &&
+              n.specifiers.some(
+                (s) =>
+                  (s.type === "ImportSpecifier" ||
+                    s.type === "ImportNamespaceSpecifier") &&
+                  s.local.name === "getLogger",
+              ),
+          );
+        }
+
+        return {
+          // Match any call to setLevel()
+          'CallExpression[callee.property.name="setLevel"]'(node) {
+            // Get the object the method is called on
+            const objectNode = node.callee.object;
+
+            // Flag for tracking if this is potentially a logger instance
+            let isLoggerCall = false;
+
+            // Direct match for variable named "logger"
+            if (
+              objectNode.type === "Identifier" && objectNode.name === "logger"
+            ) {
+              isLoggerCall = true;
+            }
+
+            // Check for any variable followed by .levels
+            if (
+              node.arguments.length > 0 &&
+              node.arguments[0].type === "MemberExpression" &&
+              node.arguments[0].property.name === "levels"
+            ) {
+              isLoggerCall = true;
+            }
+
+            // If we're in a file that imports our logger and this looks like a logger call
+            if (
+              (hasLoggerImport() && isLoggerCall) ||
+              objectNode.name === "logger"
+            ) {
+              context.report({
+                node,
+                message:
+                  "Avoid committing logger.setLevel() - this should be managed through environment variables.",
+                fix(fixer) {
+                  // Comment out the line rather than removing it completely
+                  return [
+                    fixer.insertTextBefore(
+                      node,
+                      "// UNCOMMENT FOR DEBUGGING ONLY: ",
+                    ),
+                  ];
+                },
+              });
+            }
+          },
+        };
+      },
+    },
   },
 };
 


### PR DESCRIPTION
Create a custom Deno lint rule that detects and prevents accidentally committing
logger.setLevel() calls into PRs. These calls are useful for local debugging
but should not remain in the codebase.

Changes:
- Added no-logger-set-level rule to bolt-foundry.ts lint plugin
- Created tests for the new lint rule
- Updated documentation in CLAUDE.md
- Fixed existing occurrences of logger.setLevel() in the codebase

Test plan:
1. Run bff lint to verify the lint rule catches logger.setLevel calls
2. Run tests for the lint rule to verify functionality
3. Verify the autofix functionality works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/803).
* __->__ #803
* #802

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/803)
<!-- GitContextEnd -->