### PR TITLE
Add AI safety infrastructure to BFF CLI

### DIFF
--- a/infra/bff/__tests__/ai.test.ts
+++ b/infra/bff/__tests__/ai.test.ts
@@ -1,0 +1,57 @@
+// infra/bff/__tests__/ai.test.ts
+
+import { assertEquals } from "@std/assert";
+import { register } from "../bff.ts";
+import { aiCommand } from "../friends/ai.bff.ts";
+
+Deno.test("ai command: should list AI-safe commands", async () => {
+  // Register a test AI-safe command
+  register("test-safe", "Test safe command", () => 0, [], true);
+  // Register a test non-AI-safe command
+  register("test-unsafe", "Test unsafe command", () => 0, [], false);
+
+  // Test listing AI-safe commands
+  const result = await aiCommand([]);
+  assertEquals(result, 0);
+});
+
+Deno.test("ai command: should run AI-safe commands", async () => {
+  // Register a test AI-safe command
+  let wasCalled = false;
+  register(
+    "test-ai-safe",
+    "Test AI-safe command",
+    () => {
+      wasCalled = true;
+      return 0;
+    },
+    [],
+    true,
+  );
+
+  // Test running an AI-safe command
+  const result = await aiCommand(["test-ai-safe"]);
+  assertEquals(result, 0);
+  assertEquals(wasCalled, true);
+});
+
+Deno.test("ai command: should reject non-AI-safe commands", async () => {
+  // Register a test non-AI-safe command
+  register(
+    "test-not-safe",
+    "Test non-AI-safe command",
+    () => 0,
+    [],
+    false,
+  );
+
+  // Test trying to run a non-AI-safe command
+  const result = await aiCommand(["test-not-safe"]);
+  assertEquals(result, 1); // Should fail
+});
+
+Deno.test("ai command: should handle unknown commands", async () => {
+  // Test trying to run a command that doesn't exist
+  const result = await aiCommand(["nonexistent-command"]);
+  assertEquals(result, 1); // Should fail
+});

--- a/infra/bff/bff.ts
+++ b/infra/bff/bff.ts
@@ -7,6 +7,7 @@ type Friend = {
   description: string;
   options: Array<Record<string, string>>;
   command: BffCommand;
+  aiSafe?: boolean;
 };
 
 // Scan the "friends" directory for files that end with ".bff.ts" and import them.
@@ -24,6 +25,7 @@ function wordWrap(str: string, maxWidth: number) {
 friendMap.set("help", {
   description: "Prints this help message.",
   options: [],
+  aiSafe: true,
   command: async (cmdOptions) => {
     const startTime = performance.now();
     try {
@@ -45,11 +47,14 @@ friendMap.set("help", {
 
       Usage:
         bff <friend> [options]
+        bff ai <friend> [options]  # Run only AI-safe commands
 
       Friends:
         ${
-        commands.map(([name, { description }]) =>
-          (`${name.padEnd(longestNameLength + 5)} ${description}`).padEnd(
+        commands.map(([name, { description, aiSafe }]) =>
+          (`${name.padEnd(longestNameLength + 5)} ${description}${
+            aiSafe ? " [AI-safe]" : ""
+          }`).padEnd(
             80,
             " ",
           )
@@ -75,6 +80,7 @@ export function register(
   description: string,
   command: BffCommand,
   options: Array<Record<string, string>> = [],
+  aiSafe = false,
 ) {
   // Wrap the command with analytics tracking
   const wrappedCommand: BffCommand = async (cmdOptions) => {
@@ -95,5 +101,10 @@ export function register(
     }
   };
 
-  friendMap.set(name, { description, options, command: wrappedCommand });
+  friendMap.set(name, {
+    description,
+    options,
+    command: wrappedCommand,
+    aiSafe,
+  });
 }

--- a/infra/bff/friends/ai.bff.ts
+++ b/infra/bff/friends/ai.bff.ts
@@ -1,0 +1,75 @@
+#! /usr/bin/env -S bff
+
+import { friendMap, register } from "infra/bff/bff.ts";
+import { getLogger } from "packages/logger/logger.ts";
+
+const logger = getLogger(import.meta);
+
+export async function aiCommand(args: string[]): Promise<number> {
+  if (args.length === 0) {
+    // Show AI-safe commands
+    logger.info("AI-safe BFF commands:");
+    logger.info("");
+
+    const commands = Array.from(friendMap.entries())
+      .filter(([_, friend]) => friend.aiSafe)
+      .sort((a, b) => a[0].localeCompare(b[0]));
+
+    if (commands.length === 0) {
+      logger.info("No AI-safe commands available.");
+      return 0;
+    }
+
+    // Compute the maximum length of command names
+    const longestNameLength = commands.reduce(
+      (max, [name]) => Math.max(max, name.length),
+      0,
+    );
+
+    for (const [name, { description }] of commands) {
+      logger.info(`  ${name.padEnd(longestNameLength + 2)} ${description}`);
+    }
+
+    logger.info("");
+    logger.info("Usage: bff ai <command> [options]");
+    return 0;
+  }
+
+  const commandName = args[0];
+  const commandArgs = args.slice(1);
+
+  const friend = friendMap.get(commandName);
+
+  if (!friend) {
+    logger.error(`Unknown command: ${commandName}`);
+    logger.info("Use 'bff ai' to see available AI-safe commands");
+    return 1;
+  }
+
+  if (!friend.aiSafe) {
+    logger.error(`Command '${commandName}' is not marked as AI-safe`);
+    logger.info("Use 'bff ai' to see available AI-safe commands");
+    return 1;
+  }
+
+  logger.info(`Running AI-safe command: ${commandName}`);
+  return await friend.command(commandArgs);
+}
+
+register(
+  "ai",
+  "Run only AI-safe BFF commands or list available AI-safe commands",
+  aiCommand,
+  [
+    {
+      option: "[command]",
+      description:
+        "AI-safe command to run. If not provided, lists all AI-safe commands.",
+    },
+    {
+      option: "[...args]",
+      description: "Arguments to pass to the AI-safe command.",
+    },
+  ],
+  true, // This command itself is AI-safe
+);


### PR DESCRIPTION

Add bff ai command that provides AI-safe access to development operations.
This ensures AI agents can only run approved commands that don't perform
potentially destructive operations.

Changes:
- Add aiSafe parameter to BFF command registration system in infra/bff/bff.ts
- Create infra/bff/friends/ai.bff.ts with AI-safe command filtering
- Add comprehensive test suite for AI command safety in infra/bff/__tests__/ai.test.ts
- Update help system to show [AI-safe] indicators for safe commands

Test plan:
1. Run bff ai to see list of AI-safe commands
2. Try running bff ai test to verify AI-safe commands work
3. Try running bff ai commit to verify non-AI-safe commands are blocked
4. Run tests with bff test infra/bff/__tests__/ai.test.ts

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/856).
* #862
* #861
* #860
* #859
* #858
* #857
* __->__ #856