### PR TITLE
Simplify GraphQL Builder v0.3 Implementation Plan

### DIFF
--- a/apps/bfDb/docs/0.3/implementation-plan.md
+++ b/apps/bfDb/docs/0.3/implementation-plan.md
@@ -2,352 +2,186 @@
 
 ## Summary
 
-This implementation plan outlines the approach for enhancing the barrel file
-system for GraphQL types in the bfDb system. Building on the success of v0.2's
-GraphQLNode and interface implementation, we'll now focus on creating a more
-robust, automated registration system for all GraphQL-related types. This will
-reduce manual registration work, improve consistency, and lay the groundwork for
-future feature development.
+This implementation plan outlines a minimal approach for improving the GraphQL
+interface registration system in the bfDb project. Building on v0.2's
+GraphQLNode and interface implementation, we'll organize interfaces into a
+dedicated directory and ensure the barrel file system correctly exports all
+interfaces and the loadGqlTypes function properly uses them.
 
 ## Goals
 
-- Create a unified barrel file generation system for all GraphQL types
-- Standardize the pattern for automatic type registration
-- Implement validation during the barrel file generation process
-- Provide helpers for accessing registered types programmatically
-- Ensure type safety throughout the registration system
-- Reduce manual registration work when adding new types
-- Improve developer experience when working with GraphQL types
+- Create a dedicated interfaces directory for GraphQL interfaces
+- Move existing interfaces to the new directory structure
+- Ensure the genBarrel.ts includes GraphQL interfaces in its barrel generation
+- Verify the interfacesList.ts barrel file contains all interfaces
+- Update loadGqlTypes.ts to correctly use the interfaces from the barrel file
 
 ## Non-Goals
 
+- Adding registry objects or complex validation
+- Creating new barrel utility functions
+- Implementing barrels for other GraphQL type categories (deferred to v0.4)
 - Changing the existing GraphQL interface implementation from v0.2
 - Migrating the remaining nodes to the new builder pattern (deferred to v0.4)
 - Adding Relay-style connections (deferred to v0.4)
-- Changing existing field resolution behavior
-- Adding validation against bfNodeSpec.relations (deferred to v0.4)
 
 ## Approach
 
-1. **Enhanced Barrel Generation**: Create a more comprehensive barrel file
-   generation system
-2. **Standardized Registration**: Implement consistent patterns for registration
-   across entity types
-3. **Validation Logic**: Add validation during barrel generation to catch issues
-   early
-4. **Type Safety**: Ensure strong typing throughout the system using TypeScript
-   generics
-5. **Developer Tools**: Add helpers for working with the registration system
+1. **Simple Enhancement**: Make minimal changes to the existing system
+2. **Consistent Interface Loading**: Ensure interfaces are properly loaded
 
 ## Implementation Steps
 
-1. **Analyze Current Barrel System**
-   - Review existing barrel files in **generated** directories
-   - Document the current generation process
-   - Identify improvement opportunities
-   - Catalog all type categories that need barrel files
+1. **Review Current System**
+   - Check the existing genBarrel.ts implementation
+   - Locate all GraphQL interfaces in the current structure
+   - Verify interfacesList.ts is being generated correctly
+   - Examine how loadGqlTypes.ts and graphqlInterfaces.ts work together
 
-2. **Design Enhanced Barrel System**
-   - Create a comprehensive barrel file architecture
-   - Define naming conventions and file organization
-   - Design validation rules for generated barrel files
-   - Define interfaces for the generator system
+2. **Create Interfaces Directory Structure**
+   - Create a new `apps/bfDb/graphql/interfaces/` directory
+   - Move GraphQLNode.ts and other interfaces to this directory
+   - Update imports in affected files including GraphQLObjectBase imports
 
-3. **Implement Barrel File Generator**
-   - Create generator utilities with strong typing
-   - Implement file scanning and module identification
-   - Add support for filtering modules by criteria
-   - Include validation checks during generation
+3. **Update Barrel Generator**
+   - Ensure genBarrel.ts includes GraphQL interfaces in its barrel configuration
+   - Update directory paths to point to the new interfaces directory
+   - Keep the implementation simple and focused
 
