### PR TITLE
Implement initial GraphQLNode base class

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -44,7 +44,9 @@
       "Bash(ls:*)",
       "Bash(apps/bfDb/bin/genBarrel.ts)",
       "Bash(./apps/bfDb/graphql/graphqlServer.ts)",
-      "Bash(deno check:*)"
+      "Bash(deno check:*)",
+      "Bash(chmod:*)",
+      "Bash(./apps/bfDb/graphql/__tests__/GraphQLNode.test.ts)"
     ],
     "deny": []
   }

--- a/apps/bfDb/builders/graphql/README.md
+++ b/apps/bfDb/builders/graphql/README.md
@@ -1,0 +1,229 @@
+# GraphQL Builder Usage Guide
+
+This guide provides examples and best practices for using the GraphQL Builder in
+the Bolt Foundry codebase.
+
+## Quick Start
+
+```typescript
+// Example node type definition
+class MyNode extends GraphQLObjectBase {
+  static override gqlSpec = this.defineGqlNode((gql) =>
+    gql
+      .nonNull.id("id")
+      .nonNull.string("name")
+      .boolean("isActive")
+      .object("owner", () => User)
+      .mutation("updateName", {
+        args: (a) => a.nonNull.string("newName"),
+        returns: (r) => r.nonNull.boolean("success").string("message"),
+        resolve: async (root, { newName }, ctx) => {
+          // Implementation here
+          return { success: true, message: "Name updated" };
+        },
+      })
+  );
+}
+```
+
+## Core Components
+
+The GraphQL Builder consists of the following key components:
+
+1. **Field Builder** (`makeGqlBuilder.ts`): Defines scalar and object fields
+2. **Argument Builder** (`makeArgBuilder.ts`): Defines arguments for fields and
+   mutations
+3. **Returns Builder** (`makeReturnsBuilder.ts`): Defines return types for
+   mutations
+4. **Spec Generator** (`makeGqlSpec.ts`): Collects fields, relations, and
+   mutations
+5. **Nexus Converter** (`gqlSpecToNexus.ts`): Converts specs to Nexus types
+
+## Defining Fields
+
+### Scalar Fields
+
+```typescript
+.string("name")           // Nullable string field
+.nonNull.string("name")   // Required string field
+.int("count")             // Nullable integer field
+.nonNull.int("count")     // Required integer field
+.boolean("isActive")      // Nullable boolean field
+.nonNull.boolean("isActive") // Required boolean field
+.id("id")                 // Nullable ID field
+.nonNull.id("id")         // Required ID field
+```
+
+### Object Fields (Relationships)
+
+```typescript
+// Basic relationship (implicit edge relationship)
+.object("organization", () => BfOrganization)
+
+// With custom resolver (not an edge relationship)
+.object("organization", () => BfOrganization, {
+  resolve: (root, args, ctx) => ctx.getOrganizationById(root.organizationId)
+})
+
+// With arguments
+.object("organization", () => BfOrganization, {
+  args: (a) => a.string("filter")
+})
+
+// Handling circular dependencies
+.object("organization", () => 
+  import("../nodeTypes/BfOrganization.ts").then(m => m.BfOrganization)
+)
+
+// Reversed direction relationship
+.object("followers", () => BfPerson, { 
+  isSourceToTarget: false // Makes this a target→source relationship
+})
+```
+
+## Defining Mutations
+
+```typescript
+.mutation("createItem", {
+  // Define arguments
+  args: (a) => a
+    .nonNull.string("name")
+    .string("description")
+    .nonNull.int("quantity"),
+  
+  // Define return type
+  returns: (r) => r
+    .nonNull.boolean("success")
+    .string("message")
+    .object("item", () => Item),
+  
+  // Implement resolver
+  resolve: async (root, args, ctx, info) => {
+    // Implementation here
+    return {
+      success: true,
+      message: "Item created successfully",
+      item: newItem
+    };
+  }
+})
+```
+
+## Edge Relationships
+
+Edge relationships are automatically created for object fields without custom
+resolvers. The field name becomes the edge role name, and the relationship is
+resolved through the BfEdge model.
+
+```typescript
+// This creates an edge with role "memberOf" from the current node to BfOrganization
+.object("memberOf", () => BfOrganization)
+```
+
+## Real-World Examples
+
+### Query Root
+
+```typescript
+// apps/bfDb/graphql/roots/Query.ts
+export class Query extends GraphQLObjectBase {
+  static override gqlSpec = this.defineGqlNode((field) =>
+    field
+      .boolean("ok")
+      .object("currentViewer", () => CurrentViewer)
+  );
+
+  override toGraphql() {
+    return { __typename: "Query", id: "Query" };
+  }
+}
+```
+
+### Waitlist Example
+
+```typescript
+// apps/bfDb/graphql/roots/Waitlist.ts
+export class Waitlist extends GraphQLObjectBase {
+  static override gqlSpec = this.defineGqlNode((gql) =>
+    gql
+      .id("id")
+      .mutation("joinWaitlist", {
+        args: (a) =>
+          a
+            .nonNull.string("email")
+            .nonNull.string("name")
+            .nonNull.string("company"),
+        returns: (r) =>
+          r
+            .string("message")
+            .nonNull.boolean("success"),
+        async resolve(_src, { email, name, company }) {
+          // Implementation here
+          return {
+            success: true,
+            message: "Successfully joined waitlist",
+          };
+        },
+      })
+  );
+}
+```
+
+## Best Practices
+
+1. **Always define an id field**: Every GraphQL type should have an id field
+   ```typescript
+   .nonNull.id("id")
+   ```
+
+2. **Use nonNull for required fields**: Make fields required when appropriate
+   ```typescript
+   .nonNull.string("name")
+   ```
+
+3. **Clear naming conventions**: Use descriptive field names
+   ```typescript
+   // Good
+   .string("fullName")
+
+   // Avoid
+   .string("n")
+   ```
+
+4. **Handle circular dependencies**: Use dynamic imports for circular references
+   ```typescript
+   .object("parent", () => 
+     import("../models/Parent.ts").then(m => m.Parent)
+   )
+   ```
+
+5. **Type safety**: Leverage the builder's type inference for resolvers
+   ```typescript
+   .mutation("createUser", {
+     args: (a) => a.nonNull.string("name"),
+     returns: (r) => r.nonNull.boolean("success"),
+     // TypeScript infers args.name as string and return type as { success: boolean }
+     resolve: (root, args, ctx) => {
+       return { success: true };
+     }
+   })
+   ```
+
+6. **Resolver implementation**: Follow the resolver chain guidelines
+   - Custom resolver in opts.resolve
+   - root.props[name] if present
+   - root[name] as getter or method
+
+## Future Enhancements (v0.2 and Beyond)
+
+1. **Node Interface**:
+   - GraphQLNode class and Node interface implementation
+   - Barrel files for automatic interface registration
+   - No manual registration required - just export from barrel file
+
+2. **Connection Support**: Relay-style connections with pagination
+3. **Validation**: Schema validation against bfNodeSpec.relations
+
+For more detailed information, see the
+[Implementation Plan](/apps/bfDb/docs/0.1/implementation-plan.md) and
+[Status Document](/apps/bfDb/docs/status.md).

