### PR TITLE
Create v0.1 documentation implementation plan

### DIFF
--- a/apps/boltFoundry/docs/v0.1.md
+++ b/apps/boltFoundry/docs/v0.1.md
@@ -1,0 +1,103 @@
+# v0.1 Documentation Implementation Plan
+
+## Overview
+
+Version 0.1 delivers a minimal documentation system that enables developers to
+self-serve through installation and first usage of Bolt Foundry. The focus is on
+creating the technical infrastructure to serve MDX documentation through
+Isograph, with a quickstart guide that demonstrates the value proposition
+through a concrete JSON output reliability example.
+
+## Goals
+
+| Goal             | Description                       | Success Criteria                                      |
+| ---------------- | --------------------------------- | ----------------------------------------------------- |
+| MDX via Isograph | Serve docs at `/docs/*` routes    | MDX files render correctly at boltfoundry.com/docs/x  |
+| Clear value demo | Show JSON reliability improvement | Quickstart includes before/after example with context |
+
+## Anti-Goals
+
+| Anti-Goal            | Reason                                |
+| -------------------- | ------------------------------------- |
+| API reference        | Focus on getting started first        |
+| Advanced patterns    | Keep it simple for v0.1               |
+| Multiple use cases   | Focus only on JSON output reliability |
+| Interactive features | No CodeSandbox, just static examples  |
+
+## Technical Approach
+
+Extend the existing MDX infrastructure to serve documentation through Isograph.
+Create a single entrypoint (`EntrypointDocs.ts`) that dynamically loads MDX
+files based on the route path. This maintains consistency with the blog system
+while allowing docs to live at predictable URLs that mirror the app structure.
+
+## Components
+
+| Status | Component                 | Purpose                                 |
+| ------ | ------------------------- | --------------------------------------- |
+| [ ]    | `EntrypointDocs.ts`       | Isograph entrypoint for all docs routes |
+| [ ]    | `content/docs/` directory | Store MDX documentation files           |
+| [ ]    | `Docs.tsx` resolver       | Render MDX content with basic styling   |
+| [ ]    | Build pipeline updates    | Process docs during content build       |
+| [ ]    | Route registration        | Add `/docs/*` to Isograph routes        |
+
+## Technical Decisions
+
+| Decision                   | Reasoning                    | Alternatives Considered        |
+| -------------------------- | ---------------------------- | ------------------------------ |
+| Single Isograph entrypoint | Simpler, dynamic routing     | Individual entrypoints per doc |
+| Reuse MDX infrastructure   | Already built and tested     | Custom markdown processor      |
+| `/content/docs/` location  | Consistent with blog pattern | `/docs/` at root               |
+| Minimal MDX features       | Ship faster, add later       | Full-featured from start       |
+
+## Next Steps
+
+| Question                | How to Explore                            |
+| ----------------------- | ----------------------------------------- |
+| MDX component styling   | Test with existing blog styles first      |
+| Navigation between docs | Start with manual links, auto-gen later   |
+| Search functionality    | Not needed for v0.1, revisit if requested |
+
+## Initial Content Structure
+
+```
+content/docs/
+├── quickstart.mdx       # Installation + JSON example
+└── getting-started.mdx  # Theory + first structured prompt
+```
+
+## Implementation Checklist (TDD Approach)
+
+### 0.1.0: Write Tests First
+
+- [ ] Update `infra/appBuild/__tests__/contentBuild.test.ts` to expect `/content/docs/` processing
+- [ ] Create simple E2E test expecting `/docs` route to load successfully
+
+### 0.1.1: Infrastructure (Make Tests Pass)
+
+- [ ] Create `apps/boltFoundry/entrypoints/EntrypointDocs.ts`
+- [ ] Add Isograph resolver in `apps/boltFoundry/components/Docs.tsx`
+- [ ] Update `infra/appBuild/contentBuild.ts` to process `/content/docs/`
+- [ ] Register `/docs/*` routes in Isograph configuration
+- [ ] Success: Tests pass and render content at `/docs/*`
+
+### 0.1.2: Content
+
+- [ ] Create `content/docs/quickstart.mdx` with:
+  - Installation instructions
+  - JSON output reliability example
+  - Before/after comparison
+  - Context block usage
+- [ ] Create `content/docs/getting-started.mdx` with theoretical foundation
+
+### 0.1.3: Verify & Polish
+
+- [ ] Run all tests to ensure implementation is complete
+- [ ] Manual verification of content rendering
+- [ ] Ensure routes work in production build
+
+## Success Metrics
+
+- Developers can find and access docs at boltfoundry.com/docs
+- Quickstart demonstrates clear value through JSON example
+- Documentation infrastructure ready for expansion


### PR DESCRIPTION

- Define technical infrastructure for serving MDX docs via Isograph
- Set goals for rendering docs at /docs/* routes with clear value demo
- Plan 3-phase implementation: infrastructure, content, testing
- Use existing MDX infrastructure with single dynamic entrypoint
- Target rendering company-vision.md as first success milestone
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/909).
* #918
* #915
* #910
* __->__ #909