### PR TITLE
feat(bolt-foundry): implement assistant API scaffold with TDD approach

### DIFF
--- a/packages/bolt-foundry/builders/__tests__/assistantApi.test.ts
+++ b/packages/bolt-foundry/builders/__tests__/assistantApi.test.ts
@@ -1,0 +1,42 @@
+#! /usr/bin/env -S bff test
+
+import { assert, assertEquals } from "@std/assert";
+import { boltFoundryClient } from "../builders.ts";
+
+Deno.test("boltFoundryClient.createAssistant - basic creation", () => {
+  const assistant = boltFoundryClient.createAssistant(
+    "test-assistant",
+    (b) => b,
+  );
+  assertEquals(assistant.name, "test-assistant");
+});
+
+Deno.test("AssistantSpec.render - returns OpenAI format", () => {
+  const assistant = boltFoundryClient.createAssistant(
+    "test-assistant",
+    (b) => b,
+  );
+  const result = assistant.render();
+
+  // Should have required OpenAI fields
+  assert(result.model);
+  assert(Array.isArray(result.messages));
+  assertEquals(result.messages[0].role, "system");
+});
+
+Deno.test("AssistantSpec.render - merges user options", () => {
+  const assistant = boltFoundryClient.createAssistant(
+    "test-assistant",
+    (b) => b,
+  );
+
+  const result = assistant.render({
+    model: "gpt-4",
+    temperature: 0.7,
+    messages: [{ role: "user", content: "Hello" }],
+  });
+
+  assertEquals(result.model, "gpt-4");
+  assertEquals(result.temperature, 0.7);
+  assert(result.messages.length >= 2); // System + user message
+});

--- a/packages/bolt-foundry/builders/builders.ts
+++ b/packages/bolt-foundry/builders/builders.ts
@@ -45,3 +45,110 @@ export class SpecBuilder {
     return this._specs;
   }
 }
+
+/** Assistant specification that can be rendered to OpenAI format */
+export class SpecForAssistant {
+  readonly name: string;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+  /** Render the assistant specification to OpenAI chat completion format */
+  render(options: RenderOptions = {}): ChatCompletionCreateParams {
+    const { messages = [], model = "gpt-4", ...otherOptions } = options;
+
+    // Build system message
+    const systemMessage = {
+      role: "system" as const,
+      content: "", // TODO: Generate from persona and constraints
+    };
+
+    // Combine system message with any user-provided messages
+    const allMessages = [systemMessage, ...messages];
+
+    return {
+      model,
+      messages: allMessages,
+      ...otherOptions, // This will include any other OpenAI params
+    };
+  }
+}
+
+/** Builder for creating assistant specifications */
+export class SpecBuilderForAssistant {
+  private _name: string;
+
+  constructor(name: string) {
+    this._name = name;
+  }
+
+  /** Add a persona section */
+  persona(
+    _builder: (p: PersonaBuilder) => PersonaBuilder,
+  ): SpecBuilderForAssistant {
+    // TODO: Implement
+    return this;
+  }
+
+  /** Add a constraints section */
+  constraints(
+    _builder: (c: ConstraintsBuilder) => ConstraintsBuilder,
+  ): SpecBuilderForAssistant {
+    // TODO: Implement
+    return this;
+  }
+
+  /** Build the final assistant specification */
+  build(): SpecForAssistant {
+    return new SpecForAssistant(this._name);
+  }
+}
+
+/** Builder for persona specifications */
+export class PersonaBuilder {
+  /** Set the persona description */
+  description(_value: string): PersonaBuilder {
+    // TODO: Implement
+    return this;
+  }
+
+  /** Add a trait */
+  trait(_value: string): PersonaBuilder {
+    // TODO: Implement
+    return this;
+  }
+
+  /** Get the built specs */
+  getSpecs(): Array<Spec> {
+    // TODO: Implement
+    return [];
+  }
+}
+
+/** Builder for constraints specifications */
+export class ConstraintsBuilder {
+  /** Add a constraint */
+  constraint(_value: string): ConstraintsBuilder {
+    // TODO: Implement
+    return this;
+  }
+
+  /** Get the built specs */
+  getSpecs(): Array<Spec> {
+    // TODO: Implement
+    return [];
+  }
+}
+
+/** Main client for creating assistants */
+export const boltFoundryClient = {
+  /** Create a new assistant with the given name and configuration */
+  createAssistant(
+    name: string,
+    builder: (b: SpecBuilderForAssistant) => SpecBuilderForAssistant,
+  ): SpecForAssistant {
+    const assistantBuilder = builder(new SpecBuilderForAssistant(name));
+    return assistantBuilder.build();
+  },
+};


### PR DESCRIPTION

- Add boltFoundryClient.createAssistant() public API
- Create SpecForAssistant class (renamed from AssistantSpec)
- Create SpecBuilderForAssistant immutable builder
- Add PersonaBuilder and ConstraintsBuilder scaffolds
- Implement render() method with OpenAI format output
- Add proper option merging for user-provided parameters
- Create minimal test suite (3 tests, all passing)
- Fix all lint issues for clean codebase

Phase v0.0.2.2 ~40% complete - scaffold working, need to implement:
- Persona/constraints data storage
- XML persona card generation
- True builder immutability
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/886).
* #891
* #890
* #889
* #888
* __->__ #886