-4. **Create Standard Registration Patterns**
-   - Implement consistent registration for different entity types
-   - Create unified loading mechanism in loadGqlTypes.ts
-   - Add support for registration order control
-   - Ensure proper dependency management between types
+4. **Verify Interface Loading**
+   - Check that loadGqlTypes.ts properly processes all interfaces from the new
+     location
+   - Fix any issues with interface detection or loading
 
-5. **Add Type Safety Enhancements**
-   - Create type-safe accessors for registered types
-   - Implement generic type constraints for registration functions
-   - Add runtime type checking utilities
-   - Ensure proper TypeScript integration
+5. **Testing Strategy**
+   - Verify GraphQL schema includes all interfaces
+   - Test that interface-implementing objects are properly connected
+   - Ensure all tests pass with the new directory structure
+   - Add specific tests for interface loading and registration
 
-6. **Implement Developer Tools**
-   - Create helpers for accessing registered types
-   - Add diagnostic tools for the barrel system
-   - Implement debugging utilities for registration issues
-   - Create documentation for the barrel system
+   ### Unit Tests
+   - **Interface Registration**: Verify interfaces from the new directory are
+     properly registered
+   - **Decorator Functionality**: Test that @GraphQLInterface continues to
+     identify classes correctly
+   - **Barrel Generation**: Test that interfacesList.ts contains the expected
+     exports
+   - **Interface Resolution**: Verify concrete types can be resolved to their
+     interfaces
 
-7. **Testing**
-   - Create tests for barrel file generation
-   - Test registration of various entity types
-   - Verify type safety constraints
-   - Test validation rules and error reporting
-   - Ensure backward compatibility
+   ### Integration Tests
+   - **Schema Generation**: Test that interfaces appear in the schema with
+     correct fields
+   - **Type Implementation**: Verify objects correctly implement interfaces in
+     GraphQL schema
+   - **Query Resolution**: Test GraphQL queries that rely on interface types
+     (e.g., fragments)
+   - **Interface Loading**: Verify loadInterfaces() correctly loads all
+     interfaces from the barrel file
 
 ## Technical Design
 
-### Barrel File Categories
+### Directory Structure Changes
 
-We will implement a set of barrel files for different GraphQL type categories:
+Move interfaces to a dedicated directory:
 
 ```
 apps/bfDb/
   graphql/
+    interfaces/               # New dedicated interfaces directory
+      GraphQLNode.ts         # Moved from graphql/GraphQLNode.ts
+      [other interfaces]     # Any other interface classes
     __generated__/
-      interfacesList.ts       # GraphQL interfaces (from v0.2)
-      rootObjectsList.ts      # Root query and mutation objects
-      typesList.ts            # Regular GraphQL object types
-      scalarsList.ts          # Custom scalar types
-      enumsList.ts            # GraphQL enum types
-      inputsList.ts           # GraphQL input types
-      unionsList.ts           # GraphQL union types
+      interfacesList.ts      # Generated registry of all interfaces
 ```
 
-### Barrel File Structure
+### Updated Barrel Configuration
 
