### PR TITLE
Update Nix setup in GitHub workflows

### DIFF
--- a/.github/workflows/flakehub-publish-rolling.yml
+++ b/.github/workflows/flakehub-publish-rolling.yml
@@ -1,4 +1,4 @@
-# .github/workflows/flakehub-ci.yml
+# .github/workflows/flakehub-publish-rolling.yml
 name: CI + FlakeHub
 
 on:
@@ -25,8 +25,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.ref || 'main' }}
-      - uses: DeterminateSystems/nix-installer-action@v3
-      - uses: DeterminateSystems/flakehub-cache-action@v1
+
+      - uses: DeterminateSystems/nix-installer-action@main
+        with: { determinate: true }
+
+      - uses: DeterminateSystems/flakehub-cache-action@main
 
       # build whatever you want cached
       - run: nix develop .#devShells.x86_64-linux.default -c true

--- a/.github/workflows/flakehub-publish-rolling.yml
+++ b/.github/workflows/flakehub-publish-rolling.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: DeterminateSystems/flakehub-cache-action@v1
 
       # build whatever you want cached
-      - run: nix build .#packages.x86_64-linux.default
+      - run: nix develop .#devShells.x86_64-linux.default -c true
 
       - uses: DeterminateSystems/flakehub-push@v2
         with:

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -17,15 +17,11 @@ jobs:
       contents: read
     steps:
       - name: Install Nix
-        uses: cachix/install-nix-action@v22
-        with:
-          nix_path: nixpkgs=channel:nixos-24.11
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-            max-jobs = auto
-            cores = 0
-            substituters = https://cache.nixos.org
-            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+        uses: DeterminateSystems/nix-installer-action@main
+        with: { determinate: true }
+
+      - name: Setup Nix caching
+        uses: DeterminateSystems/flakehub-cache-action@main
 
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -23,17 +23,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+        with: { determinate: true }
+
+      - name: Setup Nix caching
+        uses: DeterminateSystems/flakehub-cache-action@main
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org/"
-
-      - name: Setup Deno
-        uses: denoland/setup-deno@v1
-        with:
-          deno-version: v1.x
-          cache: true
 
       # Set Deno cache directory
       - name: Set Deno cache directory
@@ -74,8 +75,11 @@ jobs:
 
       - name: Build package
         run: |
-          cd packages/bolt-foundry
-          deno run -A bin/build.ts
+          nix develop . --accept-flake-config --command bash -euc "
+            export DENO_DIR=\"${DENO_DIR}\"
+            cd packages/bolt-foundry
+            deno run -A bin/build.ts
+          "
 
       - name: Publish to npm
         run: |
@@ -86,8 +90,11 @@ jobs:
 
       - name: Publish to JSR
         run: |
-          cd packages/bolt-foundry
-          deno publish --allow-dirty --token ${{ secrets.JSR_TOKEN }}
+          nix develop . --accept-flake-config --command bash -euc "
+            export DENO_DIR=\"${DENO_DIR}\"
+            cd packages/bolt-foundry
+            deno publish --allow-dirty --token ${{ secrets.JSR_TOKEN }}
+          "
         env:
           JSR_TOKEN: ${{ secrets.JSR_TOKEN }}
 


### PR DESCRIPTION
Standardize all workflows to use the latest DeterminateSystems/nix-installer-action@main
and DeterminateSystems/flakehub-cache-action@main to ensure consistent Nix environment.

Changes:
- Update flakehub-publish-rolling.yml to use latest Nix installer and cache actions
- Update publish-dev.yml to use same Nix setup as CI workflow
- Update publish-release.yml to use Nix setup and run commands through Nix shell

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/838).
* __->__ #838
* #837

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/838)
<!-- GitContextEnd -->