### PR TITLE
Fix GraphQL Node Interface implementation plan

### DIFF
--- a/apps/bfDb/docs/0.2/implementation-plan.md
+++ b/apps/bfDb/docs/0.2/implementation-plan.md
@@ -27,43 +27,42 @@ in the system, including BfNode and other specialized nodes.
 
 ## Approach
 
-1. **Explicit Interface Marking**: Create a mechanism for marking classes that
-   should be treated as GraphQL interfaces
-2. **Class Hierarchy**: Create the GraphQLNode class that extends
-   GraphQLObjectBase and mark it as a GraphQL interface
-3. **Interface Registration**: Implement automatic registration of GraphQL
-   interfaces from marked classes
-4. **Schema Integration**: Update gqlSpecToNexus.ts to register interface
-   implementations
+1. **Interface Registry**: Create a central registry for classes that should be
+   treated as GraphQL interfaces
+2. **Class Hierarchy**: Create the GraphQLNode class alongside other GraphQL
+   types and register it in the interface registry
+3. **Interface Registration**: Implement registration of GraphQL interfaces from
+   the registry during schema generation
+4. **Schema Integration**: Update gqlSpecToNexus.ts to detect interface
+   implementations through the prototype chain
 5. **Inheritance Refactoring**: Update BfNode to extend GraphQLNode
 6. **Testing**: Add comprehensive tests for the implementation
 
 ## Implementation Steps
 
-1. **Create Interface Marking Mechanism**
-   - Define a static property for marking classes as GraphQL interfaces
-   - Update schema generation to check for this marker
-   - Add utility functions for working with interface classes
+1. **Create Interface Registry**
+   - Create graphqlInterfaces.ts with a registry array of interface classes
+   - Add utility functions to check if a class is in the registry
+   - Document how to register new interfaces in the registry
 
 2. **Create GraphQLNode Class**
-   - Create a new GraphQLNode.ts file that extends GraphQLObjectBase
-   - Mark it as a GraphQL interface using the new marker
+   - Create a new GraphQLNode.ts file in the graphql directory
+   - Make it extend GraphQLObjectBase
    - Implement required methods and properties for node functionality
-   - Add gqlSpec definition with core Node fields
-   - Ensure id and __typename are properly implemented
+   - Add gqlSpec definition with core Node fields (id)
+   - Register it in the graphqlInterfaces registry
 
-3. **Define Interface Registration System**
-   - Create a registry for GraphQL interfaces
-   - Add functionality to automatically detect marked interface classes
+3. **Implement Interface Registration in Schema**
+   - Modify loadGqlTypes.ts to load interfaces from the registry
+   - Create functions to convert interface classes to GraphQL interfaces
    - Implement resolveType function to determine concrete types at runtime
-   - Export constants and helpers for interface registration
+   - Ensure interfaces are registered before object types in the schema
 
 4. **Update Schema Generation**
-   - Modify gqlSpecToNexus.ts to check for interface markers
-   - Modify loadGqlTypes.ts to register marked interfaces
-   - Update schema generation to automatically apply interfaces based on class
-     inheritance
-   - Ensure proper registration of interfaces and implementing types
+   - Modify gqlSpecToNexus.ts to detect implemented interfaces automatically
+   - Add prototype chain traversal to find all implemented interfaces
+   - Update schema generation to apply interfaces to implementing types
+   - Ensure proper registration of interfaces and implementations
 
 5. **Refactor BfNode and Other Classes**
    - Update BfNode to extend GraphQLNode instead of GraphQLObjectBase
@@ -72,52 +71,66 @@ in the system, including BfNode and other specialized nodes.
    - Update any dependent classes as needed
 
 6. **Testing**
-   - Create tests for interface marking mechanism
-   - Test interface registration and implementation
+   - Create tests for the interface registry system
+   - Test interface registration and implementation detection
    - Test interface type resolution with different node types
    - Verify schema generation with interface implementations
    - Test interface field resolution
 
 ## Technical Design
 
-### Interface Marking Mechanism
+### Interface Registry with Explicit Registration
 
