### PR TITLE
Use Nix environment for bff-eval CI workflows

### DIFF
--- a/.github/workflows/publish-bff-eval-dev.yml
+++ b/.github/workflows/publish-bff-eval-dev.yml
@@ -13,6 +13,13 @@ jobs:
     name: Build and Publish bff-eval Dev Version
     runs-on: ubuntu-latest
     steps:
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+        with: { determinate: true }
+
+      - name: Setup Nix caching
+        uses: DeterminateSystems/flakehub-cache-action@main
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -24,21 +31,9 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org/"
 
-      - name: Setup Deno
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.x
-
-      # Cache dependencies
-      - name: Cache Deno dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/deno
-            ~/.deno
-          key: ${{ runner.os }}-deno-${{ hashFiles('deno.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-deno-
+      # Set Deno cache directory
+      - name: Set Deno cache directory
+        run: echo "DENO_DIR=${RUNNER_TEMP}/deno-cache" >> "$GITHUB_ENV"
 
       # Cache node_modules
       - name: Cache dependencies
@@ -56,7 +51,7 @@ jobs:
       # Build bolt-foundry package first (which bff-eval depends on)
       - name: Build bolt-foundry package
         run: |
-          deno run -A infra/bff/bff.ts build --include-bolt-foundry --skip-barrels --skip-routes --skip-content --skip-config-keys --skip-gql-types --skip-isograph
+          nix develop --impure --command bff build --include-bolt-foundry --skip-barrels --skip-routes --skip-content --skip-config-keys --skip-gql-types --skip-isograph
 
       - name: Install dependencies
         working-directory: packages/bff-eval

--- a/.github/workflows/publish-bff-eval-dev.yml
+++ b/.github/workflows/publish-bff-eval-dev.yml
@@ -24,6 +24,22 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org/"
 
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      # Cache dependencies
+      - name: Cache Deno dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/deno
+            ~/.deno
+          key: ${{ runner.os }}-deno-${{ hashFiles('deno.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-deno-
+
       # Cache node_modules
       - name: Cache dependencies
         uses: actions/cache@v4
@@ -36,6 +52,11 @@ jobs:
           key: ${{ runner.os }}-bff-eval-deps-${{ hashFiles('packages/bff-eval/package-lock.json', 'packages/bff-eval/package.json') }}
           restore-keys: |
             ${{ runner.os }}-bff-eval-deps-
+
+      # Build bolt-foundry package first (which bff-eval depends on)
+      - name: Build bolt-foundry package
+        run: |
+          deno run -A infra/bff/bff.ts build --include-bolt-foundry --skip-barrels --skip-routes --skip-content --skip-config-keys --skip-gql-types --skip-isograph
 
       - name: Install dependencies
         working-directory: packages/bff-eval

--- a/.github/workflows/publish-bff-eval-release.yml
+++ b/.github/workflows/publish-bff-eval-release.yml
@@ -18,6 +18,13 @@ jobs:
     name: Build and Publish bff-eval Release
     runs-on: ubuntu-latest
     steps:
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+        with: { determinate: true }
+
+      - name: Setup Nix caching
+        uses: DeterminateSystems/flakehub-cache-action@main
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -29,21 +36,9 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org/"
 
-      - name: Setup Deno
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.x
-
-      # Cache dependencies
-      - name: Cache Deno dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/deno
-            ~/.deno
-          key: ${{ runner.os }}-deno-${{ hashFiles('deno.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-deno-
+      # Set Deno cache directory
+      - name: Set Deno cache directory
+        run: echo "DENO_DIR=${RUNNER_TEMP}/deno-cache" >> "$GITHUB_ENV"
 
       # Cache node_modules
       - name: Cache dependencies
@@ -61,7 +56,7 @@ jobs:
       # Build bolt-foundry package first (which bff-eval depends on)
       - name: Build bolt-foundry package
         run: |
-          deno run -A infra/bff/bff.ts build --include-bolt-foundry --skip-barrels --skip-routes --skip-content --skip-config-keys --skip-gql-types --skip-isograph
+          nix develop --impure --command bff build --include-bolt-foundry --skip-barrels --skip-routes --skip-content --skip-config-keys --skip-gql-types --skip-isograph
 
       - name: Install dependencies
         working-directory: packages/bff-eval

--- a/.github/workflows/publish-bff-eval-release.yml
+++ b/.github/workflows/publish-bff-eval-release.yml
@@ -29,6 +29,22 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org/"
 
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      # Cache dependencies
+      - name: Cache Deno dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/deno
+            ~/.deno
+          key: ${{ runner.os }}-deno-${{ hashFiles('deno.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-deno-
+
       # Cache node_modules
       - name: Cache dependencies
         uses: actions/cache@v4
@@ -41,6 +57,11 @@ jobs:
           key: ${{ runner.os }}-bff-eval-deps-${{ hashFiles('packages/bff-eval/package-lock.json', 'packages/bff-eval/package.json') }}
           restore-keys: |
             ${{ runner.os }}-bff-eval-deps-
+
+      # Build bolt-foundry package first (which bff-eval depends on)
+      - name: Build bolt-foundry package
+        run: |
+          deno run -A infra/bff/bff.ts build --include-bolt-foundry --skip-barrels --skip-routes --skip-content --skip-config-keys --skip-gql-types --skip-isograph
 
       - name: Install dependencies
         working-directory: packages/bff-eval


### PR DESCRIPTION

Replace manual Deno setup with the standard Nix environment setup used
in other workflows. This ensures consistency and provides all required
tools through the Nix flake.

Changes:
- Add DeterminateSystems Nix installer and cache actions
- Remove manual Deno setup and caching
- Use 'nix develop --impure --command bff build' instead of direct deno run
- Set DENO_DIR environment variable for consistency with other workflows

This aligns the bff-eval workflows with the standard CI setup used
throughout the project.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