-Each barrel file will follow a consistent structure:
-
-```typescript
-/**
- * GraphQL [Type Category] Barrel File
- *
- * @generated
- * This file is auto-generated. Do not edit directly.
- */
-
-// Export all [type category] from their respective modules
-export * from "path/to/module1.ts";
-export * from "path/to/module2.ts";
-// ...
-
-// Export a registry of all [type category]
-export const [typeCategoryRegistry] = {
-  Type1,
-  Type2,
-  // ...
-};
-```
-
-### Barrel Generator Utilities
+Add interfaces to the barrel configuration in genBarrel.ts:
 
 ```typescript
-// apps/bfDb/utils/barrelUtils.ts
+const barrels: BarrelConfig[] = [
+  // Existing barrel configurations...
 
-/**
- * Configuration for barrel file generation
- */
-export interface BarrelGenerationConfig {
-  /** The directory to search for files */
-  sourceDir: string;
-  /** The output file path for the barrel file */
-  outputPath: string;
-  /** File pattern to match (glob pattern) */
-  pattern: string;
-  /** Function to filter modules (optional) */
-  filter?: (filePath: string) => boolean;
-  /** Function to transform the module path (optional) */
-  transformPath?: (filePath: string) => string;
-  /** Header comment for the generated file */
-  header: string;
-  /** Registry variable name (optional) */
-  registryName?: string;
-}
-
-/**
- * Generates a barrel file based on the provided configuration
- */
-export async function generateBarrelFile(
-  config: BarrelGenerationConfig,
-): Promise<void> {
-  // Implementation details...
-}
-
-/**
- * Scans a directory for specific types using decorators or other criteria
- */
-export async function scanDirectoryForTypes<T>(
-  directory: string,
-  pattern: string,
-  typeCheck: (module: unknown) => module is T,
-): Promise<T[]> {
-  // Implementation details...
-}
-```
-
-### Integration with bff
-
-We'll integrate the barrel file generation with the BFF CLI tooling:
-
-```typescript
-// In genGqlTypes.bff.ts
-
-/**
- * Generate GraphQL type barrel files
- */
-export async function generateGraphQLBarrels(): Promise<void> {
-  // Generate interface barrel
-  await generateBarrelFile({
-    sourceDir: "apps/bfDb/graphql",
-    outputPath: "apps/bfDb/graphql/__generated__/interfacesList.ts",
-    pattern: "**/*.ts",
-    filter: (filePath) => {
-      // Filter for interface files (using decorators or naming conventions)
-      // ...
-    },
-    header: `/**
+  // Add GraphQL interfaces
+  {
+    dir: new URL("../graphql/interfaces/", import.meta.url),
+    out: new URL(
+      "../graphql/__generated__/interfacesList.ts",
+      import.meta.url,
+    ),
+    importPath: (f) => `apps/bfDb/graphql/interfaces/${f}`,
+    banner: `/**
  * GraphQL Interface Barrel File
  *
  * @generated
  * This file is auto-generated. Do not edit directly.
  */`,
-    registryName: "graphqlInterfaces",
-  });
-
-  // Generate other barrel files (rootObjects, types, scalars, etc.)
-  // ...
-}
+  },
+];
 ```
 
-### Updated loadGqlTypes.ts
+### Updated Interface Loading System
+
+Update graphqlInterfaces.ts to import from the new location:
 
 ```typescript
-// apps/bfDb/graphql/loadGqlTypes.ts
+// Update the import path in graphqlInterfaces.ts
+import * as interfaceClasses from "./__generated__/interfacesList.ts";
+```
 
