### PR TITLE
Include README.md in npm package build

### DIFF
--- a/packages/bolt-foundry/bin/build.ts
+++ b/packages/bolt-foundry/bin/build.ts
@@ -29,4 +29,12 @@ await build({
       url: "git+https://github.com/bolt-foundry/bolt-foundry.git",
     },
   },
+  postBuild() {
+    // Copy README.md to the npm package
+    const readmePath = import.meta.resolve("../README.md").replace(
+      "file://",
+      "",
+    );
+    Deno.copyFileSync(readmePath, `${outDir}/README.md`);
+  },
 });


### PR DESCRIPTION
Add postBuild hook to copy README.md to npm output directory,
ensuring documentation is available in published package.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/946)
<!-- GitContextEnd -->