### PR TITLE
Add big-picture strategy document

### DIFF
--- a/docs/big-picture-strategy.md
+++ b/docs/big-picture-strategy.md
@@ -1,0 +1,107 @@
+# ⚡️ Bolt Foundry: Big Picture Strategy
+
+## 🧭 Why Bolt Foundry Exists
+
+**Bolt Foundry exists to make AI assistants more understandable, reliable, and
+upgradable — by helping people build them using higher-level building blocks.**
+
+Instead of crafting one-off prompts, users define assistants with structured
+primitives — **Decks, Cards, and Specs** — similar to how an OS abstracts
+hardware. This lets teams optimize outputs, debug behavior, and evolve
+assistants over time.
+
+> We're building the foundation for a future where AI assistants are not just
+> tools, but **systems you can engineer, reason about, and trust**.
+
+---
+
+## 💎 Product Truth
+
+**Prompting is programming — but most people are stuck writing assembly.**
+
+Bolt Foundry changes that by introducing higher-level primitives for building
+assistants. With **Decks, Cards, and Specs**, users build modular, testable,
+debuggable assistants — not raw prompts.
+
+> **Bolt Foundry is the React + TypeScript + Jest for assistant logic.**
+
+---
+
+## 🧰 Core Jobs-to-Be-Done
+
+| Job                               | Description                                                                                                          |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| 🧱 **Define identity**            | Use **Cards** to express the assistant's voice, tone, personality, and values.                                       |
+| ⚙️ **Specify behaviors**          | Use **Specs** to define expected outputs, response formats, or tool-calling logic.                                   |
+| 🧪 **Generate samples**           | Automatically produce high-quality input/output examples to support synthetic data, testing, and future fine-tuning. |
+| 🧑‍🤝‍🧑 **Collaborate on meaning** | Enable teams to align on what a Deck actually _means_ — making behavior a shared, inspectable artifact.              |
+| 🔍 **Debug & inspect**            | Understand _why_ an assistant behaved a certain way through transparent, structured logic.                           |
+| 🔁 **Update with confidence**     | Modify Cards/Specs without fear — modular design ensures updates don't break unrelated behavior.                     |
+
+---
+
+## 🧬 Modularity vs. Orchestration
+
+**Modularity is essential — orchestration is emergent.**
+
+- Every Deck, Card, and Spec is independently understandable and composable.
+- Orchestration happens when those parts align into an assistant with coherent
+  voice, behavior, and context.
+- **The system is built like software, not glued together with guesswork.**
+
+---
+
+## 🔥 Differentiation
+
+**Bolt Foundry is the only system that treats assistant design like software
+engineering.**
+
+Unlike PromptLayer, OpenPipe, or LangChain:
+
+- We don't just **log**, **run**, or **fine-tune** models.
+- We provide a framework for **structured assistant development**: with version
+  control, modularity, and team collaboration at its core.
+
+> **Bolt Foundry is the Git + React + tests + types for AI assistants.**
+
+---
+
+## 🎯 Who Are Our First Believers?
+
+Our early believers are:
+
+- Teams that have **already tried** building LLM products.
+- People who've hit a wall on consistency, maintainability, or scale.
+- Builders who live in a world of:\
+  _"Every time we fix something, something else breaks."_
+
+| Audience                    | Why They Need Bolt Foundry                                              |
+| --------------------------- | ----------------------------------------------------------------------- |
+| 🧑‍💻 Startup teams          | Want to ship assistants they can reason about and iterate on safely.    |
+| 🧠 Applied AI engineers     | Need better tooling to control and evolve LLM behavior.                 |
+| 🧑‍🏫 Internal tool builders | Require brand-safe, predictable assistants that support production use. |
+
+> These are the people who realize: _"We can't scale what we can't predict."_
+
+---
+
+## 🗺 Long-Term Vision
+
+If Bolt Foundry succeeds:
+
+- Teams **design assistants like software** — with specs, tests, and modular
+  logic.
+- Assistant behavior is **predictable**, **versioned**, and **safe to iterate**.
+- Collaboration becomes the norm — not a prompt pasted into Slack.
+
+And most powerfully:
+
+> **We enable reinforcement at the inference layer.**\
+> Assistants can learn and improve _as they run_ — through structured feedback,
+> usage data, and updated specs.\
+> Continuous improvement becomes a reality — not just a training step.
+
+**Bolt Foundry unlocks a world where assistants get better every day — because
+their system is designed to learn.**
+
+---


### PR DESCRIPTION
Introduce a modern, concise articulation of Bolt Foundry's vision and strategy.
This document synthesizes and evolves our strategic thinking with:

- Clear primitives: Decks, Cards, and Specs
- Jobs-to-be-done framework for value proposition
- Memorable positioning: 'Prompting is programming — but most people are stuck writing assembly'
- Long-term vision of reinforcement at the inference layer

This complements existing strategic documents by providing a unified,
accessible pitch-deck version of our vision.

Also created strategy-source-material.md to organize existing content
for future consolidation into a master strategy document.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/962)
<!-- GitContextEnd -->