### PR TITLE
Fix non-deterministic ordering in docsImportMap generation

### DIFF
--- a/apps/boltFoundry/__generated__/docsImportMap.ts
+++ b/apps/boltFoundry/__generated__/docsImportMap.ts
@@ -5,20 +5,20 @@ import type { ComponentType } from "react";
 
 // Map of available slugs for runtime checking
 export const availableDocs = new Set([
-  "README",
-  "product-plan",
-  "measurement-strategy",
-  "team-story",
-  "business-vision",
-  "company-vision",
   "BACKLOG",
-  "CHANGELOG",
+  "business-vision",
   "card-system",
-  "improving-inference-philosophy",
+  "CHANGELOG",
+  "company-vision",
   "getting-started",
+  "improving-inference-philosophy",
   "interactive-demo",
+  "measurement-strategy",
+  "product-plan",
   "quickstart",
+  "README",
   "STATUS",
+  "team-story",
   "wut",
 ] as const);
 

--- a/infra/appBuild/contentBuild.ts
+++ b/infra/appBuild/contentBuild.ts
@@ -44,6 +44,9 @@ async function processDocsFiles() {
     await processMdxFile(path, slug, docsOutputDir);
   }
 
+  // Sort mdxFiles for deterministic output
+  mdxFiles.sort((a, b) => a.slug.localeCompare(b.slug));
+
   // Generate import map
   await generateImportMap(mdxFiles, generatedDir);
 }


### PR DESCRIPTION
Sort mdxFiles array alphabetically by slug before generating the import map
to ensure consistent ordering regardless of filesystem behavior.

Changes:
- Add sorting step in processDocsFiles() before generateImportMap()
- Generated docsImportMap.ts now has alphabetically ordered slugs

Test plan:
1. Run `deno run --allow-all infra/appBuild/contentBuild.ts` multiple times
2. Verify the availableDocs Set maintains consistent alphabetical ordering

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/934)
<!-- GitContextEnd -->