### PR TITLE
Update v0.1 docs plan to focus on markdown rendering

### DIFF
--- a/apps/boltFoundry/docs/v0.1.md
+++ b/apps/boltFoundry/docs/v0.1.md
@@ -1,78 +1,93 @@
-# v0.1 Documentation Implementation Plan
+# v0.1 documentation implementation plan
 
 ## Overview
 
-Version 0.1 delivers a minimal documentation system that enables developers to
-self-serve through installation and first usage of Bolt Foundry. The focus is on
-creating the technical infrastructure to serve MDX documentation through
-Isograph, with a quickstart guide that demonstrates the value proposition
-through a concrete JSON output reliability example.
+Version 0.1 delivers a documentation system that serves plain markdown files
+from the `/docs/` directory through the existing MDX infrastructure. The focus
+is on quickly exposing existing documentation while maintaining a path to future
+Isograph integration and cross-monorepo documentation.
 
 ## Goals
 
-| Goal             | Description                       | Success Criteria                                      |
-| ---------------- | --------------------------------- | ----------------------------------------------------- |
-| MDX via Isograph | Serve docs at `/docs/*` routes    | MDX files render correctly at boltfoundry.com/docs/x  |
-| Clear value demo | Show JSON reliability improvement | Quickstart includes before/after example with context |
+| Goal                  | Description                          | Success criteria                                         |
+| --------------------- | ------------------------------------ | -------------------------------------------------------- |
+| Markdown rendering    | Serve .md files from `/docs/` folder | Markdown files render at boltfoundry.com/docs/[filename] |
+| MDX infrastructure    | Reuse existing MDX renderer          | Syntax highlighting, styling work out of the box         |
+| Build-time processing | Process markdown during build        | Generated import map includes all .md files              |
+| Direct routing        | Bypass Isograph for speed            | Docs load quickly without GraphQL overhead               |
 
-## Anti-Goals
+## Anti-goals
 
-| Anti-Goal            | Reason                                |
-| -------------------- | ------------------------------------- |
-| API reference        | Focus on getting started first        |
-| Advanced patterns    | Keep it simple for v0.1               |
-| Multiple use cases   | Focus only on JSON output reliability |
-| Interactive features | No CodeSandbox, just static examples  |
+| Anti-goal              | Reason                                      |
+| ---------------------- | ------------------------------------------- |
+| MDX/JSX components     | Focus on plain markdown first               |
+| Isograph integration   | Optimize for speed, add GraphQL layer later |
+| Runtime file loading   | Stick with build-time for performance       |
+| Cross-monorepo docs    | Start with `/docs/` only, expand later      |
+| File extension routing | Future work (.md, .pdf extensions in URLs)  |
 
-## Technical Approach
+## Technical approach
 
-Extend the existing MDX infrastructure to serve documentation through Isograph.
-Create a single entrypoint (`EntrypointDocs.ts`) that dynamically loads MDX
-files based on the route path. Documentation files will live in the `docs/`
-directory and be processed during the build pipeline to the appropriate location
-for serving.
+Extend the existing MDX build infrastructure to also process `.md` files from
+the `/docs/` directory. Continue using direct routing (bypassing Isograph) for
+speed. The build pipeline will process markdown files and generate an import
+map, allowing the MDX renderer to handle plain markdown with all its features
+(syntax highlighting, styling, etc.).
 
 ## Components
 
-| Status | Component               | Purpose                                     |
-| ------ | ----------------------- | ------------------------------------------- |
-| [x]    | ~~`EntrypointDocs.ts`~~ | ~~Isograph entrypoint for all docs routes~~ |
-| [x]    | `DocsPage.tsx`          | Direct route component for docs pages       |
-| [x]    | `docs/` directory       | Store MDX documentation files               |
-| [x]    | Build pipeline updates  | Process docs during content build           |
-| [x]    | Route registration      | Add `/docs/*` to direct routes              |
+| Status | Component              | Purpose                                  |
+| ------ | ---------------------- | ---------------------------------------- |
+| ✅     | `DocsPage.tsx`         | Direct route component for docs pages    |
+| ✅     | `/docs/` directory     | Contains 15 markdown documentation files |
+| 🔄     | Build pipeline updates | Need to process `.md` files              |
+| ✅     | Route registration     | `/docs/*` routes already working         |
+| 🔄     | Import map generation  | Need to include `.md` files              |
 
-## Technical Decisions
+## Technical decisions
 
