### PR TITLE
Add sample field to JudgementResult for better disagreement analysis

### DIFF
--- a/packages/bolt-foundry/evals/__tests__/test-data.jsonl
+++ b/packages/bolt-foundry/evals/__tests__/test-data.jsonl
@@ -1,1 +1,1 @@
-{"id":"test-1","userMessage":"Test input","assistantResponse":"Test output"}
+{"id":"test-1","userMessage":"Test input","assistantResponse":"Test output","score":0,"description":"Basic test sample for unit testing"}

--- a/packages/bolt-foundry/evals/eval.ts
+++ b/packages/bolt-foundry/evals/eval.ts
@@ -18,6 +18,7 @@ export interface JudgementResult {
     score: number;
     notes?: string;
   };
+  sample: EvalSample;
   sampleMetadata?: Record<string, unknown>;
 }
 
@@ -26,7 +27,7 @@ interface EvalSample {
   userMessage: string;
   assistantResponse: string;
   expected?: string;
-  groundTruthScore?: number; // Expected score for meta-evaluation
+  score?: number; // Expected score for meta-evaluation
   [key: string]: unknown;
 }
 
@@ -173,6 +174,7 @@ export async function runEval(
       latencyInMs,
       rawOutput,
       output,
+      sample,
       sampleMetadata: Object.fromEntries(
         Object.entries(sample).filter(([key]) =>
           !["id", "userMessage", "assistantResponse", "expected"].includes(key)

--- a/packages/bolt-foundry/evals/examples/bad-sample-data.jsonl
+++ b/packages/bolt-foundry/evals/examples/bad-sample-data.jsonl
@@ -1,10 +1,10 @@
-{"id":"bad-001","userMessage":"Extract my info: John Doe, 30, NYC","assistantResponse":"Sure! Here's your info: John Doe is 30 years old and lives in NYC. Is there anything else you'd like to know?"}
-{"id":"bad-002","userMessage":"Parse address: 123 Main St, Apt 4B","assistantResponse":"123 Main St, Apt 4B"}
-{"id":"bad-003","userMessage":"Email: john@example.com","assistantResponse":"john@example.com"}
-{"id":"bad-004","userMessage":"Convert to JSON: name=Alice, age=25","assistantResponse":"{name: Alice, age: 25}"}
-{"id":"bad-005","userMessage":"Extract data: Product: Laptop, Price: $999","assistantResponse":"Product is Laptop\nPrice is $999"}
-{"id":"bad-006","userMessage":"Parse: {\"user\": \"Bob\", \"active\": true}","assistantResponse":"User Bob is active"}
-{"id":"bad-007","userMessage":"Format as JSON: Temperature 72F, Humidity 65%","assistantResponse":"Temperature: 72F, Humidity: 65%"}
-{"id":"bad-008","userMessage":"Extract JSON: Order #1234, Status: Shipped","assistantResponse":"Order number 1234 has been shipped! 🚚"}
-{"id":"bad-009","userMessage":"Parse contact: Tel: 555-1234, Email: test@test.com","assistantResponse":"Contact Information:\n- Phone: 555-1234\n- Email: test@test.com\n\nWould you like me to save this?"}
-{"id":"bad-010","userMessage":"JSON output: Color: Blue, Size: Large","assistantResponse":"```json\n{\n  color: \"Blue\",\n  size: \"Large\"\n}\n```"}
+{"id":"bad-001","userMessage":"Extract my info: John Doe, 30, NYC","assistantResponse":"Sure! Here's your info: John Doe is 30 years old and lives in NYC. Is there anything else you'd like to know?","score":-3,"description":"Verbose response with no JSON extraction"}
+{"id":"bad-002","userMessage":"Parse address: 123 Main St, Apt 4B","assistantResponse":"123 Main St, Apt 4B","score":-2,"description":"Echoed input without parsing into structured format"}
+{"id":"bad-003","userMessage":"Email: john@example.com","assistantResponse":"john@example.com","score":-2,"description":"Raw email without JSON structure"}
+{"id":"bad-004","userMessage":"Convert to JSON: name=Alice, age=25","assistantResponse":"{name: Alice, age: 25}","score":-2,"description":"Invalid JSON - missing quotes around keys and string values"}
+{"id":"bad-005","userMessage":"Extract data: Product: Laptop, Price: $999","assistantResponse":"Product is Laptop\nPrice is $999","score":-3,"description":"Plain text response instead of JSON extraction"}
+{"id":"bad-006","userMessage":"Parse: {\"user\": \"Bob\", \"active\": true}","assistantResponse":"User Bob is active","score":-3,"description":"Converted JSON to prose instead of parsing"}
+{"id":"bad-007","userMessage":"Format as JSON: Temperature 72F, Humidity 65%","assistantResponse":"Temperature: 72F, Humidity: 65%","score":-3,"description":"Formatted as text instead of JSON"}
+{"id":"bad-008","userMessage":"Extract JSON: Order #1234, Status: Shipped","assistantResponse":"Order number 1234 has been shipped! 🚚","score":-3,"description":"Conversational response with emoji instead of JSON"}
+{"id":"bad-009","userMessage":"Parse contact: Tel: 555-1234, Email: test@test.com","assistantResponse":"Contact Information:\n- Phone: 555-1234\n- Email: test@test.com\n\nWould you like me to save this?","score":-3,"description":"Formatted list with unnecessary question instead of JSON"}
+{"id":"bad-010","userMessage":"JSON output: Color: Blue, Size: Large","assistantResponse":"```json\n{\n  color: \"Blue\",\n  size: \"Large\"\n}\n```","score":-1,"description":"Wrapped JSON in markdown code block instead of raw JSON"}

--- a/packages/bolt-foundry/evals/examples/calibration-sample-data.jsonl
+++ b/packages/bolt-foundry/evals/examples/calibration-sample-data.jsonl
@@ -1,10 +1,10 @@
-{"id":"cal-001","userMessage":"Extract: name=John, age=30","assistantResponse":"{\"name\":\"John\",\"age\":30}","groundTruthScore":3}
-{"id":"cal-002","userMessage":"Parse: color=red","assistantResponse":"{'color': 'red'}","groundTruthScore":2}
-{"id":"cal-003","userMessage":"Convert: user=Bob, active=true","assistantResponse":"{\"user\":\"Bob\",\"active\":true,\"timestamp\":\"2024-01-01\"}","groundTruthScore":-1}
-{"id":"cal-004","userMessage":"Extract: email=test@test.com","assistantResponse":"test@test.com","groundTruthScore":-3}
-{"id":"cal-005","userMessage":"JSON: width=100, height=200","assistantResponse":"{width:100,height:200}","groundTruthScore":-2}
-{"id":"cal-006","userMessage":"Parse data: price=$99","assistantResponse":"{\"price\":99}","groundTruthScore":3}
-{"id":"cal-007","userMessage":"Convert: status=pending","assistantResponse":"{\"status\":\"pending\",\"checked\":false}","groundTruthScore":-1}
-{"id":"cal-008","userMessage":"Format: temp=72F","assistantResponse":"{\"temp\":\"72F\"}","groundTruthScore":0}
-{"id":"cal-009","userMessage":"JSON output: count=5","assistantResponse":"{}","groundTruthScore":-3}
-{"id":"cal-010","userMessage":"Extract: {name: 'Alice'}","assistantResponse":"{\"name\":\"Alice\"}","groundTruthScore":3}
+{"id":"cal-001","userMessage":"Extract: name=John, age=30","assistantResponse":"{\"name\":\"John\",\"age\":30}","score":3,"description":"Perfect JSON extraction"}
+{"id":"cal-002","userMessage":"Parse: color=red","assistantResponse":"{'color': 'red'}","score":2,"description":"Valid dict but single quotes instead of double quotes"}
+{"id":"cal-003","userMessage":"Convert: user=Bob, active=true","assistantResponse":"{\"user\":\"Bob\",\"active\":true,\"timestamp\":\"2024-01-01\"}","score":-1,"description":"Added unwanted timestamp field"}
+{"id":"cal-004","userMessage":"Extract: email=test@test.com","assistantResponse":"test@test.com","score":-3,"description":"Wrong format - returned string instead of JSON"}
+{"id":"cal-005","userMessage":"JSON: width=100, height=200","assistantResponse":"{width:100,height:200}","score":-2,"description":"Invalid JSON syntax - missing quotes on keys"}
+{"id":"cal-006","userMessage":"Parse data: price=$99","assistantResponse":"{\"price\":99}","score":3,"description":"Correctly parsed price as number"}
+{"id":"cal-007","userMessage":"Convert: status=pending","assistantResponse":"{\"status\":\"pending\",\"checked\":false}","score":-1,"description":"Added extra 'checked' field not requested"}
+{"id":"cal-008","userMessage":"Format: temp=72F","assistantResponse":"{\"temp\":\"72F\"}","score":0,"description":"Adequate but kept temperature as string"}
+{"id":"cal-009","userMessage":"JSON output: count=5","assistantResponse":"{}","score":-3,"description":"Empty object - missing required data"}
+{"id":"cal-010","userMessage":"Extract: {name: 'Alice'}","assistantResponse":"{\"name\":\"Alice\"}","score":3,"description":"Correctly extracted and formatted"}

--- a/packages/bolt-foundry/evals/examples/mixed-sample-data.jsonl
+++ b/packages/bolt-foundry/evals/examples/mixed-sample-data.jsonl
@@ -1,10 +1,10 @@
-{"id":"mixed-001","userMessage":"Extract: name=John, age=30","assistantResponse":"{\"name\":\"John\",\"age\":30}"}
-{"id":"mixed-002","userMessage":"Parse: color=red, size=large","assistantResponse":"{\"color\":\"red\",\"size\":\"large\",\"timestamp\":\"2024-01-01\"}"}
-{"id":"mixed-003","userMessage":"Convert: user Bob, status active","assistantResponse":"{\"user\":\"Bob\"}"}
-{"id":"mixed-004","userMessage":"JSON: temp=72, humidity=65","assistantResponse":"{'temp': 72, 'humidity': 65}"}
-{"id":"mixed-005","userMessage":"Extract data: price=$99, qty=5","assistantResponse":"{\"price\":\"$99\",\"qty\":\"5\"}"}
-{"id":"mixed-006","userMessage":"Parse info: email=test@test.com","assistantResponse":"The email is test@test.com"}
-{"id":"mixed-007","userMessage":"Format: width=100, height=200","assistantResponse":"{width:100,height:200}"}
-{"id":"mixed-008","userMessage":"JSON output: score=95, grade=A","assistantResponse":"{\"score\":95,\"grade\":\"A\",\"extra_field\":\"unnecessary\",\"another_extra\":123}"}
-{"id":"mixed-009","userMessage":"Convert: {name: 'Alice', age: 25}","assistantResponse":"{\"name\":\"Alice\",\"age\":25}"}
-{"id":"mixed-010","userMessage":"Parse JSON: status=pending","assistantResponse":"{}"}
+{"id":"mixed-001","userMessage":"Extract: name=John, age=30","assistantResponse":"{\"name\":\"John\",\"age\":30}","score":3,"description":"Perfect JSON extraction with correct format"}
+{"id":"mixed-002","userMessage":"Parse: color=red, size=large","assistantResponse":"{\"color\":\"red\",\"size\":\"large\",\"timestamp\":\"2024-01-01\"}","score":1,"description":"Correct extraction but added unexpected timestamp field"}
+{"id":"mixed-003","userMessage":"Convert: user Bob, status active","assistantResponse":"{\"user\":\"Bob\"}","score":-1,"description":"Missing status field from the input"}
+{"id":"mixed-004","userMessage":"JSON: temp=72, humidity=65","assistantResponse":"{'temp': 72, 'humidity': 65}","score":-2,"description":"Used single quotes instead of double quotes - invalid JSON"}
+{"id":"mixed-005","userMessage":"Extract data: price=$99, qty=5","assistantResponse":"{\"price\":\"$99\",\"qty\":\"5\"}","score":2,"description":"Correct extraction but kept qty as string instead of number"}
+{"id":"mixed-006","userMessage":"Parse info: email=test@test.com","assistantResponse":"The email is test@test.com","score":-3,"description":"Returned plain text instead of JSON format"}
+{"id":"mixed-007","userMessage":"Format: width=100, height=200","assistantResponse":"{width:100,height:200}","score":-2,"description":"Missing quotes around property names - invalid JSON"}
+{"id":"mixed-008","userMessage":"JSON output: score=95, grade=A","assistantResponse":"{\"score\":95,\"grade\":\"A\",\"extra_field\":\"unnecessary\",\"another_extra\":123}","score":0,"description":"Correct extraction but added unnecessary extra fields"}
+{"id":"mixed-009","userMessage":"Convert: {name: 'Alice', age: 25}","assistantResponse":"{\"name\":\"Alice\",\"age\":25}","score":3,"description":"Perfect conversion to valid JSON format"}
+{"id":"mixed-010","userMessage":"Parse JSON: status=pending","assistantResponse":"{}","score":-2,"description":"Returned empty object instead of parsing the status"}

--- a/packages/bolt-foundry/evals/examples/sample-data.jsonl
+++ b/packages/bolt-foundry/evals/examples/sample-data.jsonl
@@ -1,3 +1,3 @@
-{"userMessage": "Extract user info from: 'John Doe, 30, NYC'", "assistantResponse": "{\"name\":\"John Doe\",\"age\":30,\"city\":\"NYC\"}", "id": "sample-001"}
-{"userMessage": "Parse address: '123 Main St, Apt 4B'", "assistantResponse": "{\"street\":\"123 Main St\",\"unit\":\"Apt 4B\"}", "id": "sample-002"}
-{"userMessage": "Extract email from: 'Contact me at john@example.com'", "assistantResponse": "{\"email\":\"john@example.com\"}", "id": "sample-003"}
+{"userMessage":"Extract user info from: 'John Doe, 30, NYC'","assistantResponse":"{\"name\":\"John Doe\",\"age\":30,\"city\":\"NYC\"}","id":"sample-001","score":3,"description":"Perfect extraction of all fields with correct data types"}
+{"userMessage":"Parse address: '123 Main St, Apt 4B'","assistantResponse":"{\"street\":\"123 Main St\",\"unit\":\"Apt 4B\"}","id":"sample-002","score":3,"description":"Clean address parsing into structured components"}
+{"userMessage":"Extract email from: 'Contact me at john@example.com'","assistantResponse":"{\"email\":\"john@example.com\"}","id":"sample-003","score":3,"description":"Correct email extraction in JSON format"}


### PR DESCRIPTION

Store complete original sample data in evaluation results to improve
disagreement analysis. Previously, only partial metadata was preserved,
making it difficult to understand why judges scored differently than expected.

Changes:
- Add `sample: EvalSample` field to JudgementResult interface
- Store complete sample in evaluation results (eval.ts)
- Update disagreement display to show original sample data
- Merge sample data and score comparison into single table

This provides better context when analyzing judge calibration issues by
showing the full original input alongside scoring differences.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