--- a/apps/bfDb/docs/0.2/implementation-plan.md
+++ b/apps/bfDb/docs/0.2/implementation-plan.md
@@ -5,14 +5,14 @@
 This implementation plan outlines the approach for implementing a proper GraphQL
 node inheritance hierarchy in the bfDb system. We'll create a GraphQLNode class
 that extends GraphQLObjectBase, which will serve as the base for all node types
-in the system, including BfNode and other specialized nodes.
+in the system, including BfNode and other specialized nodes. We'll use barrel
+files for automatically registering interface implementations.
 
 ## Goals
 
 - Create a standard GraphQLNode class that extends GraphQLObjectBase
-- Implement a system for automatically creating GraphQL interfaces from
-  explicitly marked classes
-- Add the "Node" GraphQL interface in the schema
+- Implement the Node GraphQL interface in the schema
+- Set up a barrel file structure for interfaces and implementations
 - Refactor the inheritance structure so BfNode and other node types extend
   GraphQLNode
 - Enable proper interface resolution at runtime
@@ -27,12 +27,11 @@ in the system, including BfNode and other specialized nodes.
 
 ## Approach
 
-1. **Interface Registry**: Create a central registry for classes that should be
-   treated as GraphQL interfaces
-2. **Class Hierarchy**: Create the GraphQLNode class alongside other GraphQL
-   types and register it in the interface registry
-3. **Interface Registration**: Implement registration of GraphQL interfaces from
-   the registry during schema generation
+1. **Generated Registry**: Implement an automatic interface registry using generated files
+   in the `__generated__` directory
+2. **Class Hierarchy**: Create the GraphQLNode class alongside other interface types
+3. **Auto-Registration**: Implement a generation step for creating interface registry files
+   during build
 4. **Schema Integration**: Update gqlSpecToNexus.ts to detect interface
    implementations through the prototype chain
 5. **Inheritance Refactoring**: Update BfNode to extend GraphQLNode
