### PR TITLE
Add GithubRepoStats GraphQL node for repository star tracking

### DIFF
--- a/apps/bfDb/graphql/__generated__/_nexustypes.ts
+++ b/apps/bfDb/graphql/__generated__/_nexustypes.ts
@@ -46,6 +46,7 @@ export interface NexusGenObjects {
   BfEdge: {};
   BfOrganization: {};
   BfPerson: {};
+  GithubRepoStats: {};
   JoinWaitlistPayload: { // root type
     message?: string | null; // String
     success: boolean; // Boolean!
@@ -81,6 +82,10 @@ export interface NexusGenFieldTypes {
     memberOf: NexusGenRootTypes['BfOrganization'] | null; // BfOrganization
     name: string | null; // String
   }
+  GithubRepoStats: { // field return type
+    id: string; // ID!
+    stars: number; // Int!
+  }
   JoinWaitlistPayload: { // field return type
     message: string | null; // String
     success: boolean; // Boolean!
@@ -94,6 +99,7 @@ export interface NexusGenFieldTypes {
   }
   Query: { // field return type
     documentsBySlug: NexusGenRootTypes['PublishedDocument'] | null; // PublishedDocument
+    githubRepoStats: NexusGenRootTypes['GithubRepoStats'] | null; // GithubRepoStats
     ok: boolean | null; // Boolean
   }
   Waitlist: { // field return type
@@ -120,6 +126,10 @@ export interface NexusGenFieldTypeNames {
     memberOf: 'BfOrganization'
     name: 'String'
   }
+  GithubRepoStats: { // field return type name
+    id: 'ID'
+    stars: 'Int'
+  }
   JoinWaitlistPayload: { // field return type name
     message: 'String'
     success: 'Boolean'
@@ -133,6 +143,7 @@ export interface NexusGenFieldTypeNames {
   }
   Query: { // field return type name
     documentsBySlug: 'PublishedDocument'
+    githubRepoStats: 'GithubRepoStats'
     ok: 'Boolean'
   }
   Waitlist: { // field return type name

--- a/apps/bfDb/graphql/__generated__/schema.graphql
+++ b/apps/bfDb/graphql/__generated__/schema.graphql
@@ -23,6 +23,11 @@ type BfPerson {
   name: String
 }
 
+type GithubRepoStats {
+  id: ID!
+  stars: Int!
+}
+
 type JoinWaitlistPayload {
   message: String
   success: Boolean!
@@ -44,6 +49,7 @@ type PublishedDocument {
 
 type Query {
   documentsBySlug(slug: String): PublishedDocument
+  githubRepoStats: GithubRepoStats
   ok: Boolean
 }
 

--- a/apps/bfDb/graphql/__tests__/GithubRepoStats.test.ts
+++ b/apps/bfDb/graphql/__tests__/GithubRepoStats.test.ts
@@ -1,0 +1,40 @@
+import { assertEquals, assertExists } from "@std/assert";
+import { GithubRepoStats } from "apps/bfDb/nodeTypes/GithubRepoStats.ts";
+import { testQuery } from "apps/bfDb/graphql/__tests__/TestHelpers.test.ts";
+
+Deno.test("GithubRepoStats - should return a valid GithubRepoStats instance", async () => {
+  const stats = await GithubRepoStats.findX();
+  assertExists(stats);
+  assertEquals(stats.id, "github-repo-stats-bolt-foundry-bolt-foundry");
+});
+
+Deno.test("GithubRepoStats - should have stars property as a number", async () => {
+  const stats = await GithubRepoStats.findX();
+  assertEquals(typeof stats.stars, "number");
+});
+
+Deno.test("GithubRepoStats - should be queryable via GraphQL", async () => {
+  const query = `
+    query {
+      githubRepoStats {
+        id
+        stars
+      }
+    }
+  `;
+
+  const result = await testQuery({ query });
+  assertExists(result.data);
+  assertExists(result.data.githubRepoStats);
+  assertEquals(
+    result.data.githubRepoStats.id,
+    "github-repo-stats-bolt-foundry-bolt-foundry",
+  );
+  assertEquals(typeof result.data.githubRepoStats.stars, "number");
+});
+
+Deno.test("GithubRepoStats - should always return the same singleton instance", async () => {
+  const stats1 = await GithubRepoStats.findX();
+  const stats2 = await GithubRepoStats.findX();
+  assertEquals(stats1, stats2);
+});

--- a/apps/bfDb/graphql/roots/Query.ts
+++ b/apps/bfDb/graphql/roots/Query.ts
@@ -1,5 +1,6 @@
 import { GraphQLObjectBase } from "../GraphQLObjectBase.ts";
 import { PublishedDocument } from "apps/bfDb/nodeTypes/PublishedDocument.ts";
+import { GithubRepoStats } from "apps/bfDb/nodeTypes/GithubRepoStats.ts";
 
 export class Query extends GraphQLObjectBase {
   static override gqlSpec = this.defineGqlNode((field) =>
@@ -11,6 +12,11 @@ export class Query extends GraphQLObjectBase {
           const slug = (args.slug as string) || "README";
           const post = await PublishedDocument.findX(slug).catch(() => null);
           return post;
+        },
+      })
+      .object("githubRepoStats", () => GithubRepoStats, {
+        resolve: async () => {
+          return await GithubRepoStats.findX();
         },
       })
   );

--- a/apps/bfDb/models/__generated__/nodeTypesList.ts
+++ b/apps/bfDb/models/__generated__/nodeTypesList.ts
@@ -4,4 +4,5 @@
 export * from "apps/bfDb/nodeTypes/BfEdge.ts";
 export * from "apps/bfDb/nodeTypes/BfOrganization.ts";
 export * from "apps/bfDb/nodeTypes/BfPerson.ts";
+export * from "apps/bfDb/nodeTypes/GithubRepoStats.ts";
 export * from "apps/bfDb/nodeTypes/PublishedDocument.ts";

--- a/apps/bfDb/nodeTypes/GithubRepoStats.ts
+++ b/apps/bfDb/nodeTypes/GithubRepoStats.ts
@@ -1,0 +1,101 @@
+import { GraphQLNode } from "apps/bfDb/classes/GraphQLNode.ts";
+import { getLogger } from "@bolt-foundry/logger";
+
+/**
+ * GithubRepoStats node for querying GitHub repository statistics.
+ * Caches star count and refreshes every 2 minutes.
+ */
+const logger = getLogger("GithubRepoStats");
+
+export class GithubRepoStats extends GraphQLNode {
+  private static _instance: GithubRepoStats | null = null;
+  private static _stars: number = 0;
+  private static _lastFetch: number = 0;
+  private static _fetching: boolean = false;
+  private static readonly CACHE_DURATION = 120_000; // 2 minutes in milliseconds
+  private static readonly REPO_OWNER = "bolt-foundry";
+  private static readonly REPO_NAME = "bolt-foundry";
+
+  constructor() {
+    super();
+  }
+
+  /**
+   * Required id field from the Node interface.
+   */
+  override get id(): string {
+    return `github-repo-stats-${GithubRepoStats.REPO_OWNER}-${GithubRepoStats.REPO_NAME}`;
+  }
+
+  /**
+   * Number of GitHub stars for the repository.
+   */
+  get stars(): number {
+    // Trigger background refresh if cache is stale
+    const now = Date.now();
+    if (
+      now - GithubRepoStats._lastFetch > GithubRepoStats.CACHE_DURATION &&
+      !GithubRepoStats._fetching
+    ) {
+      GithubRepoStats.fetchStars();
+    }
+    return GithubRepoStats._stars;
+  }
+
+  /**
+   * Fetch star count from GitHub API in the background.
+   */
+  private static async fetchStars(): Promise<void> {
+    if (GithubRepoStats._fetching) return;
+
+    GithubRepoStats._fetching = true;
+
+    try {
+      const response = await fetch(
+        `https://api.github.com/repos/${this.REPO_OWNER}/${this.REPO_NAME}`,
+        {
+          headers: {
+            "Accept": "application/vnd.github.v3+json",
+            "User-Agent": "BoltFoundry-GraphQL",
+          },
+        },
+      );
+
+      if (response.ok) {
+        const data = await response.json();
+        GithubRepoStats._stars = data.stargazers_count || 0;
+        GithubRepoStats._lastFetch = Date.now();
+      }
+    } catch (error) {
+      // Silently fail and keep using cached value
+      logger.error("Failed to fetch GitHub stars:", error);
+    } finally {
+      GithubRepoStats._fetching = false;
+    }
+  }
+
+  /**
+   * Find the singleton instance of GithubRepoStats.
+   */
+  static override async findX(): Promise<GithubRepoStats> {
+    if (!GithubRepoStats._instance) {
+      GithubRepoStats._instance = new GithubRepoStats();
+
+      // Fetch initial data if we don't have any
+      if (GithubRepoStats._lastFetch === 0) {
+        await GithubRepoStats.fetchStars();
+      }
+    }
+
+    return GithubRepoStats._instance;
+  }
+
+  /**
+   * GraphQL specification extending the Node interface with stars field.
+   */
+  static override gqlSpec = this.defineGqlNode((gql) =>
+    gql
+      .nonNull.id("id")
+      .nonNull.int("stars")
+  );
+}


### PR DESCRIPTION

Implement a new GraphQL node that queries and caches GitHub repository stars
for the bolt-foundry/bolt-foundry repository. The implementation provides
efficient star count access with automatic background refreshing.

Changes:
- Add GithubRepoStats node with singleton pattern and caching logic
- Implement 2-minute cache refresh interval with stale-while-revalidate
- Add githubRepoStats field to GraphQL Query root
- Create comprehensive tests for the new functionality
- Update generated GraphQL schema and types
- Use logger instead of console for error handling

Features:
- Returns cached star count immediately while refreshing in background
- Handles API failures gracefully by returning last known value
- Works without GitHub authentication (public API access)
- Publicly accessible via GraphQL query

Test plan:
1. Run tests: `bff test apps/bfDb/graphql/__tests__/GithubRepoStats.test.ts`
2. Query via GraphQL: `{ githubRepoStats { stars } }`
3. Verify caching behavior and background refresh

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
