### PR TITLE
Change eval CLI argument from --deck to --grader

### DIFF
--- a/apps/bfDb/graphql/__generated__/_nexustypes.ts
+++ b/apps/bfDb/graphql/__generated__/_nexustypes.ts
@@ -160,7 +160,7 @@ export interface NexusGenFieldTypeNames {
 export interface NexusGenArgTypes {
   Mutation: {
     joinWaitlist: { // args
-      company: string; // String!
+      company?: string | null; // String
       email: string; // String!
       name: string; // String!
     }

--- a/apps/bfDb/graphql/__generated__/schema.graphql
+++ b/apps/bfDb/graphql/__generated__/schema.graphql
@@ -34,7 +34,7 @@ type JoinWaitlistPayload {
 }
 
 type Mutation {
-  joinWaitlist(company: String!, email: String!, name: String!): JoinWaitlistPayload
+  joinWaitlist(company: String, email: String!, name: String!): JoinWaitlistPayload
 }
 
 """An object with a unique identifier"""

--- a/apps/bfDb/graphql/__tests__/Waitlist.test.ts
+++ b/apps/bfDb/graphql/__tests__/Waitlist.test.ts
@@ -66,7 +66,7 @@ Deno.test("joinWaitlist mutation is available with returns builder", async () =>
   assert(
     sdl.includes("email: String!") &&
       sdl.includes("name: String!") &&
-      sdl.includes("company: String!"),
+      sdl.includes("company: String"),
     "joinWaitlist mutation is missing required arguments",
   );
 

--- a/apps/bfDb/graphql/roots/Waitlist.ts
+++ b/apps/bfDb/graphql/roots/Waitlist.ts
@@ -13,7 +13,7 @@ export class Waitlist extends GraphQLObjectBase {
           a
             .nonNull.string("email")
             .nonNull.string("name")
-            .nonNull.string("company"),
+            .string("company"),
         returns: (r) =>
           r
             .string("message")

--- a/infra/bff/friends/eval.bff.ts
+++ b/infra/bff/friends/eval.bff.ts
@@ -64,8 +64,8 @@ export async function evalCommand(options: string[]): Promise<number> {
 
     if (arg === "--input" || arg === "-i") {
       args.inputFile = options[++i];
-    } else if (arg === "--deck" || arg === "-d") {
-      args.deckFile = options[++i];
+    } else if (arg === "--grader" || arg === "-g") {
+      args.graderFile = options[++i];
     } else if (arg === "--model" || arg === "-m") {
       args.model = options[++i] || "gpt-4o";
     } else if (arg === "--output" || arg === "-o") {
@@ -82,8 +82,8 @@ export async function evalCommand(options: string[]): Promise<number> {
   }
 
   // Validate required arguments
-  if (!args.inputFile || !args.deckFile) {
-    logger.error("Missing required arguments: --input and --deck");
+  if (!args.inputFile || !args.graderFile) {
+    logger.error("Missing required arguments: --input and --grader");
     printHelp();
     return 1;
   }
@@ -95,14 +95,14 @@ export async function evalCommand(options: string[]): Promise<number> {
 
   logger.debug(`Running evaluation...`);
   logger.debug(`Input: ${args.inputFile}`);
-  logger.debug(`Deck: ${args.deckFile}`);
+  logger.debug(`Grader: ${args.graderFile}`);
   logger.debug(`Model: ${args.model}`);
 
   // Show evaluation configuration
   printLine("\nEvaluation Configuration:");
   printTable({
     "Input File": args.inputFile,
-    "Deck File": args.deckFile,
+    "Grader File": args.graderFile,
     "Model": args.model,
     "Output": args.outputFile || "Console",
   });
@@ -113,7 +113,7 @@ export async function evalCommand(options: string[]): Promise<number> {
     // Run the evaluation
     const results = await runEval({
       inputFile: args.inputFile,
-      deckFile: args.deckFile,
+      graderFile: args.graderFile,
       model: args.model,
     });
 
@@ -295,18 +295,18 @@ function printHelp() {
   logger.debug(`
 Usage: bff eval [options]
 
-Run LLM evaluation on a dataset using a grader deck.
+Run LLM evaluation on a dataset using a grader.
 
 Options:
   -i, --input <file>    Input JSONL file with evaluation samples (required)
-  -d, --deck <file>     Deck file with evaluation criteria (required)
+  -g, --grader <file>   Grader file with evaluation criteria (required)
   -m, --model <model>   Model to use for evaluation (default: openai/gpt-4o)
   -o, --output <file>   Output file for results (optional, defaults to console)
   -h, --help            Show this help message
 
 Example:
-  bff eval --input ./data/samples.jsonl --deck ./decks/json-validator.ts
-  bff eval -i samples.jsonl -d validator.ts -m anthropic/claude-3-opus -o results.jsonl
+  bff eval --input ./data/samples.jsonl --grader ./graders/json-validator.ts
+  bff eval -i samples.jsonl -g validator.ts -m anthropic/claude-3-opus -o results.jsonl
 `);
 }
 

--- a/packages/bff-eval/README.md
+++ b/packages/bff-eval/README.md
@@ -1,6 +1,6 @@
 # bff-eval
 
-Node.js CLI for running LLM evaluations with grader decks.
+Node.js CLI for running LLM evaluations with graders.
 
 ## Installation
 
@@ -14,16 +14,16 @@ npx bff-eval --help
 
 ```bash
 # Basic usage
-bff-eval --input samples.jsonl --deck grader.js
+bff-eval --input samples.jsonl --grader grader.js
 
 # With specific model
-bff-eval --input samples.jsonl --deck grader.js --model openai/gpt-4
+bff-eval --input samples.jsonl --grader grader.js --model openai/gpt-4
 
 # Save results to file
-bff-eval --input samples.jsonl --deck grader.js --output results.json
+bff-eval --input samples.jsonl --grader grader.js --output results.json
 
 # Verbose output
-bff-eval --input samples.jsonl --deck grader.js --verbose
+bff-eval --input samples.jsonl --grader grader.js --verbose
 ```
 
 ## Environment Variables
@@ -46,14 +46,14 @@ Fields:
 - `assistantResponse` or `completion` - The AI's response
 - `score` (optional) - Expected score for calibration metrics
 
-## Grader Deck Format
+## Grader Format
 
-Grader decks should be CommonJS modules that export a DeckBuilder:
+Graders should be CommonJS modules that export a DeckBuilder:
 
 ```javascript
 const { makeGraderDeckBuilder } = require("@bolt-foundry/evals");
 
-const deck = makeGraderDeckBuilder("accuracy-grader")
+const grader = makeGraderDeckBuilder("accuracy-grader")
   .card(
     "criteria",
     (c) =>
@@ -61,7 +61,7 @@ const deck = makeGraderDeckBuilder("accuracy-grader")
         .spec("Score from -3 (completely wrong) to 3 (perfectly accurate)"),
   );
 
-module.exports = deck;
+module.exports = grader;
 ```
 
 ## Output

--- a/packages/bff-eval/__tests__/cli.test.ts
+++ b/packages/bff-eval/__tests__/cli.test.ts
@@ -9,9 +9,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 describe("bff-eval CLI", () => {
   it("should show help when called with --help", async () => {
     const result = await runCLI(["--help"]);
-    assert.match(result.stdout, /Run LLM evaluation with grader decks/);
+    assert.match(result.stdout, /Run LLM evaluation with graders/);
     assert.match(result.stdout, /--input/);
-    assert.match(result.stdout, /--deck/);
+    assert.match(result.stdout, /--grader/);
     assert.match(result.stdout, /--model/);
     assert.equal(result.code, 0);
   });
@@ -23,14 +23,14 @@ describe("bff-eval CLI", () => {
   });
 
   it("should require input flag", async () => {
-    const result = await runCLI(["--deck", "test.ts"]);
+    const result = await runCLI(["--grader", "test.ts"]);
     assert.match(result.stderr, /Missing required argument: input/);
     assert.notEqual(result.code, 0);
   });
 
-  it("should require deck flag", async () => {
+  it("should require grader flag", async () => {
     const result = await runCLI(["--input", "test.jsonl"]);
-    assert.match(result.stderr, /Missing required argument: deck/);
+    assert.match(result.stderr, /Missing required argument: grader/);
     assert.notEqual(result.code, 0);
   });
 });

--- a/packages/bff-eval/src/cli.ts
+++ b/packages/bff-eval/src/cli.ts
@@ -8,8 +8,8 @@ export const cli = yargs(hideBin(process.argv))
   .help()
   .strict()
   .demandOption(
-    ["input", "deck"],
-    "Please provide both input and deck arguments",
+    ["input", "grader"],
+    "Please provide both input and grader arguments",
   )
   .option("input", {
     alias: "i",
@@ -17,10 +17,10 @@ export const cli = yargs(hideBin(process.argv))
     description: "Input JSONL file containing test cases",
     demandOption: true,
   })
-  .option("deck", {
-    alias: "d",
+  .option("grader", {
+    alias: "g",
     type: "string",
-    description: "Grader deck file to use for evaluation",
+    description: "Grader file to use for evaluation",
     demandOption: true,
   })
   .option("model", {
@@ -40,12 +40,12 @@ export const cli = yargs(hideBin(process.argv))
     description: "Enable verbose logging",
     default: false,
   })
-  .epilogue("Run LLM evaluation with grader decks")
+  .epilogue("Run LLM evaluation with graders")
   .example(
-    "$0 --input test.jsonl --deck grader.ts",
-    "Run evaluation with test cases from test.jsonl using grader.ts deck",
+    "$0 --input test.jsonl --grader grader.ts",
+    "Run evaluation with test cases from test.jsonl using grader.ts",
   )
   .example(
-    "$0 -i data.jsonl -d eval.ts -m gpt-3.5-turbo -o results.json",
+    "$0 -i data.jsonl -g eval.ts -m gpt-3.5-turbo -o results.json",
     "Run with custom model and output file",
   );

--- a/packages/bolt-foundry/evals/__tests__/eval.test.ts
+++ b/packages/bolt-foundry/evals/__tests__/eval.test.ts
@@ -33,7 +33,7 @@ Deno.test("eval - should run end-to-end evaluation with mock API", async () => {
   try {
     const results = await runEval({
       inputFile: new URL("./test-data.jsonl", import.meta.url).pathname,
-      deckFile: new URL("./test-deck.ts", import.meta.url).pathname,
+      graderFile: new URL("./test-deck.ts", import.meta.url).pathname,
       model: "openai/gpt-4o",
     });
 
@@ -74,7 +74,7 @@ Deno.test("eval - should handle missing input file", async () => {
       async () => {
         await runEval({
           inputFile: "./nonexistent.jsonl",
-          deckFile: "./examples/json-validator.ts",
+          graderFile: "./examples/json-validator.ts",
           model: "openai/gpt-4o",
         });
       },
@@ -86,7 +86,7 @@ Deno.test("eval - should handle missing input file", async () => {
   }
 });
 
-Deno.test("eval - should handle invalid deck file", async () => {
+Deno.test("eval - should handle invalid grader file", async () => {
   // Stub file read to succeed for input file
   const readTextFileStub = stub(
     Deno,
@@ -97,12 +97,12 @@ Deno.test("eval - should handle invalid deck file", async () => {
       ),
   );
 
-  // Stub stat to throw not found for deck file
+  // Stub stat to throw not found for grader file
   const statStub = stub(
     Deno,
     "stat",
     (path: string | URL) => {
-      if (path.toString().includes("nonexistent-deck")) {
+      if (path.toString().includes("nonexistent-grader")) {
         return Promise.reject(new Deno.errors.NotFound("file not found"));
       }
       return Promise.resolve({ isFile: true } as Deno.FileInfo);
@@ -114,7 +114,7 @@ Deno.test("eval - should handle invalid deck file", async () => {
       async () => {
         await runEval({
           inputFile: "./valid.jsonl",
-          deckFile: "./nonexistent-deck.ts",
+          graderFile: "./nonexistent-grader.ts",
           model: "openai/gpt-4o",
         });
       },

--- a/packages/bolt-foundry/evals/docs/README.md
+++ b/packages/bolt-foundry/evals/docs/README.md
@@ -9,8 +9,8 @@ across multiple underlying base models.
 
 ## Features
 
-- **Custom Grader Decks**: Create specialized graders using a standard DSL to
-  easily create and update criteria and output formats.
+- **Custom Graders**: Create specialized graders using a standard DSL to easily
+  create and update criteria and output formats.
 - **Multi-Model Evaluation**: Grader responses across multiple LLMs
   simultaneously to compare performance and consistency (powered by Open Router)
 - **Parallel Execution**: Run evaluations concurrently for faster results across
@@ -30,7 +30,7 @@ Run evaluation with sample data:
 
 ```bash
 bff eval --input packages/bolt-foundry/evals/examples/sample-data.jsonl \
-         --deck packages/bolt-foundry/evals/examples/json-validator.ts
+         --grader packages/bolt-foundry/evals/examples/json-validator.ts
 ```
 
 ## Input data
@@ -56,12 +56,13 @@ type Sample = {
 type InputSampleFile = Array<Sample>;
 ```
 
-## Create your grader using grader decks
+## Create your grader
 
-Grader decks let you build your eval logic in a structured way. Read more on our
+Graders let you build your eval logic in a structured way. Read more on our
 [prompting philosophy], or the [case studies] as to why we've done it this way.
 
-1. Structure your deck with an initial spec explaining what your grader will do.
+1. Structure your grader with an initial spec explaining what your grader will
+   do.
 2. Add cards to explain evaluation criteria
 3. Include any variables as context, INCLUDING OUTPUT FORMAT.
 
@@ -114,8 +115,8 @@ export default makeGraderDeckBuilder("json-validator")
 Specify the model to use for evaluation using the `--model` flag:
 
 ```bash
-bff eval --input data.jsonl --deck grader.ts --model openai/gpt-4o  # Default
-bff eval --input data.jsonl --deck grader.ts --model anthropic/claude-3-opus
+bff eval --input data.jsonl --grader grader.ts --model openai/gpt-4o  # Default
+bff eval --input data.jsonl --grader grader.ts --model anthropic/claude-3-opus
 ```
 
 The evaluation uses OpenRouter API, so any model available on OpenRouter can be
@@ -167,7 +168,7 @@ against ground truth scores. This calibration feature helps you:
    accurately
 2. **Improve Grader Criteria**: Identify areas where grader instructions need
    refinement
-3. **Compare Grader Versions**: Measure improvements when updating grader decks
+3. **Compare Grader Versions**: Measure improvements when updating graders
 
 ### Adding Ground Truth Scores
 

--- a/packages/bolt-foundry/evals/docs/v0.1.md
+++ b/packages/bolt-foundry/evals/docs/v0.1.md
@@ -114,8 +114,8 @@ following features:
 **Implemented:**
 
 - ✅ `bff eval` command integrated into main CLI
-- ✅ Core flags: `--input`, `--deck`, `--model`, `--output`
-- ✅ Grader deck API via `makeGraderDeckBuilder`
+- ✅ Core flags: `--input`, `--grader`, `--model`, `--output`
+- ✅ Grader API via `makeGraderDeckBuilder`
 - ✅ OpenRouter integration for multi-model support
 - ✅ Console table output for results and metrics
 - ✅ Meta grader analysis with ground truth scoring


### PR DESCRIPTION

Update the evaluation command interface to use more intuitive terminology.
The --deck argument is now --grader to better reflect its purpose.

Changes:
- Update CLI argument parsing in eval.bff.ts from --deck/-d to --grader/-g
- Update parameter names from deckFile to graderFile throughout eval.ts
- Update bff-eval npm package CLI to use --grader instead of --deck
- Update all documentation to use 'grader' terminology
- Update test files to expect --grader argument
- Update help text and error messages

Test plan:
1. Run tests: bff test packages/bolt-foundry/evals/__tests__/eval.test.ts
2. Run tests: bff test packages/bff-eval/__tests__/cli.test.ts
3. Verify bff eval --help shows updated argument names

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/992).
* __->__ #992
* #991