@@ -40,27 +39,26 @@ in the system, including BfNode and other specialized nodes.
 
 ## Implementation Steps
 
-1. **Create Interface Registry**
-   - Create graphqlInterfaces.ts with a registry array of interface classes
-   - Add utility functions to check if a class is in the registry
-   - Document how to register new interfaces in the registry
+1. **Create File Structure for Interfaces**
+   - Create `apps/bfDb/graphql/GraphQLNode.ts` interface base class
+   - Create `apps/bfDb/graphql/__generated__/` directory for generated files
+   - Create generator script to populate `graphqlInterfaces.ts`
 
 2. **Create GraphQLNode Class**
-   - Create a new GraphQLNode.ts file in the graphql directory
-   - Make it extend GraphQLObjectBase
-   - Implement required methods and properties for node functionality
+   - Implement GraphQLNode extending GraphQLObjectBase
+   - Add required methods and properties for node functionality
    - Add gqlSpec definition with core Node fields (id)
-   - Register it in the graphqlInterfaces registry
+   - Register in the generated interface registry
 
-3. **Implement Interface Registration in Schema**
-   - Modify loadGqlTypes.ts to load interfaces from the registry
-   - Create functions to convert interface classes to GraphQL interfaces
+3. **Implement Interface Registry Generator**
+   - Create genInterfaces.ts script to scan for interface classes
+   - Generate graphqlInterfaces.ts registry file only
    - Implement resolveType function to determine concrete types at runtime
    - Ensure interfaces are registered before object types in the schema
 
 4. **Update Schema Generation**
    - Modify gqlSpecToNexus.ts to detect implemented interfaces automatically
-   - Add prototype chain traversal to find all implemented interfaces
+   - Use prototype chain to find all implemented interfaces
    - Update schema generation to apply interfaces to implementing types
    - Ensure proper registration of interfaces and implementations
 
@@ -71,7 +69,7 @@ in the system, including BfNode and other specialized nodes.
    - Update any dependent classes as needed
 
 6. **Testing**
-   - Create tests for the interface registry system
+   - Create tests for the generated registry system
    - Test interface registration and implementation detection
    - Test interface type resolution with different node types
    - Verify schema generation with interface implementations
@@ -79,39 +77,51 @@ in the system, including BfNode and other specialized nodes.
 
 ## Technical Design
 
-### Interface Registry with Explicit Registration
+### Generated Interface Registry
 