-We'll use an explicit static property to mark classes that should be treated as
-GraphQL interfaces:
+Instead of using a separate directory (like `apps/bfDb/graphql/interfaces/`),
+we'll keep interfaces alongside related types and use an explicit registry:
 
 ```typescript
-export class GraphQLObjectBase {
-  // Existing implementation...
+// graphqlInterfaces.ts - Registry for GraphQL interfaces
+import { GraphQLNode } from "apps/bfDb/graphql/GraphQLNode.ts"; // Lives with other types
+import type { AnyGraphqlObjectBaseCtor } from "apps/bfDb/builders/bfDb/types.ts";
+// Import other interface classes as needed
 
-  // Static property to mark a class as a GraphQL interface
-  static readonly isGraphQLInterface?: boolean;
+// Registry of all classes that should be treated as GraphQL interfaces
+export const graphQLInterfaces = [
+  GraphQLNode,
+  // Add other interface classes here
+];
 
-  // Method to check if a class is marked as an interface
-  static isInterface(classConstructor: any): boolean {
-    return Boolean(classConstructor?.isGraphQLInterface);
-  }
+// Utility function to check if a class is registered as an interface
+export function isGraphQLInterface(
+  classConstructor: AnyGraphqlObjectBaseCtor,
+): boolean {
+  return graphQLInterfaces.includes(classConstructor);
 }
 ```
 
+This approach:
+
+- Keeps related types together in the same directory
+- Uses an explicit registry that clearly shows all interfaces in one place
+- Makes it obvious which classes are interfaces
+- Avoids fragmenting related code across different directories
+- Provides a simple way to check if a class is an interface during schema
+  generation
+
 ### GraphQLNode Class Implementation
 
-The GraphQLNode class will extend GraphQLObjectBase, be marked as an interface,
-and provide the base functionality for all node types:
+The GraphQLNode class will extend GraphQLObjectBase and provide the base
+functionality for all node types:
 
 ```typescript
 export class GraphQLNode extends GraphQLObjectBase {
-  // Mark this class as a GraphQL interface
-  static readonly isGraphQLInterface = true;
-
-  // Override gqlSpec to include the Node interface fields
+  // Define the GraphQL specification with Node interface fields
+  // Note: Do NOT define __typename as it's automatically added by GraphQL
   static override gqlSpec = this.defineGqlNode((gql) =>
     gql
       .nonNull.id("id")
-      .nonNull.string("__typename")
   );
 
   // Additional node-specific methods can be added here
 }
+
+// GraphQLNode is registered in the graphqlInterfaces registry
 ```
 
 ### Interface Definition in Schema
@@ -128,37 +141,45 @@ on the GraphQLNode class:
 ```graphql
 interface Node {
   id: ID!
-  __typename: String!
 }
 ```
 
 ### Interface Registration
 
-We'll build a system to automatically register interfaces from marked classes:
+We'll use the interface registry to register interfaces in the schema:
 
 ```typescript
 // In loadGqlTypes.ts
-export function loadGqlTypes() {
-  // Find all classes marked as interfaces and register them
-  const interfaceClasses = findInterfaceClasses();
+import { graphQLInterfaces, isGraphQLInterface } from "./graphqlInterfaces.ts";
 
-  for (const interfaceClass of interfaceClasses) {
+export function loadGqlTypes() {
+  const types = [];
+
+  // Register all interfaces from the registry
+  for (const interfaceClass of graphQLInterfaces) {
     const interfaceName = interfaceClass.name;
-    schemaConfig.interfaces.push(createInterfaceFromClass(interfaceClass));
+    const interfaceDef = createInterfaceFromClass(interfaceClass);
+    types.push(interfaceDef);
   }
 
   // Load all other types...
 }
 
 // Helper function to create a GraphQL interface from a class
-function createInterfaceFromClass(classConstructor: any) {
+function createInterfaceFromClass(classConstructor: AnyGraphqlObjectBaseCtor) {
   return {
     name: classConstructor.name,
-    definition(t: any) {
+    definition(t) {
       // Extract fields from the class's gqlSpec
       const spec = classConstructor.gqlSpec;
-      // Add fields to the interface definition
-      // ...
+      // Add fields from the specification to the interface
+      for (const [fieldName, fieldDef] of Object.entries(spec.fields)) {
+        if (fieldDef.nonNull) {
+          t.nonNull.field(fieldName, { type: fieldDef.type });
+        } else {
+          t.field(fieldName, { type: fieldDef.type });
+        }
+      }
       // Add resolveType function
       t.resolveType(resolveNodeType);
     },
@@ -166,29 +187,30 @@ function createInterfaceFromClass(classConstructor: any) {
 }
 ```
 