-import * as interfaces from "./__generated__/interfacesList.ts";
-import * as rootObjects from "./__generated__/rootObjectsList.ts";
-import * as types from "./__generated__/typesList.ts";
-import * as scalars from "./__generated__/scalarsList.ts";
-import * as enums from "./__generated__/enumsList.ts";
-import * as inputs from "./__generated__/inputsList.ts";
-import * as unions from "./__generated__/unionsList.ts";
+The loadGqlTypes.ts file already imports and uses loadInterfaces properly, so
+that doesn't need to change:
+
+```typescript
+// Existing code in loadGqlTypes.ts - doesn't need modification
+import { loadInterfaces } from "apps/bfDb/graphql/graphqlInterfaces.ts";
 
 export function loadGqlTypes() {
-  const typeDefinitions = [];
+  const types = [];
 
-  // Load in specific order to respect dependencies
-  // 1. Scalars (no dependencies)
-  for (const scalarType of Object.values(scalars.scalarRegistry)) {
-    typeDefinitions.push(createScalarTypeDefinition(scalarType));
-  }
+  // Add all defined interfaces
+  types.push(...loadInterfaces());
 
-  // 2. Enums (no dependencies)
-  for (const enumType of Object.values(enums.enumRegistry)) {
-    typeDefinitions.push(createEnumTypeDefinition(enumType));
-  }
+  // Process other types...
 
-  // 3. Interfaces (may depend on scalars and enums)
-  for (const interfaceType of Object.values(interfaces.graphqlInterfaces)) {
-    typeDefinitions.push(createInterfaceTypeDefinition(interfaceType));
-  }
-
-  // 4. Input types (may depend on scalars, enums)
-  for (const inputType of Object.values(inputs.inputRegistry)) {
-    typeDefinitions.push(createInputTypeDefinition(inputType));
-  }
-
-  // 5. Union types (may depend on object types)
-  for (const unionType of Object.values(unions.unionRegistry)) {
-    typeDefinitions.push(createUnionTypeDefinition(unionType));
-  }
-
-  // 6. Object types (may depend on interfaces, scalars, enums)
-  for (const objectType of Object.values(types.typeRegistry)) {
-    typeDefinitions.push(createObjectTypeDefinition(objectType));
-  }
-
-  // 7. Root objects (may depend on all other types)
-  for (const rootObject of Object.values(rootObjects.rootObjectRegistry)) {
-    typeDefinitions.push(createRootObjectTypeDefinition(rootObject));
-  }
-
-  return typeDefinitions;
+  return types;
 }
 ```
 
-### Validation During Generation
+Update the decorator handling to ensure it works with the interface directory
+structure:
 
 ```typescript
-/**
- * Validates a GraphQL type before including it in the barrel file
- */
-function validateGraphQLType(type: unknown, typeName: string): void {
-  // Check for required properties
-  if (!type) {
-    throw new Error(`Type ${typeName} is undefined or null`);
-  }
-
-  // Type-specific validation
-  if (isGraphQLInterface(type)) {
-    validateGraphQLInterface(type, typeName);
-  } else if (isGraphQLObjectType(type)) {
-    validateGraphQLObjectType(type, typeName);
-  }
-  // Add other type validations...
+// In decorators.ts - no changes needed
+export function isGraphQLInterface(target: unknown): boolean {
+  return !!(target as any)[GRAPHQL_INTERFACE_PROPERTY];
 }
-
-/**
- * Validates a GraphQL interface
- */
-function validateGraphQLInterface(
-  interfaceType: unknown,
-  typeName: string,
-): void {
-  // Check for the decorator
-  if (!getGraphQLInterfaceMetadata(interfaceType)) {
-    throw new Error(
-      `Interface ${typeName} is missing the @GraphQLInterface decorator`,
-    );
-  }
-
-  // Check for required fields
-  // ...
-}
-```
-
-### Type Registry Helpers
-
-```typescript
-/**
- * Gets a GraphQL interface by name
- */
-export function getGraphQLInterface(
-  name: string,
-): GraphQLInterface | undefined {
-  return Object.values(interfaces.graphqlInterfaces).find(
-    (iface) => getGraphQLInterfaceMetadata(iface)?.name === name,
-  );
-}
-
-/**
- * Gets a GraphQL object type by name
- */
-export function getGraphQLObjectType(
-  name: string,
-): GraphQLObjectType | undefined {
-  return Object.values(types.typeRegistry).find(
-    (type) => type.name === name,
-  );
-}
-
-// Add other helper functions...
 ```
 
 ## Success Metrics
 
-- Barrel files are automatically generated for all GraphQL type categories
-- No manual type registration is required when adding new types
-- The registration system maintains correct dependencies between types
-- Schema generation includes all registered types in the correct order
-- Validation catches common issues at build time
-- Developer experience is improved through helper utilities
-- Tests pass for all aspects of the barrel system
-- Documentation is clear and complete
+- All GraphQL interfaces are properly moved to the interfaces directory
+- All GraphQL interfaces are included in the barrel file
+- Interface loading in loadGqlTypes.ts and graphqlInterfaces.ts works correctly
+  with the new directory structure
+- All imports of GraphQLNode and other interfaces are updated correctly,
+  especially in:
+  - The BfNode class implementation (which extends GraphQLNode)
+  - The GraphQLObjectBase imports in interface files
+  - Any test files that use GraphQLNode directly
+- GraphQL schema includes all interfaces properly
+- Interface-implementing objects are correctly connected to their interfaces
+- The @GraphQLInterface decorator continues to work correctly with the new
+  structure
+- All tests pass with the new directory structure
 
 ## Next Steps (Future Work for v0.4)
 