-Instead of using a separate directory (like `apps/bfDb/graphql/interfaces/`),
-we'll keep interfaces alongside related types and use an explicit registry:
+We'll follow the existing project convention using generated registry files in `__generated__` folders:
 
-```typescript
-// graphqlInterfaces.ts - Registry for GraphQL interfaces
-import { GraphQLNode } from "apps/bfDb/graphql/GraphQLNode.ts"; // Lives with other types
-import type { AnyGraphqlObjectBaseCtor } from "apps/bfDb/builders/bfDb/types.ts";
-// Import other interface classes as needed
-
-// Registry of all classes that should be treated as GraphQL interfaces
-export const graphQLInterfaces = [
-  GraphQLNode,
-  // Add other interface classes here
-];
-
-// Utility function to check if a class is registered as an interface
-export function isGraphQLInterface(
-  classConstructor: AnyGraphqlObjectBaseCtor,
-): boolean {
-  return graphQLInterfaces.includes(classConstructor);
-}
+```
+apps/bfDb/
+  graphql/
+    GraphQLNode.ts               # Node interface base class
+    __generated__/
+      graphqlInterfaces.ts       # Generated registry of all interfaces
+      nodeTypesList.ts           # Generated list of all node types
+    nodeTypes/
+      BfPerson.ts                # Implements Node via GraphQLNode
+      BfOrganization.ts          # Implements Node via GraphQLNode
 ```
 
-This approach:
+This structure:
+- Maintains consistency with existing project conventions
+- Places interfaces next to related implementations
+- Keeps generated code separate in `__generated__` directories
+- Preserves type relationships through inheritance
+- Provides clear visibility into available interfaces and implementations
 
-- Keeps related types together in the same directory
-- Uses an explicit registry that clearly shows all interfaces in one place
-- Makes it obvious which classes are interfaces
-- Avoids fragmenting related code across different directories
-- Provides a simple way to check if a class is an interface during schema
-  generation
+### Generated Interface Registry File
+
+```typescript
+// apps/bfDb/graphql/__generated__/graphqlInterfaces.ts
+/* @generated */
+/* This file is auto-generated by generateBarrels.ts. */
+
+export * from "apps/bfDb/graphql/GraphQLNode.ts";
+// Other interfaces are automatically included by the generator
+```
+
+### Generated Node Types Registry
+
+```typescript
+// apps/bfDb/graphql/__generated__/nodeTypesList.ts
+/* @generated */
+/* This file is auto-generated by generateBarrels.ts. */
+
+export * from "apps/bfDb/nodeTypes/BfPerson.ts";
+export * from "apps/bfDb/nodeTypes/BfOrganization.ts";
+// Other node types are automatically included by the generator
+```
 
 ### GraphQLNode Class Implementation
 
@@ -119,24 +129,24 @@ The GraphQLNode class will extend GraphQLObjectBase and provide the base
 functionality for all node types:
 
 ```typescript
