### PR TITLE
Add helpful error message for missing OPENROUTER_API_KEY

### DIFF
--- a/.github/workflows/publish-bff-eval-dev.yml
+++ b/.github/workflows/publish-bff-eval-dev.yml
@@ -13,6 +13,13 @@ jobs:
     name: Build and Publish bff-eval Dev Version
     runs-on: ubuntu-latest
     steps:
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+        with: { determinate: true }
+
+      - name: Setup Nix caching
+        uses: DeterminateSystems/flakehub-cache-action@main
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -23,6 +30,10 @@ jobs:
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org/"
+
+      # Set Deno cache directory
+      - name: Set Deno cache directory
+        run: echo "DENO_DIR=${RUNNER_TEMP}/deno-cache" >> "$GITHUB_ENV"
 
       # Cache node_modules
       - name: Cache dependencies
@@ -36,6 +47,11 @@ jobs:
           key: ${{ runner.os }}-bff-eval-deps-${{ hashFiles('packages/bff-eval/package-lock.json', 'packages/bff-eval/package.json') }}
           restore-keys: |
             ${{ runner.os }}-bff-eval-deps-
+
+      # Build bolt-foundry package first (which bff-eval depends on)
+      - name: Build bolt-foundry package
+        run: |
+          nix develop --impure --command bff build --include-bolt-foundry --skip-barrels --skip-routes --skip-content --skip-config-keys --skip-gql-types --skip-isograph
 
       - name: Install dependencies
         working-directory: packages/bff-eval

--- a/.github/workflows/publish-bff-eval-release.yml
+++ b/.github/workflows/publish-bff-eval-release.yml
@@ -18,6 +18,13 @@ jobs:
     name: Build and Publish bff-eval Release
     runs-on: ubuntu-latest
     steps:
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+        with: { determinate: true }
+
+      - name: Setup Nix caching
+        uses: DeterminateSystems/flakehub-cache-action@main
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -28,6 +35,10 @@ jobs:
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org/"
+
+      # Set Deno cache directory
+      - name: Set Deno cache directory
+        run: echo "DENO_DIR=${RUNNER_TEMP}/deno-cache" >> "$GITHUB_ENV"
 
       # Cache node_modules
       - name: Cache dependencies
@@ -41,6 +52,11 @@ jobs:
           key: ${{ runner.os }}-bff-eval-deps-${{ hashFiles('packages/bff-eval/package-lock.json', 'packages/bff-eval/package.json') }}
           restore-keys: |
             ${{ runner.os }}-bff-eval-deps-
+
+      # Build bolt-foundry package first (which bff-eval depends on)
+      - name: Build bolt-foundry package
+        run: |
+          nix develop --impure --command bff build --include-bolt-foundry --skip-barrels --skip-routes --skip-content --skip-config-keys --skip-gql-types --skip-isograph
 
       - name: Install dependencies
         working-directory: packages/bff-eval

--- a/packages/bff-eval/README.md
+++ b/packages/bff-eval/README.md
@@ -20,11 +20,21 @@ across multiple underlying base models.
 
 ## Quickstart
 
-Set your `OPENROUTER_API_KEY` environment variable.
+### Setup
 
-```bash
-npx bff-eval --help
-```
+1. **Get an OpenRouter API Key**:
+   - Sign up for an account at [OpenRouter](https://openrouter.ai)
+   - Generate an API key from your dashboard
+   - Set the environment variable:
+   
+   ```bash
+   export OPENROUTER_API_KEY="your-api-key-here"
+   ```
+
+2. **Install and run**:
+   ```bash
+   npx bff-eval --help
+   ```
 
 Run evaluation with sample data:
 

--- a/packages/bff-eval/dist/src/run-eval.js
+++ b/packages/bff-eval/dist/src/run-eval.js
@@ -1,4 +1,37 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.runEvaluation = runEvaluation;
 function printLine(message) {
@@ -59,7 +92,7 @@ async function runEvaluation(options) {
     try {
         // Load files
         console.log("📁 Loading input file...");
-        const fs = await import("node:fs/promises");
+        const fs = await Promise.resolve().then(() => __importStar(require("node:fs/promises")));
         const inputContent = await fs.readFile(input, 'utf-8');
         console.log(`✅ Loaded input file: ${input}`);
         // Load grader module

--- a/packages/bff-eval/package.json
+++ b/packages/bff-eval/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bff-eval",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Evaluation framework for LLM systems - Node.js CLI",
   "bin": {
     "bff-eval": "dist/bin/bff-eval.js"

--- a/packages/bff-eval/src/run-eval.ts
+++ b/packages/bff-eval/src/run-eval.ts
@@ -156,7 +156,20 @@ export async function runEvaluation(options: RunOptions): Promise<void> {
         });
         
         // Call LLM API via OpenRouter
-        const apiKey = process.env.OPENROUTER_API_KEY || "";
+        const apiKey = process.env.OPENROUTER_API_KEY;
+        
+        if (!apiKey) {
+          throw new Error(
+            `Missing OPENROUTER_API_KEY environment variable.\n\n` +
+            `To use bff-eval, you need to set up an OpenRouter API key:\n` +
+            `1. Sign up for an account at https://openrouter.ai\n` +
+            `2. Generate an API key from your dashboard\n` +
+            `3. Set the environment variable:\n` +
+            `   export OPENROUTER_API_KEY="your-api-key-here"\n\n` +
+            `For more information, visit: https://openrouter.ai/docs`
+          );
+        }
+        
         const response = await fetch(
           `https://openrouter.ai/api/v1/chat/completions`,
           {


### PR DESCRIPTION

When the OPENROUTER_API_KEY environment variable is not set, bff-eval now
provides a clear and actionable error message with setup instructions.

Changes:
- Add validation check for OPENROUTER_API_KEY before making API calls
- Provide detailed error message with setup steps and documentation link
- Update README with more detailed setup instructions for API key

This improves the developer experience by making it immediately clear what's
needed when the API key is missing, rather than failing with a cryptic error.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/1011).
* __->__ #1011
* #1009