### PR TITLE
Add backlog implementation plan structure

### DIFF
--- a/cards/behaviors/backlog-management.bhc.md
+++ b/cards/behaviors/backlog-management.bhc.md
@@ -12,16 +12,20 @@ work while keeping current implementation plans focused.
 
 ## Backlog Structure
 
-Backlogs should be maintained in the docs directory structure with the following
-guidelines:
+Backlogs can be organized in two main ways depending on the complexity of the
+items:
 
-### Location
+### 1. Simple Backlog Lists
+
+For straightforward backlog items that can be documented in a single file:
+
+#### Location
 
 - Project-level backlogs should be stored in `apps/[project]/docs/backlog.md`
 - Version-specific deferred items should be documented in
   `apps/[project]/docs/[version]/backlog.md`
 
-### Organization
+#### Organization
 
 Backlog items should be organized by:
 
@@ -31,7 +35,37 @@ Backlog items should be organized by:
 4. **Target Version**: The anticipated version when the item might be
    implemented
 
+### 2. Feature-Focused Backlog Structure
+
+For more complex features that require multiple related documents:
+
+#### Location
+
+Complex backlog features should be stored in the top-level backlog directory:
+
+```
+docs/backlog/
+├── README.md                    (Structure explanation)
+├── feature-name/                (Directory for a specific feature)
+│   ├── project-plan.md          (User-focused goals and vision)
+│   ├── implementation-plan.md   (Technical approach and strategy)
+│   └── supporting-docs/         (Research, diagrams, etc.)
+└── ...
+```
+
+#### When to Use Feature Directories
+
+Use the feature directory structure when:
+
+1. A potential feature requires detailed planning before it can be considered
+   for the roadmap
+2. Multiple related documents are needed to fully describe the feature
+3. The feature might be complex enough to warrant versioned implementation plans
+4. Collaborative discussion and iteration on the feature design is expected
+
 ## Backlog Item Documentation Format
+
+### For Simple Backlog Lists
 
 Each backlog item should include:
 
@@ -54,6 +88,17 @@ or Future]
 on it yet.
 ```
 
+### For Feature Directories
+
+Each feature directory should contain at minimum:
+
+1. `project-plan.md` - Describing the user-focused goals and vision
+2. `implementation-plan.md` - Outlining the technical approach and
+   implementation strategy
+
+Additional supporting documents can be included as needed in a
+`supporting-docs/` subdirectory.
+
 ## Backlog Review Process
 
 1. **Regular Reviews**: The backlog should be reviewed at the end of each
@@ -70,7 +115,9 @@ on it yet.
 - Backlogs document what MIGHT be built in future versions
 - Items should move from backlog → implementation plan when they come into scope
 
-## Example Structure
+## Example Structures
+
+### Simple Backlog Structure
 
 ```
 apps/project-name/
