### PR TITLE
Add array pattern support for samples API alongside builder pattern

### DIFF
--- a/packages/bolt-foundry/builders/builders.ts
+++ b/packages/bolt-foundry/builders/builders.ts
@@ -55,7 +55,7 @@ export type SampleBuilder = {
  * Options for spec method including samples
  */
 export type SpecOptions = {
-  samples?: (s: SampleBuilder) => SampleBuilder;
+  samples?: ((s: SampleBuilder) => SampleBuilder) | Array<Sample>;
 };
 
 /**
@@ -106,9 +106,23 @@ export function makeCardBuilder(cards: Array<Card> = []): CardBuilder {
 
       // If options are provided, process samples
       if (options?.samples) {
-        const sampleBuilder = options.samples(makeSampleBuilder());
-        const samples = sampleBuilder.getSamples();
-        if (samples.length > 0) {
+        let samples: Array<Sample> | undefined;
+
+        if (Array.isArray(options.samples)) {
+          // Array pattern - use samples directly
+          if (options.samples.length > 0) {
+            samples = options.samples;
+          }
+        } else {
+          // Builder pattern - call the function
+          const sampleBuilder = options.samples(makeSampleBuilder());
+          const builtSamples = sampleBuilder.getSamples();
+          if (builtSamples.length > 0) {
+            samples = builtSamples;
+          }
+        }
+
+        if (samples) {
           valueCard.samples = samples;
         }
       }
@@ -279,9 +293,23 @@ export function makeDeckBuilder(
 
       // If options are provided, process samples
       if (options?.samples) {
-        const sampleBuilder = options.samples(makeSampleBuilder());
-        const samples = sampleBuilder.getSamples();
-        if (samples.length > 0) {
+        let samples: Array<Sample> | undefined;
+
+        if (Array.isArray(options.samples)) {
+          // Array pattern - use samples directly
+          if (options.samples.length > 0) {
+            samples = options.samples;
+          }
+        } else {
+          // Builder pattern - call the function
+          const sampleBuilder = options.samples(makeSampleBuilder());
+          const builtSamples = sampleBuilder.getSamples();
+          if (builtSamples.length > 0) {
+            samples = builtSamples;
+          }
+        }
+
+        if (samples) {
           valueCard.samples = samples;
         }
       }

--- a/packages/bolt-foundry/builders/examples/arrayPatternExample.ts
+++ b/packages/bolt-foundry/builders/examples/arrayPatternExample.ts
@@ -1,0 +1,135 @@
+import { BfClient } from "../../BfClient.ts";
+import { getLogger } from "@bolt-foundry/logger";
+
+const logger = getLogger(import.meta);
+
+// Example demonstrating the new array pattern for samples
+// Both array and builder patterns work side-by-side
+
+const client = BfClient.create();
+
+// Array pattern example - cleaner and more direct
+const helpfulAssistant = client.createDeck(
+  "helpful-assistant",
+  (b) =>
+    b.spec("Be helpful and supportive", {
+      // NEW: Array pattern with direct sample objects
+      samples: [
+        { text: "I'm here to help you succeed!", rating: 3 },
+        { text: "Let me guide you through this step by step", rating: 2 },
+        { text: "I can try to help with that", rating: 1 },
+        { text: "You're on your own", rating: -3 },
+        { text: "I don't care about your problem", rating: -2 },
+      ],
+    })
+      .card("communication", (c) =>
+        c
+          .spec("Use clear language", {
+            // Array pattern with descriptions
+            samples: [
+              {
+                text: "Let me break this down into simple steps...",
+                rating: 3,
+                description: "Clear explanation with structure",
+              },
+              {
+                text: "It's complicated, just google it",
+                rating: -2,
+                description: "Dismissive and unhelpful",
+              },
+            ],
+          })
+          .spec("Show empathy", {
+            // Builder pattern still works for backward compatibility
+            samples: (s) =>
+              s
+                .sample("I understand this can be frustrating", 3)
+                .sample("That sounds challenging, let's work through it", 2)
+                .sample("Whatever, deal with it", -3),
+          })),
+);
+
+logger.info("Helpful assistant deck cards:", helpfulAssistant.getCards());
+
+// Mixed pattern example showing flexibility
+const codeAssistant = client.createDeck(
+  "code-assistant",
+  (b) =>
+    b
+      .spec("Write clean code", {
+        // Array pattern is great for simple lists
+        samples: [
+          {
+            text: "const userAuthToken = await authenticate(user);",
+            rating: 3,
+          },
+          { text: "const x = auth(u);", rating: -2 },
+        ],
+      })
+      .spec("Handle errors gracefully", {
+        // Builder pattern when you prefer the fluent interface
+        samples: (s) =>
+          s
+            .sample(
+              "try { await saveData() } catch (error) { logger.error('Failed to save:', error); }",
+              3,
+            )
+            .sample("saveData() // hope it works", -3),
+      })
+      .card("best-practices", (p) =>
+        p.spec("Follow conventions", {
+          // Empty array means no samples (same as omitting samples)
+          samples: [],
+        })),
+);
+
+logger.info("Code assistant deck cards:", codeAssistant.getCards());
+
+// Example showing the benefits of array pattern:
+// 1. More readable - samples are defined inline
+// 2. Better IDE support - direct type checking on array elements
+// 3. Easier to maintain - no builder state to track
+const supportAgent = client.createDeck(
+  "support-agent",
+  (b) =>
+    b.card("responses", (r) =>
+      r
+        .spec("Acknowledge the issue", {
+          samples: [
+            {
+              text:
+                "I see you're experiencing an issue with login. That must be frustrating.",
+              rating: 3,
+            },
+            {
+              text: "Yeah, login's broken.",
+              rating: -2,
+            },
+          ],
+        })
+        .spec("Provide solutions", {
+          samples: [
+            {
+              text: "Here are three things we can try to resolve this...",
+              rating: 3,
+              description: "Structured problem-solving approach",
+            },
+            {
+              text: "Have you tried turning it off and on again?",
+              rating: -1,
+              description: "Generic unhelpful response",
+            },
+          ],
+        })),
+);
+
+logger.info("Support agent deck cards:", supportAgent.getCards());
+
+// Example rendering the deck to see how it works with OpenAI
+const rendered = helpfulAssistant.render({
+  model: "gpt-4",
+  temperature: 0.7,
+  messages: [{ role: "user", content: "I'm struggling with a math problem" }],
+});
+
+logger.info("Rendered deck for OpenAI:", JSON.stringify(rendered, null, 2));

--- a/packages/bolt-foundry/docs/samples-api-refactor-plan.md
+++ b/packages/bolt-foundry/docs/samples-api-refactor-plan.md
@@ -90,16 +90,30 @@ interface Sample {
 
 ## Implementation Phases
 
-### Phase 1: Add Array Support Alongside Builder (Non-Breaking)
+### Phase 1: Add Array Support Alongside Builder (Non-Breaking) ✅
 
 **Goal**: Support both builder and array patterns temporarily
 
-- [ ] Add array support to `SpecOptions` type:
+**Status**: Completed
+
+- [x] Add array support to `SpecOptions` type:
       `samples?: SampleBuilder | Array<Sample>`
-- [ ] Update `makeCardBuilder` to handle both patterns
-- [ ] Write tests for array pattern working alongside builder
-- [ ] Update one example to show array pattern
-- [ ] Land this change - both APIs now work
+- [x] Update `makeCardBuilder` to handle both patterns
+- [x] Update `makeDeckBuilder` to handle both patterns
+- [x] Write tests for array pattern working alongside builder
+  - Added comprehensive tests in `builders.test.ts`
+  - Added DeckBuilder tests in `deckApi.test.ts`
+  - Tests cover: basic arrays, empty arrays, mixed patterns, descriptions
+- [x] Update one example to show array pattern
+  - Created `arrayPatternExample.ts` demonstrating both patterns
+- [x] Land this change - both APIs now work
+
+**Progress Notes**:
+
+- 2025-01-06: Tests written for array pattern support. Tests currently failing
+  as expected (TDD approach).
+- 2025-01-06: Implementation completed. All tests passing. Example created
+  showing both patterns working side-by-side.
 
 ### Phase 2: Unify Score Naming in Evals
 


### PR DESCRIPTION

Implement Phase 1 of the samples API refactor to support both array and builder patterns for defining samples. This non-breaking change allows developers to use a cleaner, more direct array syntax while maintaining full backward compatibility.

Changes:
- Update SpecOptions type to accept either builder function or array of samples
- Implement array handling in makeCardBuilder and makeDeckBuilder
- Add comprehensive test coverage for array pattern in builders.test.ts
- Add DeckBuilder tests for array pattern in deckApi.test.ts
- Create arrayPatternExample.ts demonstrating both patterns working together
- Update refactor plan documentation to mark Phase 1 as complete

Benefits:
- Simpler API with direct array syntax
- Better IDE support and type inference
- Both patterns work side-by-side for gradual migration
- No breaking changes - existing code continues to work

Test plan:
1. Run tests: bff test packages/bolt-foundry/builders/
2. All 42 tests pass including new array pattern tests
3. Example runs successfully: deno run --allow-env --allow-read packages/bolt-foundry/builders/examples/arrayPatternExample.ts

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