-export class GraphQLNode extends GraphQLObjectBase {
+// apps/bfDb/graphql/GraphQLNode.ts
+export abstract class GraphQLNode extends GraphQLObjectBase {
   // Define the GraphQL specification with Node interface fields
-  // Note: Do NOT define __typename as it's automatically added by GraphQL
   static override gqlSpec = this.defineGqlNode((gql) =>
     gql
       .nonNull.id("id")
   );
 
-  // Additional node-specific methods can be added here
-}
+  // Required field for Node interface
+  abstract get id(): string;
 
-// GraphQLNode is registered in the graphqlInterfaces registry
+  // Additional node-specific methods
+}
 ```
 
 ### Interface Definition in Schema
 
-The Node interface will be automatically generated in the GraphQL schema based
-on the GraphQLNode class:
+The Node interface will be automatically generated in the GraphQL schema:
 
 ```graphql
 interface Node {
@@ -144,29 +154,46 @@ interface Node {
 }
 ```
 
-### Interface Registration
+### Automatic Loading from Generated Registry Files
 
-We'll use the interface registry to register interfaces in the schema:
+We'll modify loadGqlTypes.ts to import from the generated registry files:
 
 ```typescript
 // In loadGqlTypes.ts
-import { graphQLInterfaces, isGraphQLInterface } from "./graphqlInterfaces.ts";
+import * as interfaceTypes from './__generated__/graphqlInterfaces.ts';
+import * as nodeTypes from './__generated__/nodeTypesList.ts';
 
 export function loadGqlTypes() {
   const types = [];
+  
+  // Get all interface types from the barrel
+  const graphqlInterfaces = Object.values(interfaceTypes).filter(
+    val => typeof val === 'function' && val.prototype
+  );
+  
+  // Get all node types from the barrel
+  const objectTypes = Object.values(nodeTypes).filter(
+    val => typeof val === 'function' && val.prototype
+  );
 
-  // Register all interfaces from the registry
-  for (const interfaceClass of graphQLInterfaces) {
-    const interfaceName = interfaceClass.name;
-    const interfaceDef = createInterfaceFromClass(interfaceClass);
+  // Register interfaces first
+  for (const interfaceType of graphqlInterfaces) {
+    const interfaceDef = createInterfaceFromClass(interfaceType);
     types.push(interfaceDef);
   }
 
-  // Load all other types...
+  // Register object types, checking inheritance for interface implementation
+  for (const objectType of objectTypes) {
+    // Register the type with schema
+    const objectDef = createObjectTypeFromClass(objectType);
+    types.push(objectDef);
+  }
+
+  return types;
 }
 
 // Helper function to create a GraphQL interface from a class
-function createInterfaceFromClass(classConstructor: AnyGraphqlObjectBaseCtor) {
+function createInterfaceFromClass(classConstructor) {
   return {
     name: classConstructor.name,
     definition(t) {
@@ -187,25 +214,32 @@ function createInterfaceFromClass(classConstructor: AnyGraphqlObjectBaseCtor) {
 }
 ```
 
-This approach uses a centralized registry for interfaces and automatically
-creates the appropriate interface definitions in the schema.
-
 ### Type Resolution Logic
 
 The resolveType function will follow this logic:
 
 1. Use `metadata.className` if available (BfNode pattern)
 2. Use constructor.name as a fallback
-3. Throw an error if no type information can be determined
+3. Use `__typename` if available
+4. Throw an error if no type information can be determined
 
 ```typescript
-function resolveNodeType(obj: GraphQLRootObject): string {
+function resolveNodeType(obj): string {
+  // BfNode pattern
   if (obj.metadata?.className) {
     return obj.metadata.className;
   }
 
-  if (obj.constructor && obj.constructor.name) {
+  // Constructor name
+  if (
+    obj.constructor && obj.constructor.name && obj.constructor.name !== "Object"
+  ) {
     return obj.constructor.name;
+  }
+
+  // __typename from GraphQL
+  if (obj.__typename) {
+    return obj.__typename;
   }
 
   throw new Error(
@@ -214,64 +248,46 @@ function resolveNodeType(obj: GraphQLRootObject): string {
 }
 ```
 
-### Schema Generation Changes
+### Schema Generation with Interface Detection
 
-The gqlSpecToNexus function will be updated to automatically detect interfaces
-that a class implements:
+We'll update our schema generation to auto-detect interfaces through
+inheritance:
 
 ```typescript
-export function gqlSpecToNexus(
-  spec: GqlNodeSpec,
-  typeName: string,
-  classConstructor: AnyGraphqlObjectBaseCtor,
-) {
-  // Find all interfaces this class implements by walking up the prototype chain
-  const implementedInterfaces = findImplementedInterfaces(classConstructor);
+function createObjectTypeFromClass(classConstructor) {
+  // Find implemented interfaces through prototype chain
+  const implementedInterfaces = [];
 
-  const mainType = {
-    name: typeName,
-    // Automatically add implements for all interfaces the class extends
+  // Check the prototype chain
+  let current = classConstructor;
+  while (current && current.prototype) {
+    // Get parent class
+    const parent = Object.getPrototypeOf(current);
+
+    // Check if parent is in our interfaces registry by walking up the prototype chain
+    if (graphqlInterfaces.includes(parent)) {
+      implementedInterfaces.push(parent.name);
+    }
+
+    current = parent;
+  }
+
+  return {
+    name: classConstructor.name,
+    // Add implements if there are any
     ...(implementedInterfaces.length > 0
       ? { implements: implementedInterfaces }
       : {}),
     definition(t) {
-      // Existing field definitions...
+      // Object type definition logic
     },
   };
-
-  // Rest of function...
-}
-
-// Helper function to find all interfaces a class implements
-function findImplementedInterfaces(
-  classConstructor: AnyGraphqlObjectBaseCtor,
-): string[] {
-  const interfaces: string[] = [];
-
-  // Check all the classes in the prototype chain
-  let current = classConstructor;
-  while (current && current !== GraphQLObjectBase) {
-    // Check each parent class
-    const parentClass = Object.getPrototypeOf(current);
-
-    // If the parent class is in the interface registry, add it
-    if (parentClass && isGraphQLInterface(parentClass)) {
-      interfaces.push(parentClass.name);
-    }
-
-    current = parentClass;
-  }
-
-  return interfaces;
 }
 ```
 
-This approach automatically detects interface implementations based on
-inheritance hierarchy.
-
 ### BfNode Refactoring
 
-BfNode will be updated to extend GraphQLNode instead of GraphQLObjectBase:
+BfNode will be updated to extend GraphQLNode:
 
 ```typescript
 export abstract class BfNode extends GraphQLNode {
@@ -282,10 +298,8 @@ export abstract class BfNode extends GraphQLNode {
 
 ## Success Metrics
 
-- Interface registry system is implemented and works correctly
-- GraphQLNode class is properly implemented and registered as an interface
-- Interface registration system correctly identifies and registers interfaces
-  from the registry
+- GraphQLNode class is properly implemented and included in the interface registry
+- Generated registry system correctly identifies and registers interfaces
 - BfNode and other classes correctly inherit from GraphQLNode
 - Interface implementations are automatically detected based on class
   inheritance
@@ -293,6 +307,7 @@ export abstract class BfNode extends GraphQLNode {
 - Tests pass for all aspects of the implementation
 - Schema includes proper interface definitions and implementations
 - Existing functionality continues to work with the new inheritance structure
+- Adding new interfaces is automatically handled by the generation process
 
 ## Next Steps (Future Work)
 

--- a/apps/bfDb/docs/0.2/implementation-plan.md
+++ b/apps/bfDb/docs/0.2/implementation-plan.md
@@ -27,11 +27,12 @@ files for automatically registering interface implementations.
 
 ## Approach
 
-1. **Generated Registry**: Implement an automatic interface registry using generated files
-   in the `__generated__` directory
-2. **Class Hierarchy**: Create the GraphQLNode class alongside other interface types
-3. **Auto-Registration**: Implement a generation step for creating interface registry files
-   during build
+1. **Generated Registry**: Implement an automatic interface registry using
+   generated files in the `__generated__` directory
+2. **Class Hierarchy**: Create the GraphQLNode class alongside other interface
+   types
+3. **Auto-Registration**: Implement a generation step for creating interface
+   registry files during build
 4. **Schema Integration**: Update gqlSpecToNexus.ts to detect interface
    implementations through the prototype chain
 5. **Inheritance Refactoring**: Update BfNode to extend GraphQLNode
@@ -79,7 +80,8 @@ files for automatically registering interface implementations.
 
 ### Generated Interface Registry
 
-We'll follow the existing project convention using generated registry files in `__generated__` folders:
+We'll follow the existing project convention using generated registry files in
+`__generated__` folders:
 
 ```
 apps/bfDb/
@@ -94,6 +96,7 @@ apps/bfDb/
 ```
 
 This structure:
+
 - Maintains consistency with existing project conventions
 - Places interfaces next to related implementations
 - Keeps generated code separate in `__generated__` directories
@@ -160,20 +163,20 @@ We'll modify loadGqlTypes.ts to import from the generated registry files:
 
 ```typescript
 // In loadGqlTypes.ts
-import * as interfaceTypes from './__generated__/graphqlInterfaces.ts';
-import * as nodeTypes from './__generated__/nodeTypesList.ts';
+import * as interfaceTypes from "./__generated__/graphqlInterfaces.ts";
+import * as nodeTypes from "./__generated__/nodeTypesList.ts";
 
 export function loadGqlTypes() {
   const types = [];
-  
+
   // Get all interface types from the barrel
   const graphqlInterfaces = Object.values(interfaceTypes).filter(
-    val => typeof val === 'function' && val.prototype
+    (val) => typeof val === "function" && val.prototype,
   );
-  
+
   // Get all node types from the barrel
   const objectTypes = Object.values(nodeTypes).filter(
-    val => typeof val === 'function' && val.prototype
+    (val) => typeof val === "function" && val.prototype,
   );
 
   // Register interfaces first
@@ -298,7 +301,8 @@ export abstract class BfNode extends GraphQLNode {
 
 ## Success Metrics
 
-- GraphQLNode class is properly implemented and included in the interface registry
+- GraphQLNode class is properly implemented and included in the interface
+  registry
 - Generated registry system correctly identifies and registers interfaces
 - BfNode and other classes correctly inherit from GraphQLNode
 - Interface implementations are automatically detected based on class

--- a/apps/bfDb/docs/status.md
+++ b/apps/bfDb/docs/status.md
@@ -31,6 +31,8 @@ hierarchy, which is needed for the Login Integration project.
   defineGqlNode method
 - ✅ Dynamic Root Loading: Improved loadGqlTypes.ts to use Object.values for
   automatic root loading
+- ⏱️ Interface Detection: Using barrel files for automatic interface
+  registration
 - ⏱️ Validation: Validation against bfNodeSpec.relations pending
 
 ## Next Steps (Priority Order)
@@ -38,8 +40,8 @@ hierarchy, which is needed for the Login Integration project.
 1. Implement GraphQLNode and Node interface (v0.2):
    - Create GraphQLNode class that extends GraphQLObjectBase
    - Define Node GraphQL interface in the schema
-   - Update loadGqlTypes.ts to automatically register the Node interface
-   - Modify gqlSpecToNexus.ts to automatically detect GraphQLNode types
+   - Implement barrel files for interfaces and implementations
+   - Modify loadGqlTypes.ts to use barrel files for automatic registration
    - Refactor BfNode to extend GraphQLNode
    - Add resolveType function for interface resolution
    - Add tests to verify implementation

--- a/apps/bfDb/graphql/GraphQLNode.ts
+++ b/apps/bfDb/graphql/GraphQLNode.ts
@@ -1,0 +1,47 @@
+import { GraphQLObjectBase } from "./GraphQLObjectBase.ts";
+import type { GqlNodeSpec } from "apps/bfDb/builders/graphql/makeGqlSpec.ts";
+
+/**
+ * Base class for all GraphQL nodes that implement the Node interface.
+ * This class provides the foundation for objects that can be retrieved by ID
+ * and conform to the Relay Node specification.
+ */
+export abstract class GraphQLNode extends GraphQLObjectBase {
+  /**
+   * Define the GraphQL specification with Node interface fields.
+   * This includes the id field which is required for all Node interface implementations.
+   */
+  static override gqlSpec: GqlNodeSpec = this.defineGqlNode((gql) =>
+    gql
+      .nonNull.id("id")
+  );
+
+  /**
+   * ID field required by the Node interface.
+   * Concrete implementations must provide this field.
+   */
+  abstract override get id(): string;
+
+  constructor() {
+    super();
+
+    // Ensure that get id() is implemented in subclasses
+    const proto = Object.getPrototypeOf(this);
+    const hasOwnId = Object.getOwnPropertyDescriptor(proto, "id")?.get;
+
+    if (this.constructor === GraphQLNode) {
+      throw new TypeError("Cannot instantiate abstract class GraphQLNode");
+    }
+
+    if (!hasOwnId) {
+      // Make the id property throw when accessed if it's not implemented
+      Object.defineProperty(this, "id", {
+        get() {
+          throw new TypeError("Abstract method 'get id()' must be implemented");
+        },
+        configurable: true,
+        enumerable: true,
+      });
+    }
+  }
+}

--- a/apps/bfDb/graphql/__tests__/GraphQLNode.test.ts
+++ b/apps/bfDb/graphql/__tests__/GraphQLNode.test.ts
@@ -1,0 +1,65 @@
+#! /usr/bin/env -S bff test
+
+/**
+ * Tests for the GraphQLNode class implementation
+ */
+
+import { assert, assertEquals, assertThrows } from "@std/assert";
+import { GraphQLObjectBase } from "../GraphQLObjectBase.ts";
+
+// Import the class we're about to create
+import { GraphQLNode } from "../GraphQLNode.ts";
+
+Deno.test("GraphQLNode extends GraphQLObjectBase", () => {
+  // This test will fail until we create the GraphQLNode class
+  assert(
+    Object.getPrototypeOf(GraphQLNode.prototype) ===
+      GraphQLObjectBase.prototype,
+    "GraphQLNode should extend GraphQLObjectBase",
+  );
+});
+
+Deno.test("GraphQLNode defines gqlSpec with required Node interface fields", () => {
+  // This test will fail until we implement gqlSpec correctly
+  assert(GraphQLNode.gqlSpec, "GraphQLNode should define gqlSpec");
+
+  // Fields should exist
+  assert(
+    GraphQLNode.gqlSpec.fields,
+    "GraphQLNode.gqlSpec should define fields",
+  );
+
+  // ID field should exist
+  const idField = GraphQLNode.gqlSpec.fields["id"];
+  assert(idField, "GraphQLNode.gqlSpec should define an 'id' field");
+});
+
+Deno.test("GraphQLNode requires concrete implementations to provide an id getter", () => {
+  // Abstract classes can't be directly instantiated in JavaScript/TypeScript,
+  // but we can test that we've properly made the getter abstract
+
+  // We should be able to extend it with a concrete implementation
+  class TestNode extends GraphQLNode {
+    override get id(): string {
+      return "test-id";
+    }
+  }
+
+  const testNode = new TestNode();
+  assertEquals(
+    testNode.id,
+    "test-id",
+    "TestNode should have the correct id value",
+  );
+
+  // Test instantiating the abstract class directly
+  assertThrows(
+    () => {
+      // @ts-ignore - We're intentionally trying to instantiate an abstract class
+      new GraphQLNode();
+    },
+    TypeError,
+    "Cannot instantiate abstract class",
+    "Should not be able to instantiate GraphQLNode directly",
+  );
+});


### PR DESCRIPTION

Create the foundation for the GraphQL Node interface implementation as outlined in v0.2 implementation plan. This adds the GraphQLNode abstract base class that extends GraphQLObjectBase and requires implementing classes to provide an id field.

Changes:
- Add GraphQLNode class with nonNull id field requirement
- Create tests to verify inheritance and abstract method enforcement
- Make the test file executable for direct test runs

Test plan:
1. Run the GraphQLNode tests to verify the implementation works
2. Verify that GraphQLNode extends GraphQLObjectBase
3. Check that id is properly marked as abstract and required

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/827).
* __->__ #827
* #822
* #821