-| Decision                   | Reasoning                    | Alternatives Considered        |
-| -------------------------- | ---------------------------- | ------------------------------ |
-| Single Isograph entrypoint | Simpler, dynamic routing     | Individual entrypoints per doc |
-| Reuse MDX infrastructure   | Already built and tested     | Custom markdown processor      |
-| `/docs/` location          | Clear separation of docs     | `/content/docs/` subdirectory  |
-| Minimal MDX features       | Ship faster, add later       | Full-featured from start       |
-| Static build-time imports  | Works with ESBuild/Isograph  | Dynamic runtime loading        |
-| Import map generation      | Automatic, maintainable      | Manual imports for each doc    |
-| `__generated__/` location  | Follows codebase conventions | Component-local generation     |
+| Decision                    | Reasoning                            | Alternatives considered        |
+| --------------------------- | ------------------------------------ | ------------------------------ |
+| Process `.md` files as MDX  | Reuse existing infrastructure        | Build separate markdown system |
+| Direct routing (no GraphQL) | Speed of implementation              | Isograph integration now       |
+| Build-time processing       | Better performance, existing pattern | Runtime file loading           |
+| `/docs/` directory only     | Start simple, expand later           | All monorepo docs immediately  |
+| Keep MDX renderer features  | Free syntax highlighting, styling    | Strip down to basic markdown   |
+| Import map generation       | Automatic, maintainable              | Manual imports for each doc    |
+| Ignore `.mdx` files         | Focus on plain markdown              | Process both file types        |
 
-## Next Steps
+## Next steps
 
-| Question                | How to Explore                            |
+| Question                | How to explore                            |
 | ----------------------- | ----------------------------------------- |
 | MDX component styling   | Test with existing blog styles first      |
 | Navigation between docs | Start with manual links, auto-gen later   |
 | Search functionality    | Not needed for v0.1, revisit if requested |
 
-## Initial Content Structure
+## Existing content (15 files)
 
 ```
 docs/
-├── quickstart.mdx       # Installation + JSON example
-└── getting-started.mdx  # Theory + first structured prompt
+├── README.md               # Documentation overview
+├── BACKLOG.md              # Development backlog
+├── CHANGELOG.md            # Version history
+├── STATUS.md               # Current project status
+├── business-vision.md      # Business strategy
+├── company-vision.md       # Company direction
+├── deck-system.md          # Deck/card system docs
+├── early-content-plan.md   # Content strategy
+├── improving-inference-philosophy.md  # AI philosophy
+├── library-vision.md       # Library architecture
+├── marketing-plan.md       # Marketing strategy
+├── measurement-strategy.md # Metrics and KPIs
+├── product-plan.md         # Product roadmap
+├── team-story.md           # Team background
+└── wut.md                  # (Unknown content)
 ```
 
-## Implementation Notes
+## Implementation notes
 
-### Build-Time Import Map Generation
+### Build-time import map generation
 
 The docs system uses static build-time imports due to ESBuild/Isograph
 architecture:
@@ -86,85 +101,67 @@ architecture:
 This approach ensures type safety, build-time validation, and optimal
 performance.
 
-## Implementation Checklist (TDD Approach)
+## Implementation checklist
 
-### 0.1.0: Write Tests First
+### 0.1.0: Markdown support (today's focus)
 
-- [x] Update `infra/appBuild/__tests__/contentBuild.test.ts` to expect `/docs/`
-      processing (tests written)
-- [x] Create simple E2E test expecting `/docs` route to load successfully
+- [ ] Update `infra/appBuild/contentBuild.ts` to:
+  - Process `.md` files from `/docs/` directory (not MDX files)
+  - Generate import map including both `.md` and `.mdx` files
+  - Use MDX compiler to process plain markdown
+- [ ] Update `apps/boltFoundry/pages/DocsPage.tsx` to handle markdown files
+- [ ] Update tests to expect markdown processing
+- [ ] Verify all 15 markdown files in `/docs/` render correctly
 
-### 0.1.1: Infrastructure (Make Tests Pass)
+### 0.1.x: Future enhancements
 