@@ -86,6 +133,23 @@ apps/project-name/
           └── backlog.md              (Items deferred from 0.2)
 ```
 
+### Feature-Focused Backlog Structure
+
+```
+docs/backlog/
+├── README.md
+├── feature-a/
+│   ├── project-plan.md
+│   ├── implementation-plan.md
+│   └── supporting-docs/
+│       ├── research.md
+│       └── diagrams/
+├── feature-b/
+│   ├── project-plan.md
+│   └── implementation-plan.md
+└── ...
+```
+
 ## Best Practices
 
 1. **Be Specific**: Backlog items should be specific enough to be actionable
@@ -96,6 +160,8 @@ apps/project-name/
    should be valuable
 5. **Regular Triage**: Periodically review and prioritize items to keep the
    backlog fresh
+6. **Choose the Right Format**: Use simple backlog items for straightforward
+   work and feature directories for complex features
 
 Remember that a well-maintained backlog provides a roadmap for future
 development while helping the team stay focused on current priorities.

--- a/docs/backlog-documentation.md
+++ b/docs/backlog-documentation.md
@@ -20,12 +20,51 @@ The backlog serves several important functions:
 4. **Institutional Knowledge**: Preserves context and reasoning around potential
    future work
 
-## Where to Store Backlog Documentation
+## Backlog Organization Approaches
 
-Backlog documentation should be integrated into the existing documentation
-structure:
+There are two main ways to organize backlog items depending on their complexity
+and documentation needs:
 
-### Project-Level Backlog
+### 1. Simple Backlog Lists
+
+For straightforward items that can be documented in a single file:
+
+```
+apps/[project]/docs/backlog.md
+```
+
+### 2. Feature-Focused Backlog Structure
+
+For more complex features that require multiple related documents (project
+plans, implementation plans, research, etc.):
+
+```
+docs/backlog/
+├── README.md                    (Structure explanation)
+├── feature-name/                (Directory for a specific feature)
+│   ├── project-plan.md          (User-focused goals and vision)
+│   ├── implementation-plan.md   (Technical approach and strategy)
+│   └── supporting-docs/         (Research, diagrams, etc.)
+├── another-feature/
+│   ├── project-plan.md
+│   └── implementation-plan.md
+└── ...
+```
+
+#### When to Use Feature Directories
+
+Use the feature directory structure when:
+
+1. A potential feature requires detailed planning before it can be considered
+   for the roadmap
+2. Multiple related documents are needed to fully describe the feature
+3. The feature might be complex enough to warrant versioned implementation plans
+4. Collaborative discussion and iteration on the feature design is expected
+
+See [the backlog README.md](/docs/backlog/README.md) for more details on this
+approach.
+
+### 3. Project-Level Backlog
 
 For broad backlog items that aren't specific to a particular version:
 
@@ -36,7 +75,7 @@ apps/[project]/docs/backlog/
   └── technical-debt.md   (Code quality improvements)
 ```
 
-### Version-Specific Deferred Items
+### 4. Version-Specific Deferred Items
 
 For items that were considered for a specific version but deferred:
 

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -1,0 +1,73 @@
+# Backlog Feature Directory Structure
+
+This directory contains potential features, enhancements, and changes that are
+not currently on the roadmap but are being considered for future implementation.
+
+## Purpose
+
+The feature-focused backlog structure helps organize and document potential work
+more comprehensively than simple backlog items. When a potential feature
+requires multiple related documents (project plans, implementation plans,
+research, etc.), it should be organized in its own directory rather than as a
+single entry in a backlog list.
+
+## Directory Structure
+
+```
+backlog/
+├── README.md                    (This file)
+├── feature-name/                (Directory for a specific feature)
+│   ├── project-plan.md          (User-focused goals and vision)
+│   ├── implementation-plan.md   (Technical approach and strategy)
+│   └── supporting-docs/         (Research, diagrams, etc.)
+├── another-feature/
+│   ├── project-plan.md
+│   └── implementation-plan.md
+└── ...
+```
+
+## When to Use Feature Directories
+
+Use this structure when:
+
+1. A potential feature requires detailed planning before it can be considered
+   for the roadmap
+2. Multiple related documents are needed to fully describe the feature
+3. The feature might be complex enough to warrant versioned implementation plans
+4. Collaborative discussion and iteration on the feature design is expected
+
+## Feature Directory Template
+
+Each feature directory should contain at minimum:
+
+1. `project-plan.md` - Describing the user-focused goals and vision
+2. `implementation-plan.md` - Outlining the technical approach and
+   implementation strategy
+
+You can include additional supporting documents as needed, such as:
+
+- Research findings
+- Technical specifications
+- Architecture diagrams
+- UI mockups
+- Competitive analysis
+
+## Relationship to Project Roadmap
+
+Features in this backlog are **not currently scheduled** for implementation.
+When a feature is approved for the roadmap:
+
+1. The feature directory can be moved to the appropriate project structure
+2. The plans can be refined and versioned as needed
+3. Implementation work can begin based on the established plans
+
+## Managing the Backlog
+
+Follow the
+[Backlog Management Protocol](../cards/behaviors/backlog-management.bhc.md) for
+guidelines on:
+
+- Adding items to the backlog
+- Reviewing and prioritizing backlog items
+- Promoting items from backlog to implementation plans
+- Deferring items from current plans to the backlog