+- Implement barrel files for other GraphQL type categories
+- Add validation during barrel generation
+- Create a more comprehensive barrel utility
 - Complete the migration of remaining nodes to the new builder pattern
 - Add support for additional edge relationship patterns
 - Add Relay-style connections with pagination support
-- Implement validation against bfNodeSpec.relations
-- Add more sophisticated type generation tools
-- Create visual diagram generators for schema visualization
+- Consider further organizing types by function (queries, mutations, etc.)

--- a/apps/bfDb/docs/status.md
+++ b/apps/bfDb/docs/status.md
@@ -6,9 +6,8 @@
 
 The GraphQL Builder project has completed two major milestones: v0.1 (core
 builder implementation) and v0.2 (GraphQLNode class and Node interface
-implementation). We're now focusing on v0.3 to improve the barrel file system
-for automated interface and type registration, which will streamline development
-and reduce manual registration work.
+implementation). We're now focusing on v0.3 to ensure GraphQL interfaces are
+properly registered and loaded in the schema.
 
 ## Completed Work
 
@@ -48,26 +47,23 @@ and reduce manual registration work.
   AnyGraphqlObjectBaseCtor
 - ✅ Interface Testing: Added tests for GraphQLNode and interface implementation
 
-## Current Work (v0.3 - Barrel Files)
+## Current Work (v0.3 - Interface Loading)
 
-We're now focusing on improving the barrel file system for automated type
-registration:
+We're now focusing on improving the GraphQL interface registration:
 
-1. Enhance the barrel file generation system
-2. Improve the automatic interface and type detection
-3. Create consistent patterns for registration across different entity types
-4. Add validation capabilities in the barrel generation process
+1. Ensure genBarrel.ts includes GraphQL interfaces
+2. Verify the interfacesList.ts barrel file contains all interfaces
+3. Ensure loadGqlTypes.ts correctly uses the interfaces from the barrel file
 
 ## Deferred to v0.4
 
-1. Complete the migration of remaining nodes to the new builder pattern
-2. Add support for additional edge relationship patterns (target→source,
-   many-to-many)
-3. Complete additional tests for the GraphQL builder
-4. Remove legacy builders completely
-5. Add Relay-style connections with pagination support
-6. Implement validation against bfNodeSpec.relations
-7. ⏱️ Validation: Validation against bfNodeSpec.relations pending
+1. Implement barrel files for other GraphQL type categories
+2. Add validation during barrel generation
+3. Create a more comprehensive barrel utility
+4. Complete the migration of remaining nodes to the new builder pattern
+5. Add support for additional edge relationship patterns
+6. Add Relay-style connections with pagination support
+7. Implement validation against bfNodeSpec.relations
 
 ## Blocking Issues
 
@@ -83,3 +79,4 @@ plans:
 
 - [v0.1 Implementation Plan](/apps/bfDb/docs/0.1/implementation-plan.md)
 - [v0.2 Implementation Plan](/apps/bfDb/docs/0.2/implementation-plan.md)
+- [v0.3 Implementation Plan](/apps/bfDb/docs/0.3/implementation-plan.md)


### PR DESCRIPTION

Streamline the implementation plan for v0.3 to focus solely on ensuring
GraphQL interfaces are properly registered and loaded.

Changes:
- Simplify implementation steps to focus on minimal changes
- Remove complex registry and validation features (deferred to v0.4)
- Update status.md to reflect simplified approach
- Keep technical design minimal and focused
