### PR TITLE
fix: update npm library references from @bolt-foundry/sdk to @bolt-foundry/bolt-foundry

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -25,10 +25,10 @@ priorities for v0.1 are:
 _For definitions of project phases and priority levels, see
 [WUT](/docs/wut.md#project-phases) and [WUT](/docs/wut.md#priority-system)._
 
-| Priority | Project Name          | Project Phase | Status | Next Milestone            | Description                          | References                                                                                         |
-| -------- | --------------------- | ------------- | ------ | ------------------------- | ------------------------------------ | -------------------------------------------------------------------------------------------------- |
-| P0       | examples              | Alpha         | 🟢     | Add more example patterns | Working examples demonstrating SDK   | [README](../examples/README.md), [NextJS](../examples/nextjs-sample/README.md)                     |
-| P1       | packages/bolt-foundry | Alpha         | 🚀     | Stabilize API interfaces  | Core SDK for AI-powered applications | [NPM](https://www.npmjs.com/package/@bolt-foundry/sdk), [Docs](../packages/bolt-foundry/README.md) |
+| Priority | Project Name          | Project Phase | Status | Next Milestone            | Description                          | References                                                                                                  |
+| -------- | --------------------- | ------------- | ------ | ------------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| P0       | examples              | Alpha         | 🟢     | Add more example patterns | Working examples demonstrating SDK   | [README](../examples/README.md), [NextJS](../examples/nextjs-sample/README.md)                              |
+| P1       | packages/bolt-foundry | Alpha         | 🚀     | Stabilize API interfaces  | Core SDK for AI-powered applications | [NPM](https://www.npmjs.com/package/@bolt-foundry/bolt-foundry), [Docs](../packages/bolt-foundry/README.md) |
 
 ## Other Projects
 

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -49,7 +49,7 @@ The -3 to +3 scoring isn't just about examples - it's about achieving 99% reliab
 Let's build a customer support assistant step by step:
 
 ```typescript
-import { BfClient } from "@bolt-foundry/sdk";
+import { BfClient } from "@bolt-foundry/bolt-foundry";
 
 const client = BfClient.create();
 

--- a/docs/product-plan.md
+++ b/docs/product-plan.md
@@ -52,7 +52,7 @@ const prompt = "You are a customer support agent. Be helpful and empathetic. " +
   "User query: " + userMessage;
 
 // Bolt Foundry approach: Structured, reusable cards
-import { BfClient } from "@bolt-foundry/sdk";
+import { BfClient } from "@bolt-foundry/bolt-foundry";
 
 const client = BfClient.create();
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -5,7 +5,7 @@ Welcome to Bolt Foundry! This quickstart guide will help you get up and running 
 ## Installation
 
 ```bash
-npm install @bolt-foundry/sdk
+npm install @bolt-foundry/bolt-foundry
 ```
 
 ## Your First Structured Prompt
@@ -23,7 +23,7 @@ const prompt = `You are a helpful assistant. Please analyze the sentiment of the
 ### After (Bolt Foundry Approach)
 
 ```typescript
-import { BfClient } from "@bolt-foundry/sdk";
+import { BfClient } from "@bolt-foundry/bolt-foundry";
 
 const client = BfClient.create();
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -40,7 +40,7 @@ Each example demonstrates:
 ## Basic pattern
 
 ```typescript
-import { createDeck } from "@bolt-foundry/sdk";
+import { createDeck } from "@bolt-foundry/bolt-foundry";
 
 const assistantDeck = createDeck("assistant", (b) =>
   b


### PR DESCRIPTION

- Updated installation instructions and import statements across documentation
- Fixed package references in quickstart, getting-started, product-plan, examples README, and status docs
- Corrected NPM package link in STATUS.md

Fixes #1019

Co-authored-by: justicart <justicart@users.noreply.github.com>