--- a/docs/backlog/example-feature/implementation-plan.md
+++ b/docs/backlog/example-feature/implementation-plan.md
@@ -1,0 +1,152 @@
+# Example Feature - Implementation Plan
+
+This document provides a technical implementation plan for the Example Feature.
+It follows the
+[Technical Implementation Planning Protocol](../../cards/behaviors/technical-implementation-plans.bhc.md).
+
+## Technical Reasoning
+
+Explain the technical reasoning behind this feature. Why is this approach being
+considered? What alternatives were evaluated?
+
+## System Architecture
+
+Describe at a high level how this feature would integrate with the existing
+system architecture.
+
+### Component Diagram
+
+```
+┌────────────────┐       ┌────────────────┐
+│                │       │                │
+│  Component A   │──────▶│  Component B   │
+│                │       │                │
+└────────────────┘       └────────────────┘
+        │                        │
+        ▼                        ▼
+┌────────────────┐       ┌────────────────┐
+│                │       │                │
+│  Component C   │◀─────▶│  Component D   │
+│                │       │                │
+└────────────────┘       └────────────────┘
+```
+
+## Technical Specifications
+
+### API Definitions
+
+```typescript
+/**
+ * Description of what the function does
+ * @param param1 - Description of first parameter
+ * @param options - Configuration options
+ * @returns Description of return value
+ */
+function exampleFunction(param1: string, options?: {
+  option1?: boolean;
+  option2?: string;
+}): Promise<ExampleResult>;
+
+interface ExampleResult {
+  id: string;
+  name: string;
+  data: {
+    field1: string;
+    field2: number;
+  };
+}
+```
+
+### Data Model Changes
+
+Describe any changes needed to the data model:
+
+```typescript
+interface NewEntity {
+  id: string;
+  name: string;
+  createdAt: Date;
+  properties: {
+    key: string;
+    value: any;
+  }[];
+}
+```
+
+## Implementation Versions
+
+### Version 0.1: Foundation (Complexity: Simple)
+
+**Technical Goal**: Establish the basic infrastructure for the feature
+
+**Components**:
+
+- Component A: Technical specifications for component A
+- Component B: Technical specifications for component B
+
+**Integration Points**:
+
+- How Component A and B would interact
+- API contracts between them
+
+**Testing Strategy**:
+
+- Unit test approach for Component A
+- Integration test approach for A+B interaction
+
+### Version 0.2: Core Functionality (Complexity: Moderate)
+
+**Technical Goal**: Implement the main functionality of the feature
+
+**Dependencies**:
+
+- Version 0.1 must be completed
+
+**Components**:
+
+- Component C: Technical specifications for component C
+- Component D: Technical specifications for component D
+
+**Integration Points**:
+
+- How components C and D integrate with A and B
+- Data flow between all components
+
+**Testing Strategy**:
+
+- Test cases for component C
+- Test cases for component D
+- End-to-end test approach
+
+## Code Path References
+
+List the code paths that would need to be modified:
+
+- `apps/example/src/components/ExampleComponent.tsx`
+- `apps/example/src/services/exampleService.ts`
+- `apps/example/graphql/roots/ExampleQuery.ts`
+
+## Technical Risks & Mitigation
+
+| Risk   | Impact | Likelihood | Mitigation                     |
+| ------ | ------ | ---------- | ------------------------------ |
+| Risk 1 | High   | Medium     | Mitigation strategy for risk 1 |
+| Risk 2 | Medium | Low        | Mitigation strategy for risk 2 |
+
+## Appendix: Technical Specifications
+
+### Database Schema
+
+```sql
+CREATE TABLE example_table (
+  id UUID PRIMARY KEY,
+  name TEXT NOT NULL,
+  created_at TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP NOT NULL
+);
+```
+
+### State Management
+
+Describe how state would be managed for this feature, including any state
+machines or state transitions.

