### PR TITLE
Add TDD tests for v0.1 documentation system

### DIFF
--- a/apps/boltFoundry/__tests__/e2e/docs.test.e2e.ts
+++ b/apps/boltFoundry/__tests__/e2e/docs.test.e2e.ts
@@ -1,0 +1,106 @@
+#!/usr/bin/env -S bff test
+
+import { assert, assertEquals } from "@std/assert";
+import {
+  navigateTo,
+  setupE2ETest,
+  teardownE2ETest,
+} from "infra/testing/e2e/setup.ts";
+import { getLogger } from "packages/logger/logger.ts";
+
+const logger = getLogger(import.meta);
+
+Deno.test("renders documentation at /docs route", async () => {
+  const context = await setupE2ETest({ headless: true });
+
+  try {
+    // Navigate to the docs page
+    await navigateTo(context, "/docs");
+
+    // Take screenshot after initial page load
+    await context.takeScreenshot("docs-page-initial");
+
+    // Wait for content to ensure page loaded
+    const title = await context.page.title();
+    logger.info(`Page title: ${title}`);
+
+    // Check if the page contains expected content
+    const bodyText = await context.page.evaluate(() =>
+      document.body.textContent
+    );
+
+    // Basic assertion to verify the page loaded successfully
+    assertEquals(
+      typeof bodyText,
+      "string",
+      "Page body should contain text",
+    );
+
+    // Additional assertion that some content exists
+    assertEquals(
+      bodyText && bodyText.length > 0,
+      true,
+      "Page body should not be empty",
+    );
+
+    // Verify we're on the docs page (not a 404 or error)
+    const url = context.page.url();
+    assert(
+      url.includes("/docs"),
+      "Should be on the docs route"
+    );
+    
+    // Verify docs content is present (this should fail with 404)
+    assert(
+      bodyText?.includes("Documentation") || bodyText?.includes("Docs"),
+      "Page should contain documentation content"
+    );
+
+    // Take screenshot after test has completed successfully
+    await context.takeScreenshot("docs-page-completed");
+  } finally {
+    await teardownE2ETest(context);
+  }
+});
+
+Deno.test("renders specific documentation page at /docs/quickstart", async () => {
+  const context = await setupE2ETest({ headless: true });
+
+  try {
+    // Navigate to a specific doc page
+    await navigateTo(context, "/docs/quickstart");
+
+    // Take screenshot after initial page load
+    await context.takeScreenshot("docs-quickstart-initial");
+
+    // Check if the page loaded without errors
+    const bodyText = await context.page.evaluate(() =>
+      document.body.textContent
+    );
+
+    // Verify content loaded
+    assertEquals(
+      typeof bodyText,
+      "string",
+      "Page body should contain text",
+    );
+
+    // Verify we're on the correct subpage
+    const url = context.page.url();
+    assert(
+      url.includes("/docs/quickstart"),
+      "Should be on the docs/quickstart route"
+    );
+    
+    // Verify quickstart content is present (this should fail with 404)
+    assert(
+      bodyText?.toLowerCase().includes("quickstart"),
+      "Page should contain quickstart content"
+    );
+
+    // Take screenshot after test has completed successfully
+    await context.takeScreenshot("docs-quickstart-completed");
+  } finally {
+    await teardownE2ETest(context);
+  }
+});

