### PR TITLE
Fix outdated documentation in bff-eval package

### DIFF
--- a/docs/evals-overview.md
+++ b/docs/evals-overview.md
@@ -29,8 +29,8 @@ npx bff-eval --help
 Run evaluation with sample data:
 
 ```bash
-npx bff-eval --input packages/bolt-foundry/evals/examples/sample-data.jsonl \
-         --grader packages/bolt-foundry/evals/examples/json-validator.ts
+npx bff-eval --input examples/json-validator/samples.jsonl \
+         --grader examples/json-validator/grader.js
 ```
 
 ## Input data
@@ -71,7 +71,7 @@ To be clear, you SHOULD NOT BE INTERPOLATING ANY STRINGS IN THE SPECS. Use
 `.context` builders to safely include variables.
 
 ```typescript
-import { makeGraderDeckBuilder } from "../makeGraderDeckBuilder.ts";
+import { makeGraderDeckBuilder } from "@bolt-foundry/bolt-foundry";
 
 // Create a grader that evaluates JSON outputs
 export default makeGraderDeckBuilder("json-validator")
@@ -155,7 +155,7 @@ export interface GradingResult {
     notes: "Perfect JSON with correct schema"
   },
   sampleMetadata: {
-    groundTruthScore: 3  // If provided in input
+    score: 3  // If provided in input
   }
 }
 ```
@@ -163,7 +163,7 @@ export interface GradingResult {
 ## Meta Grader Analysis
 
 Bolt Foundry Evals supports "grading the grader" by comparing grader scores
-against ground truth scores. This calibration feature helps you:
+against expected scores. This calibration feature helps you:
 
 1. **Validate Grader Quality**: Ensure your graders score consistently and
    accurately
@@ -171,26 +171,25 @@ against ground truth scores. This calibration feature helps you:
    refinement
 3. **Compare Grader Versions**: Measure improvements when updating graders
 
-### Adding Ground Truth Scores
+### Adding Expected Scores
 
-Include a `groundTruthScore` field in your input samples:
+Include a `score` field in your input samples:
 
 ```jsonl
-{"userMessage": "Extract: name=John", "assistantResponse": "{\"name\":\"John\"}", "groundTruthScore": 3}
-{"userMessage": "Parse: color=red", "assistantResponse": "{'color': 'red'}", "groundTruthScore": 2}
-{"userMessage": "Convert: email=test@test.com", "assistantResponse": "test@test.com", "groundTruthScore": -3}
+{"userMessage": "Extract: name=John", "assistantResponse": "{\"name\":\"John\"}", "score": 3}
+{"userMessage": "Parse: color=red", "assistantResponse": "{'color': 'red'}", "score": 2}
+{"userMessage": "Convert: email=test@test.com", "assistantResponse": "test@test.com", "score": -3}
 ```
 
 ### Calibration Metrics
 
-When ground truth scores are provided, the eval command reports:
+When expected scores are provided, the eval command reports:
 
-- **Exact Match Rate**: Percentage of samples where grader score equals ground
-  truth
-- **Within ±1 Accuracy**: Percentage of samples within 1 point of ground truth
-- **Average Absolute Error**: Mean difference between grader and ground truth
-  scores
-- **Disagreements**: Specific samples where grader and ground truth differ
+- **Exact Match Rate**: Percentage of samples where grader score equals expected
+  score
+- **Within ±1 Accuracy**: Percentage of samples within 1 point of expected score
+- **Average Absolute Error**: Mean difference between grader and expected scores
+- **Disagreements**: Specific samples where grader and expected score differ
 
 ### Example: Improving a JSON Validator
 

--- a/packages/bff-eval/README.md
+++ b/packages/bff-eval/README.md
@@ -39,8 +39,8 @@ across multiple underlying base models.
 Run evaluation with sample data:
 
 ```bash
-npx bff-eval --input packages/bolt-foundry/evals/examples/sample-data.jsonl \
-         --grader packages/bolt-foundry/evals/examples/json-validator.ts
+npx bff-eval --input examples/json-validator/samples.jsonl \
+         --grader examples/json-validator/grader.js
 ```
 
 ### Running Demos
@@ -99,7 +99,7 @@ To be clear, you SHOULD NOT BE INTERPOLATING ANY STRINGS IN THE SPECS. Use
 `.context` builders to safely include variables.
 
 ```typescript
-import { makeGraderDeckBuilder } from "../makeGraderDeckBuilder.ts";
+import { makeGraderDeckBuilder } from "@bolt-foundry/bolt-foundry";
 
 // Create a grader that evaluates JSON outputs
 export default makeGraderDeckBuilder("json-validator")

--- a/packages/bff-eval/docs/demo-flag-spec.md
+++ b/packages/bff-eval/docs/demo-flag-spec.md
@@ -30,7 +30,7 @@ Where `$NAME` is the name of a demo folder in `packages/bff-eval/examples/`. If 
 The `samples.jsonl` file should follow the standard bff-eval format:
 
 ```jsonl
-{"userMessage": "Extract user info from: 'John Doe, 30, NYC'", "assistantResponse": "{\"name\":\"John Doe\",\"age\":30,\"city\":\"NYC\"}", "id": "sample-001", "score": 3, "metadata": {"category": "extraction"}}
+{"userMessage": "Extract user info from: 'John Doe, 30, NYC'", "assistantResponse": "{\"name\":\"John Doe\",\"age\":30,\"city\":\"NYC\"}", "id": "sample-001", "score": 3, "category": "extraction"}
 {"userMessage": "Parse address: '123 Main St'", "assistantResponse": "{\"street\":\"123 Main St\"}", "id": "sample-002", "score": 2}
 ```
 
@@ -38,8 +38,8 @@ Fields:
 - `userMessage` (required): The user's input
 - `assistantResponse` (required): The assistant's response to evaluate
 - `id` (optional): Unique identifier for the sample
-- `score` (optional): Ground truth score for meta-evaluation (-3 to 3)
-- `metadata` (optional): Custom metadata to forward to the reporter
+- `score` (optional): Expected score for meta-evaluation (-3 to 3)
+- Any additional fields are captured in `sampleMetadata` for use in reporting
 
 ## Example
 

--- a/packages/bff-eval/src/cli.ts
+++ b/packages/bff-eval/src/cli.ts
@@ -6,7 +6,7 @@ import * as fs from "node:fs";
 export const cli = yargs(hideBin(process.argv))
   .scriptName("bff-eval")
   .usage("$0 [options]")
-  .version("0.1.1")
+  .version("0.1.2")
   .help()
   .strict()
   .option("input", {


### PR DESCRIPTION

Update bff-eval package documentation to match implementation:

Changes:
- Replace 'groundTruthScore' with 'score' field in docs/evals-overview.md
- Update all references from 'ground truth' to 'expected' scores for consistency
- Fix CLI version from 0.1.1 to 0.1.2 to match package.json
- Correct example paths from packages/bolt-foundry/evals/ to examples/
- Update import statements to use @bolt-foundry/bolt-foundry
- Clarify that custom fields go into sampleMetadata in demo-flag-spec.md

These documentation fixes ensure users have accurate information when using
the meta-evaluation features and running demos.

Test plan:
1. Run demos: bff eval --demo json-validator
2. Verify documentation matches implementation behavior
3. Check that score field works for meta-evaluation

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