--- a/docs/backlog/example-feature/project-plan.md
+++ b/docs/backlog/example-feature/project-plan.md
@@ -1,0 +1,75 @@
+# Example Feature - Project Plan
+
+## Feature Overview
+
+This document provides an example of how to structure a project plan for a
+backlog feature. Replace this content with a description of your feature's
+purpose and goals.
+
+## User Problem Statement
+
+Describe the user problem that this feature would solve. What pain points or
+needs would it address?
+
+## Goals
+
+- Goal 1: Description of the first goal
+- Goal 2: Description of the second goal
+- Goal 3: Description of the third goal
+
+## Non-Goals
+
+- Non-Goal 1: What this feature explicitly will not do
+- Non-Goal 2: Another explicit limitation of scope
+
+## User Personas
+
+### Primary Persona
+
+Describe the primary user(s) who would benefit from this feature.
+
+### Secondary Personas
+
+Describe any secondary users who might also benefit.
+
+## User Journeys
+
+Outline the key user journeys that this feature would enable:
+
+1. Journey 1: Step-by-step description
+2. Journey 2: Step-by-step description
+
+## Success Metrics
+
+- Metric 1: How would you measure success?
+- Metric 2: Another success measurement
+
+## Prioritization Information
+
+**Priority**: [High/Medium/Low]\
+**Type**: [Feature/Enhancement/Bug/Technical Debt]\
+**Complexity**: [Simple/Moderate/Complex]\
+**Target Version**: [e.g., 0.3 or Future]
+
+## Justification
+
+Why should this feature be considered for future implementation? What value
+would it bring?
+
+## Dependencies
+
+List any dependencies or prerequisites that would need to be in place before
+this feature could be implemented.
+
+## Why This Is in the Backlog
+
+Explain why this feature hasn't been prioritized for current implementation.
+This helps provide context for future consideration.
+
+## Acceptance Criteria
+
+What would constitute a successful implementation of this feature?
+
+- Criterion 1: Description
+- Criterion 2: Description
+- Criterion 3: Description

--- a/docs/backlog/example-feature/supporting-docs/research.md
+++ b/docs/backlog/example-feature/supporting-docs/research.md
@@ -1,0 +1,72 @@
+# Example Feature - Research
+
+## Overview
+
+This document contains research findings and reference material relevant to the
+Example Feature. Replace this content with actual research for your feature.
+
+## Market Analysis
+
+Summary of market analysis for similar features in competitive products.
+
+### Competitor Approaches
+
+Outline how competitors have implemented similar features:
+
+1. Competitor A: Implementation approach and notable aspects
+2. Competitor B: Implementation approach and notable aspects
+
+## User Research
+
+Summary of any user research that supports the need for this feature.
+
+### Key User Insights
+
+- Insight 1: Description and implications
+- Insight 2: Description and implications
+
+## Technical Research
+
+Research on technical approaches, libraries, or patterns that could be used to
+implement this feature.
+
+### Potential Technical Solutions
+
+#### Solution 1: [Name]
+
+Pros:
+
+- Pro 1
+- Pro 2
+
+Cons:
+
+- Con 1
+- Con 2
+
+#### Solution 2: [Name]
+
+Pros:
+
+- Pro 1
+- Pro 2
+
+Cons:
+
+- Con 1
+- Con 2
+
+## Open Questions
+
+List any open questions that would need to be answered before implementing this
+feature:
+
+1. Question 1
+2. Question 2
+3. Question 3
+
+## References and Resources
+
+- [Link to relevant resource 1](https://example.com)
+- [Link to relevant resource 2](https://example.com)
+- [Link to relevant resource 3](https://example.com)


### PR DESCRIPTION

Implement a feature-focused backlog organization structure that allows for more detailed planning of potential future features that aren't yet on the roadmap.

Changes:
- Create docs/backlog/ directory with README explaining the structure
- Add example feature directory with project plan and implementation plan templates
- Update backlog-documentation.md to include the new structure
- Update backlog-management.bhc.md behavior card to reference both approaches

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: randallb <randallb@users.noreply.github.com>
Co-Authored-By: Claude <noreply@anthropic.com>