--- a/apps/boltFoundry/docs/v0.1.md
+++ b/apps/boltFoundry/docs/v0.1.md
@@ -1,0 +1,103 @@
+# v0.1 Documentation Implementation Plan
+
+## Overview
+
+Version 0.1 delivers a minimal documentation system that enables developers to
+self-serve through installation and first usage of Bolt Foundry. The focus is on
+creating the technical infrastructure to serve MDX documentation through
+Isograph, with a quickstart guide that demonstrates the value proposition
+through a concrete JSON output reliability example.
+
+## Goals
+
+| Goal             | Description                       | Success Criteria                                      |
+| ---------------- | --------------------------------- | ----------------------------------------------------- |
+| MDX via Isograph | Serve docs at `/docs/*` routes    | MDX files render correctly at boltfoundry.com/docs/x  |
+| Clear value demo | Show JSON reliability improvement | Quickstart includes before/after example with context |
+
+## Anti-Goals
+
+| Anti-Goal            | Reason                                |
+| -------------------- | ------------------------------------- |
+| API reference        | Focus on getting started first        |
+| Advanced patterns    | Keep it simple for v0.1               |
+| Multiple use cases   | Focus only on JSON output reliability |
+| Interactive features | No CodeSandbox, just static examples  |
+
+## Technical Approach
+
+Extend the existing MDX infrastructure to serve documentation through Isograph.
+Create a single entrypoint (`EntrypointDocs.ts`) that dynamically loads MDX
+files based on the route path. This maintains consistency with the blog system
+while allowing docs to live at predictable URLs that mirror the app structure.
+
+## Components
+
+| Status | Component                 | Purpose                                 |
+| ------ | ------------------------- | --------------------------------------- |
+| [ ]    | `EntrypointDocs.ts`       | Isograph entrypoint for all docs routes |
+| [ ]    | `content/docs/` directory | Store MDX documentation files           |
+| [ ]    | `Docs.tsx` resolver       | Render MDX content with basic styling   |
+| [ ]    | Build pipeline updates    | Process docs during content build       |
+| [ ]    | Route registration        | Add `/docs/*` to Isograph routes        |
+
+## Technical Decisions
+
+| Decision                   | Reasoning                    | Alternatives Considered        |
+| -------------------------- | ---------------------------- | ------------------------------ |
+| Single Isograph entrypoint | Simpler, dynamic routing     | Individual entrypoints per doc |
+| Reuse MDX infrastructure   | Already built and tested     | Custom markdown processor      |
+| `/content/docs/` location  | Consistent with blog pattern | `/docs/` at root               |
+| Minimal MDX features       | Ship faster, add later       | Full-featured from start       |
+
+## Next Steps
+
+| Question                | How to Explore                            |
+| ----------------------- | ----------------------------------------- |
+| MDX component styling   | Test with existing blog styles first      |
+| Navigation between docs | Start with manual links, auto-gen later   |
+| Search functionality    | Not needed for v0.1, revisit if requested |
+
+## Initial Content Structure
+
+```
+content/docs/
+├── quickstart.mdx       # Installation + JSON example
+└── getting-started.mdx  # Theory + first structured prompt
+```
+
+## Implementation Checklist (TDD Approach)
+
+### 0.1.0: Write Tests First
+
+- [ ] Update `infra/appBuild/__tests__/contentBuild.test.ts` to expect `/content/docs/` processing
+- [ ] Create simple E2E test expecting `/docs` route to load successfully
+
+### 0.1.1: Infrastructure (Make Tests Pass)
+
+- [ ] Create `apps/boltFoundry/entrypoints/EntrypointDocs.ts`
+- [ ] Add Isograph resolver in `apps/boltFoundry/components/Docs.tsx`
+- [ ] Update `infra/appBuild/contentBuild.ts` to process `/content/docs/`
+- [ ] Register `/docs/*` routes in Isograph configuration
+- [ ] Success: Tests pass and render content at `/docs/*`
+
+### 0.1.2: Content
+
+- [ ] Create `content/docs/quickstart.mdx` with:
+  - Installation instructions
+  - JSON output reliability example
+  - Before/after comparison
+  - Context block usage
+- [ ] Create `content/docs/getting-started.mdx` with theoretical foundation
+
+### 0.1.3: Verify & Polish
+
+- [ ] Run all tests to ensure implementation is complete
+- [ ] Manual verification of content rendering
+- [ ] Ensure routes work in production build
+
+## Success Metrics
+
+- Developers can find and access docs at boltfoundry.com/docs
+- Quickstart demonstrates clear value through JSON example
+- Documentation infrastructure ready for expansion