-- [x] Create `apps/boltFoundry/pages/DocsPage.tsx` (direct routing component)
-- [x] Update `infra/appBuild/contentBuild.ts` to:
-  - Process `/docs/` directory
-  - Generate import map at `apps/boltFoundry/__generated__/docsImportMap.ts`
-  - Compile MDX files to ES modules
-- [x] Register `/docs` and `/docs/:slug` routes in direct routes configuration
-- [x] Fix runtime rendering by bypassing Isograph for documentation pages
-- [x] Implement slug-to-import-key conversion (hyphens to underscores)
+- [ ] Add `/docs` index page listing all available documentation
+- [ ] Improve URL slug handling for better navigation
+- [ ] Add basic navigation between docs
+- [ ] Ensure code blocks have syntax highlighting
+- [ ] Apply consistent typography and spacing
+- [ ] Add copy-to-clipboard for code blocks
+- [ ] Style to match Bolt Foundry design system
+- [ ] Document the path to cross-monorepo documentation
+- [ ] Plan for file extension routing (.md, .pdf)
+- [ ] Design migration path to Isograph integration
+- [ ] E2E tests for all documentation routes
+- [ ] Build pipeline tests for markdown processing
+- [ ] Manual verification of all docs content
+- [ ] Create GraphQL types for documentation
+- [ ] Migrate from direct routing to Isograph entrypoints
+- [ ] Add document querying capabilities
+- [ ] Enable dynamic documentation features
 
-### 0.1.2: Content
+## Success metrics for v0.1.0
 
-- [x] Create `docs/quickstart.mdx` with:
-  - Installation instructions
-  - JSON output reliability example
-  - Before/after comparison
-  - Context block usage
-- [x] Create `docs/getting-started.mdx` with theoretical foundation
+- All 15 markdown files from `/docs/` are accessible at `/docs/[filename]`
+- Markdown content renders with proper formatting
+- Build process successfully compiles `.md` files
+- No errors when navigating to documentation pages
 
-### 0.1.3: Verify & Polish
+## Current status
 
-- [x] Run all tests to ensure implementation is complete
-- [x] Manual verification of content rendering
-- [x] Ensure routes work in production build
+### What's working
 
-## Success Metrics
+- MDX infrastructure for processing and rendering
+- Direct routing pattern (bypassing Isograph)
+- Build-time content processing pipeline
+- 15 markdown files ready in `/docs/` directory
 
-- Developers can find and access docs at boltfoundry.com/docs
-- Quickstart demonstrates clear value through JSON example
-- Documentation infrastructure ready for expansion
+### Implementation strategy
 
-## Current Status & Next Steps
+1. **Extend MDX infrastructure to handle `.md` files**
+   - Modify contentBuild.ts to process both `.md` and `.mdx`
+   - Generate unified import map
+   - Let MDX renderer handle plain markdown
 
-### What's Working
+2. **Continue with direct routing**
+   - Already proven to work
+   - Faster implementation
+   - No GraphQL complexity
 
-- MDX to JS compilation at build time
-- Route recognition and parameter extraction (`/docs/:slug`)
-- Import map generation with all documentation files
-- E2E test infrastructure (with relaxed assertions)
-
-### Current Blocker
-
-The runtime rendering fails when trying to display MDX content through Isograph.
-The error occurs in the `BfIsographFragmentReader` component when attempting to
-render the documentation.
-
-### Recommended Next Steps
-
-1. **Fix Isograph Integration (Option A)**
-   - Add proper GraphQL type for Docs (not just a field on Query)
-   - Update schema to handle document queries with parameters
-   - Fix parameter passing chain: router → entrypoint → component
-   - Ensure MDX components can render within Isograph's fragment system
-
-2. **Bypass Isograph for Docs (Option B - Faster)**
-   - Create a separate route handler for `/docs/*` that doesn't use Isograph
-   - Render MDX components directly without GraphQL layer
-   - Similar to how `/ui`, `/justin`, and `/plinko` routes work
-   - Would be simpler but less consistent with the app's architecture
-
-3. **Once Rendering Works**
-   - Add `/docs` root route with documentation index
-   - Implement syntax highlighting for code blocks
-   - Add copy-to-clipboard functionality
-   - Create navigation sidebar
-   - Style documentation pages to match design system
-
-### Technical Debt Considerations
-
-- Current implementation tries to force MDX rendering through GraphQL/Isograph
-- This may be over-engineering for static documentation
-- Consider if docs need the full Isograph treatment or if simpler routing would
-  suffice
+3. **Future-proof architecture**
+   - Keep Isograph integration as a future enhancement (0.1.5)
+   - Design with cross-monorepo docs in mind
+   - Plan for file extension routing


### PR DESCRIPTION

Refocus the documentation implementation plan on rendering plain markdown
files from /docs/ directory rather than MDX integration.

Changes:
- Update goals to prioritize markdown rendering over MDX features
- Document all 15 existing markdown files in /docs/ directory
- Move Isograph integration to future v0.1.x enhancements
- Apply writing style guide (sentence case for headers)
- Clarify technical decisions for markdown processing approach

The plan now focuses on quickly exposing existing documentation while
maintaining the path to future enhancements like cross-monorepo docs
and Isograph integration.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