-This approach ensures interfaces are automatically created from marked classes,
-and types that extend those classes will implement the corresponding interfaces.
+This approach uses a centralized registry for interfaces and automatically
+creates the appropriate interface definitions in the schema.
 
 ### Type Resolution Logic
 
 The resolveType function will follow this logic:
 
-1. Use the `__typename` field if available (GraphQLObjectBase standard)
-2. Fall back to `metadata.className` if available (BfNode pattern)
-3. Use constructor.name as a last resort
-4. Return "Unknown" if no type information can be determined
+1. Use `metadata.className` if available (BfNode pattern)
+2. Use constructor.name as a fallback
+3. Throw an error if no type information can be determined
 
 ```typescript
 function resolveNodeType(obj: GraphQLRootObject): string {
-  if (obj.__typename) {
-    return obj.__typename;
-  }
-
   if (obj.metadata?.className) {
     return obj.metadata.className;
   }
 
-  return "Unknown";
+  if (obj.constructor && obj.constructor.name) {
+    return obj.constructor.name;
+  }
+
+  throw new Error(
+    `Unable to resolve GraphQL type for object: ${JSON.stringify(obj)}`,
+  );
 }
 ```
 
@@ -201,7 +223,7 @@ that a class implements:
 export function gqlSpecToNexus(
   spec: GqlNodeSpec,
   typeName: string,
-  classConstructor: any,
+  classConstructor: AnyGraphqlObjectBaseCtor,
 ) {
   // Find all interfaces this class implements by walking up the prototype chain
   const implementedInterfaces = findImplementedInterfaces(classConstructor);
@@ -221,17 +243,23 @@ export function gqlSpecToNexus(
 }
 
 // Helper function to find all interfaces a class implements
-function findImplementedInterfaces(classConstructor: any): string[] {
+function findImplementedInterfaces(
+  classConstructor: AnyGraphqlObjectBaseCtor,
+): string[] {
   const interfaces: string[] = [];
-  let current = Object.getPrototypeOf(classConstructor);
 
-  // Walk up the prototype chain
+  // Check all the classes in the prototype chain
+  let current = classConstructor;
   while (current && current !== GraphQLObjectBase) {
-    // If this parent class is marked as an interface, add it
-    if (GraphQLObjectBase.isInterface(current.constructor)) {
-      interfaces.push(current.constructor.name);
+    // Check each parent class
+    const parentClass = Object.getPrototypeOf(current);
+
+    // If the parent class is in the interface registry, add it
+    if (parentClass && isGraphQLInterface(parentClass)) {
+      interfaces.push(parentClass.name);
     }
-    current = Object.getPrototypeOf(current);
+
+    current = parentClass;
   }
 
   return interfaces;
@@ -254,10 +282,10 @@ export abstract class BfNode extends GraphQLNode {
 
 ## Success Metrics
 
-- Interface marking mechanism is implemented and works correctly
-- GraphQLNode class is properly implemented, marked as an interface, and extends
-  GraphQLObjectBase
+- Interface registry system is implemented and works correctly
+- GraphQLNode class is properly implemented and registered as an interface
 - Interface registration system correctly identifies and registers interfaces
+  from the registry
 - BfNode and other classes correctly inherit from GraphQLNode
 - Interface implementations are automatically detected based on class
   inheritance


### PR DESCRIPTION

Update the v0.2 implementation plan with several important corrections:

- Clarify that interfaces should NOT be in a separate directory
- Remove redundant __typename field definition (auto-added by GraphQL)
- Update import paths to always use full filenames with extensions
- Replace 'any' type with specific AnyGraphqlObjectBaseCtor
- Improve error handling in resolveType to throw instead of return "Unknown"

These changes ensure the implementation follows GraphQL best practices
and project conventions for importing, type safety, and error handling.