--- a/infra/appBuild/__tests__/contentBuild.test.ts
+++ b/infra/appBuild/__tests__/contentBuild.test.ts
@@ -1,0 +1,201 @@
+#!/usr/bin/env -S bff test
+
+import { assert, assertEquals } from "@std/assert";
+import { exists } from "@std/fs";
+import { join } from "@std/path";
+
+Deno.test("processes docs directory and creates build output", async () => {
+  // Arrange: Create a temporary docs structure for testing
+  const tempDir = await Deno.makeTempDir();
+  try {
+    const docsDir = join(tempDir, "docs");
+    const buildDocsDir = join(tempDir, "build", "docs");
+    
+    // Create test files
+    await Deno.mkdir(docsDir, { recursive: true });
+    
+    // Create test MDX file
+    const testMdxContent = `# Test Documentation
+
+This is a test MDX file for the documentation system.
+
+## Example Section
+
+Some example content here.`;
+    
+    await Deno.writeTextFile(
+      join(docsDir, "test-doc.mdx"),
+      testMdxContent
+    );
+    
+    // Create test MD file
+    const testMdContent = `# Regular Markdown Documentation
+
+This is a standard markdown file.
+
+- Should be processed like MDX
+- But without component support`;
+    
+    await Deno.writeTextFile(
+      join(docsDir, "regular-doc.md"),
+      testMdContent
+    );
+
+    // Act: Run the content build process
+    // Note: This will fail initially as we haven't implemented the functionality
+    const contentBuildPath = join(Deno.cwd(), "infra", "appBuild", "contentBuild.ts");
+    const command = new Deno.Command("deno", {
+      args: ["run", "-A", contentBuildPath],
+      env: {
+        DOCS_DIR: docsDir,
+        BUILD_DIR: join(tempDir, "build"),
+      },
+    });
+    
+    const { success } = await command.output();
+    
+    // Assert: Verify the docs were processed
+    assert(success, "Content build should complete successfully");
+    
+    // Check that the build directory was created
+    assert(
+      await exists(buildDocsDir),
+      "Build docs directory should be created"
+    );
+    
+    // Check that the MDX file was processed
+    const processedMdxPath = join(buildDocsDir, "test-doc.mdx");
+    assert(
+      await exists(processedMdxPath),
+      "MDX file should be processed and copied to build directory"
+    );
+    
+    // Check that the MD file was processed
+    const processedMdPath = join(buildDocsDir, "regular-doc.md");
+    assert(
+      await exists(processedMdPath),
+      "MD file should be processed and copied to build directory"
+    );
+  } finally {
+    // Clean up
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("compiles MDX files with components", async () => {
+  // This test verifies that MDX files are actually compiled, not just copied
+  const tempDir = await Deno.makeTempDir();
+  try {
+    const docsDir = join(tempDir, "docs");
+    const buildDocsDir = join(tempDir, "build", "docs");
+    
+    // Create test MDX file with JSX
+    await Deno.mkdir(docsDir, { recursive: true });
+    const testMdxContent = `# Documentation with Component
+
+<BfDsCallout type="info">
+  This is an MDX component in the docs
+</BfDsCallout>
+
+Regular markdown content here.`;
+    
+    await Deno.writeTextFile(
+      join(docsDir, "component-doc.mdx"),
+      testMdxContent
+    );
+
+    // Act: Run the content build process
+    const contentBuildPath = join(Deno.cwd(), "infra", "appBuild", "contentBuild.ts");
+    const command = new Deno.Command("deno", {
+      args: ["run", "-A", contentBuildPath],
+      env: {
+        DOCS_DIR: docsDir,
+        BUILD_DIR: join(tempDir, "build"),
+      },
+    });
+    
+    const { success } = await command.output();
+    
+    // Assert
+    assert(success, "Content build with MDX components should complete successfully");
+    
+    const processedFilePath = join(buildDocsDir, "component-doc.mdx");
+    assert(
+      await exists(processedFilePath),
+      "MDX file with components should be processed"
+    );
+    
+    // Read the processed content to verify it was compiled
+    const processedContent = await Deno.readTextFile(processedFilePath);
+    
+    // The compiled MDX should have been transformed
+    // (exact format depends on MDX compiler output)
+    assert(
+      processedContent.length > 0,
+      "Processed MDX file should have content"
+    );
+  } finally {
+    // Clean up
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("compiles .md files through MDX processor", async () => {
+  // This test verifies that regular .md files are also processed through MDX
+  const tempDir = await Deno.makeTempDir();
+  try {
+    const docsDir = join(tempDir, "docs");
+    const buildDocsDir = join(tempDir, "build", "docs");
+    
+    // Create test MD file with code blocks
+    await Deno.mkdir(docsDir, { recursive: true });
+    const testMdContent = `# Markdown with Code
+
+Here's a code example:
+
+\`\`\`typescript
+const greeting = "Hello, docs!";
+console.log(greeting);
+\`\`\`
+
+This should be compiled through MDX even though it's a .md file.`;
+    
+    await Deno.writeTextFile(
+      join(docsDir, "code-example.md"),
+      testMdContent
+    );
+
+    // Act: Run the content build process
+    const contentBuildPath = join(Deno.cwd(), "infra", "appBuild", "contentBuild.ts");
+    const command = new Deno.Command("deno", {
+      args: ["run", "-A", contentBuildPath],
+      env: {
+        DOCS_DIR: docsDir,
+        BUILD_DIR: join(tempDir, "build"),
+      },
+    });
+    
+    const { success } = await command.output();
+    
+    // Assert
+    assert(success, "Content build with .md files should complete successfully");
+    
+    const processedFilePath = join(buildDocsDir, "code-example.md");
+    assert(
+      await exists(processedFilePath),
+      "MD file should be processed"
+    );
+    
+    // Read the processed content to verify it was compiled
+    const processedContent = await Deno.readTextFile(processedFilePath);
+    
+    // The compiled content should exist and be non-empty
+    assert(
+      processedContent.length > 0,
+      "Processed MD file should have content"
+    );
+  } finally {
+    // Clean up
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});


### PR DESCRIPTION

- Add build pipeline tests for processing /docs/ directory
- Add e2e tests for /docs and /docs/quickstart routes
- Tests process both .md and .mdx files through MDX compiler
- All tests currently failing as expected (TDD red phase)
- Tests will guide implementation of docs infrastructure
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/910).
* #918
* #915
* __->__ #910
* #909