### PR TITLE
Add Relay Connection support to GraphQL builder

### DIFF
--- a/apps/bfDb/builders/graphql/__tests__/gqlSpecToNexus.connection.test.ts
+++ b/apps/bfDb/builders/graphql/__tests__/gqlSpecToNexus.connection.test.ts
@@ -1,0 +1,238 @@
+#! /usr/bin/env -S bff test
+import { assert, assertEquals, assertExists } from "@std/assert";
+import { gqlSpecToNexus } from "../gqlSpecToNexus.ts";
+import type { GqlNodeSpec } from "../makeGqlBuilder.ts";
+import type { Connection, ConnectionArguments } from "graphql-relay";
+
+/** Test node type */
+class TestNode {
+  static name = "TestNode";
+  id: string;
+
+  constructor(id: string) {
+    this.id = id;
+  }
+}
+
+Deno.test("gqlSpecToNexus should process connections", async () => {
+  // Create a spec with a connection
+  const spec: GqlNodeSpec = {
+    fields: {},
+    relations: {},
+    mutations: {},
+    connections: {
+      testNodes: {
+        type: "TestNode",
+        args: {
+          sortDirection: "String",
+        },
+        resolve: (
+          _root: unknown,
+          _args: ConnectionArguments & { sortDirection?: string },
+        ) => {
+          // Access args.first, args.sortDirection
+          return {
+            edges: [],
+            pageInfo: {
+              hasNextPage: false,
+              hasPreviousPage: false,
+              startCursor: null,
+              endCursor: null,
+            },
+          } as Connection<TestNode>;
+        },
+        _targetThunk: () => TestNode,
+      },
+    },
+  };
+
+  const result = await gqlSpecToNexus(spec, "TestType");
+
+  // The mainType definition should process connections
+  assertExists(result.mainType, "Should have mainType");
+
+  // We can't easily test the definition function without mocking Nexus
+  // but we can verify the structure is correct
+  assertEquals(result.mainType.name, "TestType");
+});
+
+Deno.test("gqlSpecToNexus should use connectionField for connections", async () => {
+  let connectionFieldCalled = false;
+  let fieldName: string | undefined;
+  let fieldConfig:
+    | { type?: string; resolve?: unknown; args?: unknown }
+    | undefined;
+
+  // Mock the t object that gets passed to definition
+  const mockT = {
+    connectionField: (
+      name: string,
+      config: { type?: string; resolve?: unknown; args?: unknown },
+    ) => {
+      connectionFieldCalled = true;
+      fieldName = name;
+      fieldConfig = config;
+    },
+    field: () => {}, // Regular fields
+  };
+
+  const spec: GqlNodeSpec = {
+    fields: {},
+    relations: {},
+    mutations: {},
+    connections: {
+      testNodes: {
+        type: "TestNode",
+        args: {
+          sortDirection: "String",
+        },
+        resolve: () => ({
+          edges: [],
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: null,
+            endCursor: null,
+          },
+        }),
+        _targetThunk: () => TestNode,
+      },
+    },
+  };
+
+  const result = await gqlSpecToNexus(spec, "TestType");
+
+  // Call the definition function with our mock
+  if (result.mainType.definition) {
+    result.mainType.definition(mockT);
+  }
+
+  assert(
+    connectionFieldCalled,
+    "Should call t.connectionField for connections",
+  );
+  assertEquals(fieldName, "testNodes", "Should use correct field name");
+  assertExists(fieldConfig?.type, "Should have type in config");
+  assertExists(fieldConfig?.resolve, "Should have resolve in config");
+});
+
+Deno.test("gqlSpecToNexus should pass custom args to connectionField", async () => {
+  let capturedArgs: Record<string, unknown> | undefined;
+
+  const mockT = {
+    connectionField: (
+      _name: string,
+      config: { args?: Record<string, unknown> },
+    ) => {
+      capturedArgs = config.args;
+    },
+    field: () => {},
+  };
+
+  const spec: GqlNodeSpec = {
+    fields: {},
+    relations: {},
+    mutations: {},
+    connections: {
+      testNodes: {
+        type: "TestNode",
+        args: {
+          sortDirection: "String",
+          includeArchived: "Boolean",
+        },
+        resolve: () => ({
+          edges: [],
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: null,
+            endCursor: null,
+          },
+        }),
+        _targetThunk: () => TestNode,
+      },
+    },
+  };
+
+  const result = await gqlSpecToNexus(spec, "TestType");
+
+  if (result.mainType.definition) {
+    result.mainType.definition(mockT);
+  }
+
+  assertExists(capturedArgs, "Should pass args to connectionField");
+  assert(
+    "sortDirection" in capturedArgs,
+    "Should include custom sortDirection arg",
+  );
+  assert(
+    "includeArchived" in capturedArgs,
+    "Should include custom includeArchived arg",
+  );
+});
+
+Deno.test("gqlSpecToNexus should resolve target type from thunk", async () => {
+  const spec: GqlNodeSpec = {
+    fields: {},
+    relations: {},
+    mutations: {},
+    connections: {
+      testNodes: {
+        type: "PENDING_TestType_testNodes", // Should be resolved
+        args: {},
+        resolve: () => ({
+          edges: [],
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: null,
+            endCursor: null,
+          },
+        }),
+        _targetThunk: () => TestNode,
+        _pendingTypeResolution: true,
+      },
+    },
+  };
+
+  const _result = await gqlSpecToNexus(spec, "TestType");
+
+  // After processing, the type should be resolved
+  const connection = spec.connections?.testNodes;
+  assertEquals(connection?.type, "TestNode", "Should resolve type from thunk");
+});
+
+Deno.test("gqlSpecToNexus should handle async target thunks", async () => {
+  const spec: GqlNodeSpec = {
+    fields: {},
+    relations: {},
+    mutations: {},
+    connections: {
+      testNodes: {
+        type: "PENDING_TestType_testNodes",
+        args: {},
+        resolve: () => ({
+          edges: [],
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: null,
+            endCursor: null,
+          },
+        }),
+        _targetThunk: async () => {
+          // Simulate dynamic import
+          await new Promise((resolve) => setTimeout(resolve, 1));
+          return TestNode;
+        },
+        _pendingTypeResolution: true,
+      },
+    },
+  };
+
+  const _result = await gqlSpecToNexus(spec, "TestType");
+
+  // Type should be resolved even with async thunk
+  const connection = spec.connections?.testNodes;
+  assertEquals(connection?.type, "TestNode", "Should handle async thunk");
+});

--- a/apps/bfDb/builders/graphql/__tests__/makeGqlBuilder.connection.test.ts
+++ b/apps/bfDb/builders/graphql/__tests__/makeGqlBuilder.connection.test.ts
@@ -1,0 +1,232 @@
+#! /usr/bin/env -S bff test
+import { assert, assertEquals, assertExists } from "@std/assert";
+import { makeGqlBuilder } from "../makeGqlBuilder.ts";
+import type { Connection, ConnectionArguments } from "graphql-relay";
+
+/** Test type to use as connection target */
+class TestNode {
+  static name = "TestNode";
+  id: string;
+
+  constructor(id: string) {
+    this.id = id;
+  }
+}
+
+/** Helper to reach into the builder's private spec */
+const specOf = <T extends Record<string, unknown>>(b: unknown): T => {
+  type WithSpec = { _spec: T };
+  return (b as WithSpec)._spec;
+};
+
+type ConnectionSpec = {
+  type: string;
+  args?: Record<string, unknown>;
+  resolve?: (...args: unknown[]) => unknown;
+  _targetThunk?: () => unknown;
+};
+
+interface BuilderSpec extends Record<string, unknown> {
+  fields: Record<string, unknown>;
+  mutations: Record<string, unknown>;
+  relations: Record<string, unknown>;
+  connections?: Record<string, ConnectionSpec>;
+}
+
+Deno.test("gqlBuilder should have connection method", () => {
+  const builder = makeGqlBuilder();
+
+  // Test that connection method exists
+  assert(
+    "connection" in builder,
+    "Builder should have connection method",
+  );
+
+  assert(
+    typeof builder.connection === "function",
+    "connection should be a function",
+  );
+});
+
+Deno.test("connection method should accept name, targetThunk, and options", () => {
+  const builder = makeGqlBuilder();
+
+  // This test will fail until we implement the connection method
+  try {
+    builder.connection("testNodes", () => TestNode, {
+      resolve: (_root, _args: ConnectionArguments) => {
+        return {
+          edges: [],
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: null,
+            endCursor: null,
+          },
+        } as Connection<TestNode>;
+      },
+    });
+
+    // If we get here without error, the method signature is correct
+    assert(true, "connection method accepts expected parameters");
+  } catch (error) {
+    throw new Error(`connection method failed: ${error.message}`);
+  }
+});
+
+Deno.test("connection method should return builder for chaining", () => {
+  const builder = makeGqlBuilder();
+
+  // Test method chaining
+  const result = builder
+    .string("name")
+    .connection("testNodes", () => TestNode, {
+      resolve: () => ({
+        edges: [],
+        pageInfo: {
+          hasNextPage: false,
+          hasPreviousPage: false,
+          startCursor: null,
+          endCursor: null,
+        },
+      } as Connection<TestNode>),
+    })
+    .int("count");
+
+  // Should return the same builder instance
+  assertEquals(
+    result,
+    builder,
+    "connection should return builder for chaining",
+  );
+});
+
+Deno.test("connection should store spec in connections property", () => {
+  const builder = makeGqlBuilder();
+
+  const resolver = (_root: unknown, _args: ConnectionArguments) => ({
+    edges: [],
+    pageInfo: {
+      hasNextPage: false,
+      hasPreviousPage: false,
+      startCursor: null,
+      endCursor: null,
+    },
+  } as Connection<TestNode>);
+
+  builder.connection("testNodes", () => TestNode, {
+    resolve: resolver,
+  });
+
+  const spec = specOf<BuilderSpec>(builder);
+
+  // Check that connections property exists
+  assertExists(spec.connections, "spec should have connections property");
+
+  // Check that our connection was stored
+  assert(
+    "testNodes" in spec.connections,
+    "connections should contain testNodes",
+  );
+
+  const connectionSpec = spec.connections.testNodes;
+  assertEquals(
+    connectionSpec.type,
+    "testNodes",
+    "Should store field name as initial type",
+  );
+  assertEquals(connectionSpec.resolve, resolver, "Should store resolver");
+  assertExists(connectionSpec._targetThunk, "Should store target thunk");
+  assertEquals(
+    connectionSpec._pendingTypeResolution,
+    true,
+    "Should mark for type resolution",
+  );
+});
+
+Deno.test("connection should support custom args", () => {
+  const builder = makeGqlBuilder();
+
+  builder.connection("testNodes", () => TestNode, {
+    args: (a) =>
+      a
+        .string("sortDirection")
+        .boolean("includeArchived"),
+    resolve: (
+      _root,
+      _args: ConnectionArguments & {
+        sortDirection?: string;
+        includeArchived?: boolean;
+      },
+    ) => {
+      // Resolver can access both Relay args and custom args
+      // Access args.first, args.sortDirection, args.includeArchived
+      return {
+        edges: [],
+        pageInfo: {
+          hasNextPage: false,
+          hasPreviousPage: false,
+          startCursor: null,
+          endCursor: null,
+        },
+      } as Connection<TestNode>;
+    },
+  });
+
+  const spec = specOf<BuilderSpec>(builder);
+  const connectionSpec = spec.connections?.testNodes;
+
+  assertExists(connectionSpec?.args, "Connection should have args");
+  assert(
+    "sortDirection" in connectionSpec.args,
+    "Should have sortDirection arg",
+  );
+  assert(
+    "includeArchived" in connectionSpec.args,
+    "Should have includeArchived arg",
+  );
+});
+
+Deno.test("connection resolver should be required", () => {
+  const builder = makeGqlBuilder();
+
+  // Test that resolver is required - this might need adjustment based on implementation
+  try {
+    // @ts-expect-error - Testing that resolver is required
+    builder.connection("testNodes", () => TestNode);
+    throw new Error("Should require resolver");
+  } catch (error) {
+    assert(
+      error.message.includes("resolver") || error.message.includes("required"),
+      "Should throw error about missing resolver",
+    );
+  }
+});
+
+Deno.test("connection should work with async thunk", () => {
+  const builder = makeGqlBuilder();
+
+  // Test with async import pattern
+  builder.connection(
+    "testNodes",
+    async () => {
+      // Simulate dynamic import
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      return TestNode;
+    },
+    {
+      resolve: () => ({
+        edges: [],
+        pageInfo: {
+          hasNextPage: false,
+          hasPreviousPage: false,
+          startCursor: null,
+          endCursor: null,
+        },
+      } as Connection<TestNode>),
+    },
+  );
+
+  const spec = specOf<BuilderSpec>(builder);
+  assertExists(spec.connections?.testNodes, "Should handle async thunk");
+});

--- a/apps/bfDb/builders/graphql/makeGqlSpec.ts
+++ b/apps/bfDb/builders/graphql/makeGqlSpec.ts
@@ -22,10 +22,11 @@ export function makeGqlSpec(
   // Run the builder function with nonNull support
   build(gqlBuilder);
 
-  // Return the built spec, including mutations
+  // Return the built spec, including mutations and connections
   return {
     fields: gqlBuilder._spec.fields,
     relations: gqlBuilder._spec.relations,
     mutations: gqlBuilder._spec.mutations,
+    connections: gqlBuilder._spec.connections,
   };
 }

--- a/apps/bfDb/builders/graphql/types/nexusTypes.ts
+++ b/apps/bfDb/builders/graphql/types/nexusTypes.ts
@@ -74,6 +74,20 @@ export interface GqlMutationDef {
 }
 
 /**
+ * Connection definition from the GQL spec
+ * Represents a Relay-style connection field with pagination
+ */
+export interface GqlConnectionDef {
+  type: string;
+  description?: string;
+  args?: Record<string, unknown>;
+  resolve: GqlFieldResolver; // Required for connections
+  // deno-lint-ignore no-explicit-any
+  _targetThunk?: () => any;
+  _pendingTypeResolution?: boolean;
+}
+
+/**
  * Type-safe replacement for Nexus object definition function parameter
  * This represents the 't' parameter in Nexus type definitions
  */

--- a/apps/bfDb/graphql/__generated__/_nexustypes.ts
+++ b/apps/bfDb/graphql/__generated__/_nexustypes.ts
@@ -47,12 +47,28 @@ export interface NexusGenObjects {
   BfOrganization: {};
   BfPerson: {};
   BlogPost: {};
+  BlogPostConnection: { // root type
+    count?: number | null; // Int
+    edges?: Array<NexusGenRootTypes['BlogPostEdge'] | null> | null; // [BlogPostEdge]
+    nodes?: Array<NexusGenRootTypes['BlogPost'] | null> | null; // [BlogPost]
+    pageInfo: NexusGenRootTypes['PageInfo']; // PageInfo!
+  }
+  BlogPostEdge: { // root type
+    cursor: string; // String!
+    node?: NexusGenRootTypes['BlogPost'] | null; // BlogPost
+  }
   GithubRepoStats: {};
   JoinWaitlistPayload: { // root type
     message?: string | null; // String
     success: boolean; // Boolean!
   }
   Mutation: {};
+  PageInfo: { // root type
+    endCursor?: string | null; // String
+    hasNextPage: boolean; // Boolean!
+    hasPreviousPage: boolean; // Boolean!
+    startCursor?: string | null; // String
+  }
   PublishedDocument: {};
   Query: {};
   Waitlist: {};
@@ -87,6 +103,16 @@ export interface NexusGenFieldTypes {
     content: string; // String!
     id: string; // ID!
   }
+  BlogPostConnection: { // field return type
+    count: number | null; // Int
+    edges: Array<NexusGenRootTypes['BlogPostEdge'] | null> | null; // [BlogPostEdge]
+    nodes: Array<NexusGenRootTypes['BlogPost'] | null> | null; // [BlogPost]
+    pageInfo: NexusGenRootTypes['PageInfo']; // PageInfo!
+  }
+  BlogPostEdge: { // field return type
+    cursor: string; // String!
+    node: NexusGenRootTypes['BlogPost'] | null; // BlogPost
+  }
   GithubRepoStats: { // field return type
     id: string; // ID!
     stars: number; // Int!
@@ -98,12 +124,19 @@ export interface NexusGenFieldTypes {
   Mutation: { // field return type
     joinWaitlist: NexusGenRootTypes['JoinWaitlistPayload'] | null; // JoinWaitlistPayload
   }
+  PageInfo: { // field return type
+    endCursor: string | null; // String
+    hasNextPage: boolean; // Boolean!
+    hasPreviousPage: boolean; // Boolean!
+    startCursor: string | null; // String
+  }
   PublishedDocument: { // field return type
     content: string; // String!
     id: string; // ID!
   }
   Query: { // field return type
     blogPost: NexusGenRootTypes['BlogPost'] | null; // BlogPost
+    blogPosts: NexusGenRootTypes['BlogPostConnection'] | null; // BlogPostConnection
     documentsBySlug: NexusGenRootTypes['PublishedDocument'] | null; // PublishedDocument
     githubRepoStats: NexusGenRootTypes['GithubRepoStats'] | null; // GithubRepoStats
     ok: boolean | null; // Boolean
@@ -136,6 +169,16 @@ export interface NexusGenFieldTypeNames {
     content: 'String'
     id: 'ID'
   }
+  BlogPostConnection: { // field return type name
+    count: 'Int'
+    edges: 'BlogPostEdge'
+    nodes: 'BlogPost'
+    pageInfo: 'PageInfo'
+  }
+  BlogPostEdge: { // field return type name
+    cursor: 'String'
+    node: 'BlogPost'
+  }
   GithubRepoStats: { // field return type name
     id: 'ID'
     stars: 'Int'
@@ -147,12 +190,19 @@ export interface NexusGenFieldTypeNames {
   Mutation: { // field return type name
     joinWaitlist: 'JoinWaitlistPayload'
   }
+  PageInfo: { // field return type name
+    endCursor: 'String'
+    hasNextPage: 'Boolean'
+    hasPreviousPage: 'Boolean'
+    startCursor: 'String'
+  }
   PublishedDocument: { // field return type name
     content: 'String'
     id: 'ID'
   }
   Query: { // field return type name
     blogPost: 'BlogPost'
+    blogPosts: 'BlogPostConnection'
     documentsBySlug: 'PublishedDocument'
     githubRepoStats: 'GithubRepoStats'
     ok: 'Boolean'
@@ -179,6 +229,14 @@ export interface NexusGenArgTypes {
   Query: {
     blogPost: { // args
       slug?: string | null; // String
+    }
+    blogPosts: { // args
+      after?: string | null; // String
+      before?: string | null; // String
+      filterByYear?: string | null; // String
+      first?: number | null; // Int
+      last?: number | null; // Int
+      sortDirection?: string | null; // String
     }
     documentsBySlug: { // args
       slug?: string | null; // String

--- a/apps/bfDb/graphql/__generated__/schema.graphql
+++ b/apps/bfDb/graphql/__generated__/schema.graphql
@@ -28,6 +28,31 @@ type BlogPost {
   id: ID!
 }
 
+type BlogPostConnection {
+  count: Int
+
+  """
+  https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types
+  """
+  edges: [BlogPostEdge]
+
+  """Flattened list of BlogPost type"""
+  nodes: [BlogPost]
+
+  """
+  https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
+  """
+  pageInfo: PageInfo!
+}
+
+type BlogPostEdge {
+  """https://facebook.github.io/relay/graphql/connections.htm#sec-Cursor"""
+  cursor: String!
+
+  """https://facebook.github.io/relay/graphql/connections.htm#sec-Node"""
+  node: BlogPost
+}
+
 type GithubRepoStats {
   id: ID!
   stars: Int!
@@ -47,6 +72,31 @@ interface Node {
   id: ID!
 }
 
+"""
+PageInfo cursor, as defined in https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
+"""
+type PageInfo {
+  """
+  The cursor corresponding to the last nodes in edges. Null if the connection is empty.
+  """
+  endCursor: String
+
+  """
+  Used to indicate whether more edges exist following the set defined by the clients arguments.
+  """
+  hasNextPage: Boolean!
+
+  """
+  Used to indicate whether more edges exist prior to the set defined by the clients arguments.
+  """
+  hasPreviousPage: Boolean!
+
+  """
+  The cursor corresponding to the first nodes in edges. Null if the connection is empty.
+  """
+  startCursor: String
+}
+
 type PublishedDocument {
   content: String!
   id: ID!
@@ -54,6 +104,21 @@ type PublishedDocument {
 
 type Query {
   blogPost(slug: String): BlogPost
+  blogPosts(
+    """Returns the elements in the list that come after the specified cursor"""
+    after: String
+
+    """Returns the elements in the list that come before the specified cursor"""
+    before: String
+    filterByYear: String
+
+    """Returns the first n elements from the list."""
+    first: Int
+
+    """Returns the last n elements from the list."""
+    last: Int
+    sortDirection: String
+  ): BlogPostConnection
   documentsBySlug(slug: String): PublishedDocument
   githubRepoStats: GithubRepoStats
   ok: Boolean

--- a/apps/bfDb/graphql/__tests__/BlogPost.connection.test.ts
+++ b/apps/bfDb/graphql/__tests__/BlogPost.connection.test.ts
@@ -1,0 +1,268 @@
+#! /usr/bin/env -S bff test
+import { assert, assertEquals, assertExists } from "@std/assert";
+import { graphql } from "graphql";
+import { buildTestSchema } from "./TestHelpers.test.ts";
+import { createContext } from "../graphqlContext.ts";
+
+// Helper to execute GraphQL queries
+async function executeQuery(
+  query: string,
+  variableValues?: Record<string, unknown>,
+) {
+  const schema = await buildTestSchema();
+  const mockRequest = new Request("http://localhost/graphql", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+  });
+
+  using ctx = await createContext(mockRequest);
+
+  return await graphql({
+    schema,
+    source: query,
+    variableValues,
+    contextValue: ctx,
+  });
+}
+
+// Create some test blog posts
+async function setupTestPosts() {
+  const testDir = "docs/blog";
+  await Deno.mkdir(testDir, { recursive: true });
+
+  const posts = [
+    {
+      id: "2025-01-test-latest",
+      content: "# Latest Post\n\nThis is the latest test post.",
+    },
+    {
+      id: "2024-12-test-second",
+      content: "# Second Post\n\nThis is the second test post.",
+    },
+    {
+      id: "2024-11-test-third",
+      content: "# Third Post\n\nThis is the third test post.",
+    },
+  ];
+
+  for (const post of posts) {
+    await Deno.writeTextFile(`${testDir}/${post.id}.md`, post.content);
+  }
+
+  return posts;
+}
+
+async function cleanupTestPosts() {
+  const testDir = "docs/blog";
+  for await (const entry of Deno.readDir(testDir)) {
+    if (entry.name.includes("test-")) {
+      await Deno.remove(`${testDir}/${entry.name}`);
+    }
+  }
+}
+
+Deno.test("GraphQL blogPosts connection query should return paginated results", async () => {
+  await setupTestPosts();
+
+  try {
+    const query = `
+      query BlogPostsConnection {
+        blogPosts(first: 2) {
+          pageInfo {
+            hasNextPage
+            hasPreviousPage
+            startCursor
+            endCursor
+          }
+          edges {
+            cursor
+            node {
+              id
+              content
+            }
+          }
+          nodes {
+            id
+          }
+        }
+      }
+    `;
+
+    const result = await executeQuery(query);
+
+    assertExists(result.data, "Query should return data");
+    assertExists(result.data.blogPosts, "Should have blogPosts field");
+
+    const connection = result.data.blogPosts;
+    assertExists(connection.pageInfo, "Should have pageInfo");
+    assertExists(connection.edges, "Should have edges");
+    assertExists(connection.nodes, "Should have nodes");
+
+    // Check pagination info - we have at least 3 test posts plus any existing ones
+    assertEquals(
+      connection.pageInfo.hasPreviousPage,
+      false,
+      "Should not have previous page",
+    );
+    assertExists(connection.pageInfo.startCursor, "Should have start cursor");
+    assertExists(connection.pageInfo.endCursor, "Should have end cursor");
+
+    // Check edges
+    assertEquals(connection.edges.length, 2, "Should return 2 edges");
+    // Since we're ordering DESC by default, check that first edge is newer than second
+    const firstId = connection.edges[0].node.id;
+    const secondId = connection.edges[1].node.id;
+    assert(
+      firstId > secondId,
+      `First post (${firstId}) should be newer than second (${secondId})`,
+    );
+    assertExists(connection.edges[0].cursor, "Each edge should have cursor");
+    assertExists(connection.edges[1].cursor, "Each edge should have cursor");
+
+    // Check nodes shortcut
+    assertEquals(connection.nodes.length, 2, "Should return 2 nodes");
+  } finally {
+    await cleanupTestPosts();
+  }
+});
+
+Deno.test("GraphQL blogPosts connection should handle 'after' cursor", async () => {
+  await setupTestPosts();
+
+  try {
+    // First get initial results to get a cursor
+    const firstQuery = `
+      query FirstPage {
+        blogPosts(first: 1) {
+          edges {
+            cursor
+            node {
+              id
+            }
+          }
+        }
+      }
+    `;
+
+    const firstResult = await executeQuery(firstQuery);
+
+    const afterCursor = firstResult.data?.blogPosts?.edges[0]?.cursor;
+    assertExists(afterCursor, "Should get cursor from first query");
+    const firstId = firstResult.data?.blogPosts?.edges[0]?.node?.id;
+
+    // Now query with after cursor
+    const query = `
+      query NextPage($after: String) {
+        blogPosts(first: 2, after: $after) {
+          pageInfo {
+            hasNextPage
+            hasPreviousPage
+          }
+          edges {
+            node {
+              id
+            }
+          }
+        }
+      }
+    `;
+
+    const result = await executeQuery(query, { after: afterCursor });
+
+    assertExists(result.data?.blogPosts, "Should have blogPosts");
+    const connection = result.data.blogPosts;
+
+    assert(connection.edges.length > 0, "Should return edges");
+    // Verify we skipped the first post
+    assert(
+      connection.edges[0].node.id !== firstId,
+      "Should skip the first post",
+    );
+    // hasPreviousPage might be true or false depending on cursor implementation
+  } finally {
+    await cleanupTestPosts();
+  }
+});
+
+Deno.test("GraphQL blogPosts connection should handle 'last' argument", async () => {
+  await setupTestPosts();
+
+  try {
+    const query = `
+      query LastPosts {
+        blogPosts(last: 2) {
+          pageInfo {
+            hasNextPage
+            hasPreviousPage
+          }
+          edges {
+            node {
+              id
+            }
+          }
+        }
+      }
+    `;
+
+    const result = await executeQuery(query);
+
+    assertExists(result.data?.blogPosts, "Should have blogPosts");
+    const connection = result.data.blogPosts;
+
+    assertEquals(connection.edges.length, 2, "Should return 2 edges");
+    assertEquals(
+      connection.edges[0].node.id,
+      "2024-12-test-second",
+      "Should be second post",
+    );
+    assertEquals(
+      connection.edges[1].node.id,
+      "2024-11-test-third",
+      "Should be third post",
+    );
+    assertEquals(
+      connection.pageInfo.hasNextPage,
+      false,
+      "Should not have next page",
+    );
+    assertEquals(
+      connection.pageInfo.hasPreviousPage,
+      true,
+      "Should have previous page",
+    );
+  } finally {
+    await cleanupTestPosts();
+  }
+});
+
+Deno.test("GraphQL blogPosts connection should return all with no pagination args", async () => {
+  await setupTestPosts();
+
+  try {
+    // Query without first/last should return all posts
+    const query = `
+      query AllPosts {
+        blogPosts {
+          edges {
+            node {
+              id
+            }
+          }
+        }
+      }
+    `;
+
+    const result = await executeQuery(query);
+
+    assertExists(result.data?.blogPosts, "Should have blogPosts field");
+    const connection = result.data.blogPosts;
+
+    // Should have at least our 3 test posts
+    assert(
+      connection.edges.length >= 3,
+      `Should have at least 3 posts, got ${connection.edges.length}`,
+    );
+  } finally {
+    await cleanupTestPosts();
+  }
+});

--- a/apps/bfDb/graphql/__tests__/BlogPost.customArgs.test.ts
+++ b/apps/bfDb/graphql/__tests__/BlogPost.customArgs.test.ts
@@ -1,0 +1,215 @@
+#! /usr/bin/env -S bff test
+import { assert, assertEquals, assertExists } from "@std/assert";
+import { graphql } from "graphql";
+import { buildTestSchema } from "./TestHelpers.test.ts";
+import { createContext } from "../graphqlContext.ts";
+
+// Helper to execute GraphQL queries
+async function executeQuery(
+  query: string,
+  variableValues?: Record<string, unknown>,
+) {
+  const schema = await buildTestSchema();
+  const mockRequest = new Request("http://localhost/graphql", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+  });
+
+  using ctx = await createContext(mockRequest);
+
+  return await graphql({
+    schema,
+    source: query,
+    variableValues,
+    contextValue: ctx,
+  });
+}
+
+// Create some test blog posts
+async function setupTestPosts() {
+  const testDir = "docs/blog";
+  await Deno.mkdir(testDir, { recursive: true });
+
+  const posts = [
+    {
+      id: "2025-01-custom-latest",
+      content: "# Latest Post\n\nThis is the latest test post.",
+    },
+    {
+      id: "2024-12-custom-second",
+      content: "# Second Post\n\nThis is the second test post.",
+    },
+    {
+      id: "2024-11-custom-third",
+      content: "# Third Post\n\nThis is the third test post.",
+    },
+    {
+      id: "2023-10-custom-old",
+      content: "# Old Post\n\nThis is an old test post.",
+    },
+  ];
+
+  for (const post of posts) {
+    await Deno.writeTextFile(`${testDir}/${post.id}.md`, post.content);
+  }
+
+  return posts;
+}
+
+async function cleanupTestPosts() {
+  const testDir = "docs/blog";
+  for await (const entry of Deno.readDir(testDir)) {
+    if (entry.name.includes("custom-")) {
+      await Deno.remove(`${testDir}/${entry.name}`);
+    }
+  }
+}
+
+Deno.test("GraphQL blogPosts connection should support sortDirection argument", async () => {
+  await setupTestPosts();
+
+  try {
+    // Query with ASC sort direction
+    const ascQuery = `
+      query AscendingPosts {
+        blogPosts(first: 3, sortDirection: "ASC") {
+          edges {
+            node {
+              id
+            }
+          }
+        }
+      }
+    `;
+
+    const ascResult = await executeQuery(ascQuery);
+    assertExists(ascResult.data?.blogPosts, "Should have blogPosts field");
+
+    const ascEdges = ascResult.data.blogPosts.edges;
+    assert(ascEdges.length > 0, "Should have edges");
+
+    // Verify ascending order
+    for (let i = 1; i < ascEdges.length; i++) {
+      const prevId = ascEdges[i - 1].node.id;
+      const currId = ascEdges[i].node.id;
+      assert(
+        prevId < currId,
+        `Posts should be in ascending order: ${prevId} < ${currId}`,
+      );
+    }
+
+    // Query with DESC sort direction
+    const descQuery = `
+      query DescendingPosts {
+        blogPosts(first: 3, sortDirection: "DESC") {
+          edges {
+            node {
+              id
+            }
+          }
+        }
+      }
+    `;
+
+    const descResult = await executeQuery(descQuery);
+    const descEdges = descResult.data.blogPosts.edges;
+
+    // Verify descending order
+    for (let i = 1; i < descEdges.length; i++) {
+      const prevId = descEdges[i - 1].node.id;
+      const currId = descEdges[i].node.id;
+      assert(
+        prevId > currId,
+        `Posts should be in descending order: ${prevId} > ${currId}`,
+      );
+    }
+  } finally {
+    await cleanupTestPosts();
+  }
+});
+
+Deno.test("GraphQL blogPosts connection should support filterByYear argument", async () => {
+  await setupTestPosts();
+
+  try {
+    // Query for 2024 posts only
+    const query = `
+      query FilteredByYear {
+        blogPosts(first: 10, filterByYear: "2024") {
+          edges {
+            node {
+              id
+            }
+          }
+        }
+      }
+    `;
+
+    const result = await executeQuery(query);
+    assertExists(result.data?.blogPosts, "Should have blogPosts field");
+
+    const edges = result.data.blogPosts.edges;
+    assertEquals(edges.length, 2, "Should have exactly 2 posts from 2024");
+
+    // Verify all posts are from 2024
+    for (const edge of edges) {
+      assert(
+        edge.node.id.startsWith("2024"),
+        `Post ${edge.node.id} should be from 2024`,
+      );
+    }
+
+    // Verify the specific posts
+    const ids = edges.map((e: { node: { id: string } }) => e.node.id);
+    assert(
+      ids.includes("2024-12-custom-second"),
+      "Should include December 2024 post",
+    );
+    assert(
+      ids.includes("2024-11-custom-third"),
+      "Should include November 2024 post",
+    );
+  } finally {
+    await cleanupTestPosts();
+  }
+});
+
+Deno.test("GraphQL schema introspection should show custom args", async () => {
+  const query = `
+    query IntrospectBlogPosts {
+      __type(name: "Query") {
+        fields {
+          name
+          args {
+            name
+            type {
+              name
+              kind
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const result = await executeQuery(query);
+  assertExists(result.data?.__type, "Should have type introspection");
+
+  const queryFields = result.data.__type.fields;
+  const blogPostsField = queryFields.find((f: { name: string }) =>
+    f.name === "blogPosts"
+  );
+  assertExists(blogPostsField, "Should have blogPosts field");
+
+  const argNames = blogPostsField.args.map((a: { name: string }) => a.name);
+
+  // Should have standard Relay args
+  assert(argNames.includes("first"), "Should have first arg");
+  assert(argNames.includes("last"), "Should have last arg");
+  assert(argNames.includes("after"), "Should have after arg");
+  assert(argNames.includes("before"), "Should have before arg");
+
+  // Should have custom args
+  assert(argNames.includes("sortDirection"), "Should have sortDirection arg");
+  assert(argNames.includes("filterByYear"), "Should have filterByYear arg");
+});

--- a/apps/bfDb/graphql/__tests__/TestHelpers.test.ts
+++ b/apps/bfDb/graphql/__tests__/TestHelpers.test.ts
@@ -5,12 +5,13 @@
  */
 
 import { makeSchema } from "nexus";
-import { loadGqlTypes } from "../loadGqlTypes.ts";
 import { graphql } from "graphql";
 import { createContext } from "../graphqlContext.ts";
+import { getSchemaOptions } from "../schemaConfig.ts";
 
 export async function buildTestSchema() {
-  return makeSchema({ types: await loadGqlTypes() });
+  const schemaOptions = await getSchemaOptions();
+  return makeSchema(schemaOptions);
 }
 
 export async function testQuery(options: { query: string }) {

--- a/apps/bfDb/graphql/roots/Query.ts
+++ b/apps/bfDb/graphql/roots/Query.ts
@@ -23,6 +23,25 @@ export class Query extends GraphQLObjectBase {
           return post;
         },
       })
+      .connection("blogPosts", () => BlogPost, {
+        args: (a) =>
+          a
+            .string("sortDirection")
+            .string("filterByYear"),
+        resolve: async (_root, args, _ctx) => {
+          // Default to reverse chronological order
+          const sortDir = (args.sortDirection as "ASC" | "DESC") || "DESC";
+          const posts = await BlogPost.listAll(sortDir);
+
+          // Apply year filter if provided
+          const filtered = args.filterByYear
+            ? posts.filter((p) => p.id.startsWith(args.filterByYear as string))
+            : posts;
+
+          // Return relay connection
+          return BlogPost.connection(filtered, args);
+        },
+      })
       .object("githubRepoStats", () => GithubRepoStats, {
         resolve: async () => {
           return await GithubRepoStats.findX();

--- a/apps/bfDb/nodeTypes/__tests__/BlogPost.connection.test.ts
+++ b/apps/bfDb/nodeTypes/__tests__/BlogPost.connection.test.ts
@@ -1,0 +1,112 @@
+#! /usr/bin/env -S bff test
+import { assertEquals, assertExists } from "@std/assert";
+import { BlogPost } from "../BlogPost.ts";
+import type { ConnectionArguments } from "graphql-relay";
+
+// Mock blog posts for testing
+const mockPosts = [
+  new BlogPost("2025-01-latest", "Latest content"),
+  new BlogPost("2024-12-second", "Second content"),
+  new BlogPost("2024-11-third", "Third content"),
+  new BlogPost("2024-10-fourth", "Fourth content"),
+  new BlogPost("2024-09-fifth", "Fifth content"),
+];
+
+Deno.test("BlogPost.connection() should return a valid connection with edges and pageInfo", async () => {
+  const args: ConnectionArguments = { first: 3 };
+  const connection = await BlogPost.connection(mockPosts, args);
+
+  assertExists(connection, "Connection should exist");
+  assertExists(connection.edges, "Connection should have edges");
+  assertExists(connection.pageInfo, "Connection should have pageInfo");
+
+  assertEquals(connection.edges.length, 3, "Should return 3 edges");
+  assertEquals(connection.edges[0].node.id, "2025-01-latest");
+  assertEquals(connection.edges[1].node.id, "2024-12-second");
+  assertEquals(connection.edges[2].node.id, "2024-11-third");
+
+  assertExists(connection.edges[0].cursor, "Each edge should have a cursor");
+  assertEquals(connection.pageInfo.hasNextPage, true, "Should have next page");
+  assertEquals(
+    connection.pageInfo.hasPreviousPage,
+    false,
+    "Should not have previous page",
+  );
+});
+
+Deno.test("BlogPost.connection() should handle last argument", async () => {
+  const args: ConnectionArguments = { last: 2 };
+  const connection = await BlogPost.connection(mockPosts, args);
+
+  assertEquals(connection.edges.length, 2, "Should return 2 edges");
+  assertEquals(connection.edges[0].node.id, "2024-10-fourth");
+  assertEquals(connection.edges[1].node.id, "2024-09-fifth");
+
+  assertEquals(
+    connection.pageInfo.hasNextPage,
+    false,
+    "Should not have next page",
+  );
+  assertEquals(
+    connection.pageInfo.hasPreviousPage,
+    true,
+    "Should have previous page",
+  );
+});
+
+Deno.test("BlogPost.connection() should handle after cursor", async () => {
+  // First get a connection to get a cursor
+  const firstConn = await BlogPost.connection(mockPosts, { first: 2 });
+  const afterCursor = firstConn.edges[1].cursor;
+
+  // Now use that cursor
+  const args: ConnectionArguments = { first: 2, after: afterCursor };
+  const connection = await BlogPost.connection(mockPosts, args);
+
+  assertEquals(connection.edges.length, 2, "Should return 2 edges");
+  assertEquals(connection.edges[0].node.id, "2024-11-third");
+  assertEquals(connection.edges[1].node.id, "2024-10-fourth");
+});
+
+Deno.test("BlogPost.connection() should handle before cursor", async () => {
+  // First get a connection to get cursors
+  const firstConn = await BlogPost.connection(mockPosts, { first: 5 });
+  const beforeCursor = firstConn.edges[3].cursor; // Fourth item
+
+  // Now use that cursor
+  const args: ConnectionArguments = { last: 2, before: beforeCursor };
+  const connection = await BlogPost.connection(mockPosts, args);
+
+  assertEquals(connection.edges.length, 2, "Should return 2 edges");
+  assertEquals(connection.edges[0].node.id, "2024-12-second");
+  assertEquals(connection.edges[1].node.id, "2024-11-third");
+});
+
+Deno.test("BlogPost.connection() should handle empty array", async () => {
+  const args: ConnectionArguments = { first: 10 };
+  const connection = await BlogPost.connection([], args);
+
+  assertEquals(connection.edges.length, 0, "Should return no edges");
+  assertEquals(connection.pageInfo.hasNextPage, false);
+  assertEquals(connection.pageInfo.hasPreviousPage, false);
+  assertEquals(
+    connection.pageInfo.startCursor,
+    null,
+    "Start cursor should be null for empty connection",
+  );
+  assertEquals(
+    connection.pageInfo.endCursor,
+    null,
+    "End cursor should be null for empty connection",
+  );
+});
+
+Deno.test("BlogPost.connection() should handle no pagination args", async () => {
+  // When no first/last is provided, should return all items
+  const args: ConnectionArguments = {};
+  const connection = await BlogPost.connection(mockPosts, args);
+
+  assertEquals(connection.edges.length, 5, "Should return all edges");
+  assertEquals(connection.pageInfo.hasNextPage, false);
+  assertEquals(connection.pageInfo.hasPreviousPage, false);
+});

--- a/apps/bfDb/nodeTypes/__tests__/BlogPost.test.ts
+++ b/apps/bfDb/nodeTypes/__tests__/BlogPost.test.ts
@@ -1,0 +1,121 @@
+#! /usr/bin/env -S bff test
+import { assertEquals } from "@std/assert";
+import { BlogPost } from "../BlogPost.ts";
+import { join } from "@std/path";
+
+// Create test blog posts in a temp directory
+async function setupTestBlogPosts(dir: string) {
+  await Deno.mkdir(join(dir, "docs", "blog"), { recursive: true });
+
+  // Create test posts with different dates
+  const posts = [
+    {
+      name: "2024-01-first-post.md",
+      content: "# First Post\n\nThis is the first post.",
+    },
+    {
+      name: "2024-06-middle-post.md",
+      content: "# Middle Post\n\nThis is a middle post.",
+    },
+    {
+      name: "2025-01-latest-post.md",
+      content: "# Latest Post\n\nThis is the latest post.",
+    },
+    {
+      name: "2023-12-oldest-post.md",
+      content: "# Oldest Post\n\nThis is the oldest post.",
+    },
+  ];
+
+  for (const post of posts) {
+    await Deno.writeTextFile(
+      join(dir, "docs", "blog", post.name),
+      post.content,
+    );
+  }
+}
+
+Deno.test("BlogPost.listAll() should return posts in reverse chronological order by default", async () => {
+  const tempDir = await Deno.makeTempDir();
+  const originalCwd = Deno.cwd();
+
+  try {
+    await setupTestBlogPosts(tempDir);
+    Deno.chdir(tempDir);
+
+    const posts = await BlogPost.listAll();
+
+    assertEquals(posts.length, 4, "Should find all 4 posts");
+
+    // Check order - newest first
+    assertEquals(posts[0].id, "2025-01-latest-post");
+    assertEquals(posts[1].id, "2024-06-middle-post");
+    assertEquals(posts[2].id, "2024-01-first-post");
+    assertEquals(posts[3].id, "2023-12-oldest-post");
+  } finally {
+    Deno.chdir(originalCwd);
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("BlogPost.listAll() should support ascending order", async () => {
+  const tempDir = await Deno.makeTempDir();
+  const originalCwd = Deno.cwd();
+
+  try {
+    await setupTestBlogPosts(tempDir);
+    Deno.chdir(tempDir);
+
+    const posts = await BlogPost.listAll("ASC");
+
+    assertEquals(posts.length, 4, "Should find all 4 posts");
+
+    // Check order - oldest first
+    assertEquals(posts[0].id, "2023-12-oldest-post");
+    assertEquals(posts[1].id, "2024-01-first-post");
+    assertEquals(posts[2].id, "2024-06-middle-post");
+    assertEquals(posts[3].id, "2025-01-latest-post");
+  } finally {
+    Deno.chdir(originalCwd);
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("BlogPost.listAll() should return empty array when no posts exist", async () => {
+  const tempDir = await Deno.makeTempDir();
+  const originalCwd = Deno.cwd();
+
+  try {
+    // Create docs/blog directory but no posts
+    await Deno.mkdir(join(tempDir, "docs", "blog"), { recursive: true });
+    Deno.chdir(tempDir);
+
+    const posts = await BlogPost.listAll();
+
+    assertEquals(posts.length, 0, "Should return empty array");
+  } finally {
+    Deno.chdir(originalCwd);
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("BlogPost.listAll() should handle missing blog directory", async () => {
+  const tempDir = await Deno.makeTempDir();
+  const originalCwd = Deno.cwd();
+
+  try {
+    // Don't create docs/blog directory
+    Deno.chdir(tempDir);
+
+    const posts = await BlogPost.listAll();
+
+    assertEquals(
+      posts.length,
+      0,
+      "Should return empty array when directory doesn't exist",
+    );
+  } finally {
+    Deno.chdir(originalCwd);
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});

--- a/docs/blog/2023-03-introduction-to-deno.md
+++ b/docs/blog/2023-03-introduction-to-deno.md
@@ -1,0 +1,30 @@
+# Introduction to Deno: A Modern JavaScript Runtime
+
+_March 15, 2023_
+
+Deno is a modern runtime for JavaScript and TypeScript that addresses many of
+the design flaws in Node.js. Created by Ryan Dahl (the original creator of
+Node.js), Deno provides built-in TypeScript support, secure defaults, and a
+standard library inspired by Go.
+
+## Key Features
+
+- **Secure by default**: No file, network, or environment access unless
+  explicitly enabled
+- **TypeScript support out of the box**: No need for separate compilation steps
+- **Standard modules**: Curated set of standard modules that are guaranteed to
+  work with Deno
+- **Built-in tooling**: Formatter, linter, and test runner included
+
+## Getting Started
+
+```bash
+# Install Deno
+curl -fsSL https://deno.land/install.sh | sh
+
+# Run a simple script
+deno run https://deno.land/std/examples/welcome.ts
+```
+
+Deno represents a fresh take on server-side JavaScript, learning from a decade
+of Node.js experience.

--- a/docs/blog/2023-06-understanding-web-components.md
+++ b/docs/blog/2023-06-understanding-web-components.md
@@ -1,0 +1,42 @@
+# Understanding Web Components: The Future of Reusable UI
+
+_June 8, 2023_
+
+Web Components represent a set of web platform APIs that allow you to create
+custom, reusable HTML elements. They provide true encapsulation and work across
+modern browsers without any framework.
+
+## The Four Pillars
+
+1. **Custom Elements**: Define new HTML elements
+2. **Shadow DOM**: Encapsulated DOM and styling
+3. **HTML Templates**: Declare fragments of markup
+4. **ES Modules**: Reusable JavaScript modules
+
+## Simple Example
+
+```javascript
+class MyButton extends HTMLElement {
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+    shadow.innerHTML = `
+      <style>
+        button {
+          background: #007bff;
+          color: white;
+          padding: 10px 20px;
+          border: none;
+          border-radius: 4px;
+        }
+      </style>
+      <button><slot></slot></button>
+    `;
+  }
+}
+
+customElements.define("my-button", MyButton);
+```
+
+Web Components offer a standards-based approach to building reusable UI
+components that work everywhere.

--- a/docs/blog/2023-09-graphql-best-practices.md
+++ b/docs/blog/2023-09-graphql-best-practices.md
@@ -1,0 +1,41 @@
+# GraphQL Best Practices: Building Efficient APIs
+
+_September 22, 2023_
+
+GraphQL has revolutionized how we build and consume APIs. However, with great
+power comes great responsibility. Here are essential best practices for building
+efficient GraphQL APIs.
+
+## Schema Design
+
+- **Think in graphs, not endpoints**: Design your schema around relationships
+- **Use clear, consistent naming**: Follow naming conventions (camelCase for
+  fields)
+- **Leverage the type system**: Make invalid states unrepresentable
+
+## Performance Optimization
+
+### 1. Implement DataLoader
+
+```javascript
+const userLoader = new DataLoader(async (userIds) => {
+  const users = await db.users.findByIds(userIds);
+  return userIds.map((id) => users.find((user) => user.id === id));
+});
+```
+
+### 2. Add Query Complexity Analysis
+
+Prevent expensive queries by analyzing complexity before execution.
+
+### 3. Use Field-Level Permissions
+
+Control access at the field level, not just the query level.
+
+## Error Handling
+
+Always return meaningful error messages with proper error codes. Use GraphQL's
+built-in error handling rather than throwing exceptions.
+
+Building great GraphQL APIs requires thoughtful design and careful
+implementation of performance optimizations.

--- a/docs/blog/2023-11-rust-for-web-developers.md
+++ b/docs/blog/2023-11-rust-for-web-developers.md
@@ -1,0 +1,46 @@
+# Rust for Web Developers: Why You Should Care
+
+_November 10, 2023_
+
+Rust is making waves in the web development community, and for good reason. From
+WebAssembly to blazing-fast web servers, Rust offers unique advantages for web
+developers.
+
+## Why Rust?
+
+- **Memory safety without garbage collection**: Prevent entire classes of bugs
+- **Fearless concurrency**: Write parallel code without data races
+- **Zero-cost abstractions**: High-level code with low-level performance
+
+## Web Development with Rust
+
+### WebAssembly
+
+Rust has first-class support for compiling to WebAssembly:
+
+```rust
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub fn greet(name: &str) -> String {
+    format!("Hello, {}!", name)
+}
+```
+
+### Web Frameworks
+
+Popular Rust web frameworks include:
+
+- **Actix-web**: High-performance actor framework
+- **Rocket**: Ergonomic and type-safe
+- **Axum**: Built on tokio and tower
+
+## Getting Started
+
+1. Install Rust:
+   `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
+2. Try the Rust Book: https://doc.rust-lang.org/book/
+3. Build something small and iterate
+
+Rust's learning curve is worth it for the performance and safety benefits it
+brings to web development.

--- a/docs/blog/2024-01-microservices-vs-monoliths.md
+++ b/docs/blog/2024-01-microservices-vs-monoliths.md
@@ -1,0 +1,48 @@
+# Microservices vs Monoliths: Making the Right Choice in 2024
+
+_January 18, 2024_
+
+The debate between microservices and monolithic architectures continues to
+evolve. In 2024, the answer isn't as clear-cut as "microservices for
+everything."
+
+## The Monolith Renaissance
+
+Many teams are returning to monoliths, but with a twist:
+
+- **Modular monoliths**: Internal boundaries without network calls
+- **Better tooling**: Modern deployment and monitoring for monoliths
+- **Simplified operations**: One deployment, one database, one codebase
+
+## When Microservices Make Sense
+
+- **Team autonomy**: Large organizations with independent teams
+- **Polyglot requirements**: Different services need different languages
+- **Scaling patterns**: Services with vastly different scaling needs
+
+## The Hybrid Approach
+
+```yaml
+# Start with a monolith
+app/
+  ├── modules/
+  │   ├── users/
+  │   ├── orders/
+  │   └── payments/
+  └── shared/
+
+# Extract services when needed
+services/
+  ├── api-gateway/
+  ├── core-app/  # The monolith
+  └── payment-service/  # Extracted for compliance
+```
+
+## Key Takeaways
+
+1. Start with a well-structured monolith
+2. Extract services based on real needs, not hypothetical ones
+3. Invest in observability regardless of architecture
+
+The best architecture is the one that matches your team's needs and
+capabilities.

--- a/docs/blog/2024-03-typescript-5-features.md
+++ b/docs/blog/2024-03-typescript-5-features.md
@@ -1,0 +1,55 @@
+# TypeScript 5.0: Game-Changing Features for Modern Development
+
+_March 5, 2024_
+
+TypeScript 5.0 brings significant improvements that make our code safer and
+development experience smoother. Let's explore the most impactful features.
+
+## Decorators (Finally Stable!)
+
+After years in experimental, decorators are now part of the ECMAScript standard:
+
+```typescript
+function logged(target: any, key: string, descriptor: PropertyDescriptor) {
+  const original = descriptor.value;
+  descriptor.value = function (...args: any[]) {
+    console.log(`Calling ${key} with:`, args);
+    return original.apply(this, args);
+  };
+}
+
+class Calculator {
+  @logged
+  add(a: number, b: number) {
+    return a + b;
+  }
+}
+```
+
+## const Type Parameters
+
+Generic functions can now specify that type parameters should be inferred as
+const:
+
+```typescript
+function getConfig<const T>(config: T): T {
+  return config;
+}
+
+// Type is { readonly api: "https://api.example.com" }
+const config = getConfig({ api: "https://api.example.com" });
+```
+
+## Performance Improvements
+
+- **Faster type checking**: Up to 30% improvement in large codebases
+- **Smaller bundle sizes**: Better tree-shaking with new emit strategies
+- **Improved memory usage**: Significant reductions in language service memory
+
+## All enums Are Union enums
+
+TypeScript now treats all enums as union enums, providing better type narrowing
+and exhaustiveness checking.
+
+TypeScript 5.0 represents a major milestone in the language's evolution,
+bringing us closer to a truly type-safe JavaScript ecosystem.

--- a/docs/blog/2024-05-ai-powered-development.md
+++ b/docs/blog/2024-05-ai-powered-development.md
@@ -1,0 +1,60 @@
+# AI-Powered Development: Beyond the Hype
+
+_May 12, 2024_
+
+AI coding assistants have moved from novelty to necessity. Here's a practical
+guide to integrating AI into your development workflow effectively.
+
+## Current Landscape
+
+- **Code completion**: GitHub Copilot, Cursor, Codeium
+- **Chat interfaces**: ChatGPT, Claude, Gemini
+- **Specialized tools**: AI for testing, documentation, and code review
+
+## Effective AI Integration
+
+### 1. Code Generation
+
+```javascript
+// Prompt: Create a rate limiter using Redis
+// AI generates:
+class RateLimiter {
+  constructor(redis, windowMs = 60000, maxRequests = 100) {
+    this.redis = redis;
+    this.windowMs = windowMs;
+    this.maxRequests = maxRequests;
+  }
+
+  async checkLimit(identifier) {
+    const key = `rate_limit:${identifier}`;
+    const current = await this.redis.incr(key);
+
+    if (current === 1) {
+      await this.redis.expire(key, Math.ceil(this.windowMs / 1000));
+    }
+
+    return current <= this.maxRequests;
+  }
+}
+```
+
+### 2. Code Review
+
+Use AI to catch common issues before human review:
+
+- Security vulnerabilities
+- Performance bottlenecks
+- Code style violations
+
+### 3. Documentation
+
+AI excels at generating initial documentation drafts from code.
+
+## Best Practices
+
+1. **Trust but verify**: Always review AI-generated code
+2. **Provide context**: Better prompts yield better results
+3. **Learn from suggestions**: Use AI as a learning tool
+4. **Maintain security**: Never share sensitive data with AI
+
+AI is a powerful multiplier for developer productivity when used thoughtfully.

--- a/docs/blog/2024-07-edge-computing-patterns.md
+++ b/docs/blog/2024-07-edge-computing-patterns.md
@@ -1,0 +1,75 @@
+# Edge Computing Patterns: Building for Global Performance
+
+_July 28, 2024_
+
+Edge computing has transformed from a buzzword to a practical necessity for
+global applications. Here are proven patterns for leveraging edge infrastructure
+effectively.
+
+## Why Edge Computing?
+
+- **Reduced latency**: Serve users from locations closer to them
+- **Improved reliability**: Distribute failure points
+- **Cost efficiency**: Reduce bandwidth costs by processing at the edge
+
+## Key Patterns
+
+### 1. Edge-First Rendering
+
+```javascript
+// Cloudflare Worker example
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+
+    // Check cache first
+    const cached = await caches.default.match(request);
+    if (cached) return cached;
+
+    // Generate response at edge
+    const response = await generatePage(url, env);
+
+    // Cache for future requests
+    await caches.default.put(request, response.clone());
+    return response;
+  },
+};
+```
+
+### 2. Regional Data Sharding
+
+Partition data by geography to keep it close to users:
+
+- User profiles in user's region
+- Regional inventory for e-commerce
+- Compliance-driven data residency
+
+### 3. Edge State Management
+
+Use durable objects or edge KV stores for stateful edge computing:
+
+```javascript
+// Durable Object for real-time collaboration
+export class DocumentSession {
+  constructor(state, env) {
+    this.state = state;
+    this.sessions = new Map();
+  }
+
+  async fetch(request) {
+    // Handle WebSocket connections for real-time updates
+    const upgradeHeader = request.headers.get("Upgrade");
+    if (upgradeHeader === "websocket") {
+      return this.handleWebSocket(request);
+    }
+  }
+}
+```
+
+## Challenges and Solutions
+
+- **Cold starts**: Pre-warm critical paths
+- **Data consistency**: Use eventual consistency where possible
+- **Debugging**: Invest in distributed tracing
+
+Edge computing is no longer optional for applications serving a global audience.

--- a/docs/blog/2024-09-database-evolution.md
+++ b/docs/blog/2024-09-database-evolution.md
@@ -1,0 +1,57 @@
+# The Evolution of Databases: From SQL to NewSQL and Beyond
+
+_September 15, 2024_
+
+The database landscape has evolved dramatically. Understanding modern database
+options is crucial for building scalable applications.
+
+## The Current Spectrum
+
+### Traditional SQL
+
+- **PostgreSQL**: The Swiss Army knife of databases
+- **MySQL**: Still powering much of the web
+- **SQLite**: Perfect for edge and embedded use cases
+
+### NoSQL Varieties
+
+```javascript
+// Document stores (MongoDB, CouchDB)
+await db.collection('users').insertOne({
+  name: 'Alice',
+  preferences: { theme: 'dark', language: 'en' }
+});
+
+// Key-Value (Redis, DynamoDB)
+await redis.hset('session:123', {
+  userId: '456',
+  expires: Date.now() + 3600000
+});
+
+// Graph databases (Neo4j, Amazon Neptune)
+MATCH (user:User)-[:FOLLOWS]->(friend:User)
+WHERE user.name = 'Alice'
+RETURN friend
+```
+
+### NewSQL Revolution
+
+- **CockroachDB**: Distributed SQL with ACID guarantees
+- **TiDB**: MySQL-compatible distributed database
+- **Vitess**: Scales MySQL horizontally
+
+## Choosing the Right Database
+
+1. **Start with PostgreSQL**: Unless you have specific requirements
+2. **Consider specialized databases**: For specific use cases (time-series,
+   graph)
+3. **Plan for scale**: But don't over-engineer early
+
+## Emerging Trends
+
+- **Serverless databases**: Pay-per-query pricing (Neon, PlanetScale)
+- **Multi-model databases**: One database, multiple paradigms
+- **Edge databases**: SQLite at the edge with sync
+
+The key is matching your database choice to your actual needs, not hypothetical
+future requirements.

--- a/docs/blog/2024-11-react-server-components.md
+++ b/docs/blog/2024-11-react-server-components.md
@@ -1,0 +1,85 @@
+# React Server Components: The New Paradigm for Full-Stack React
+
+_November 3, 2024_
+
+React Server Components (RSC) represent the biggest shift in React since hooks.
+They fundamentally change how we think about data fetching and component
+composition.
+
+## Understanding Server Components
+
+```jsx
+// This component runs on the server
+async function ProductList() {
+  // Direct database access - no API needed!
+  const products = await db.query("SELECT * FROM products");
+
+  return (
+    <div>
+      {products.map((product) => (
+        <ProductCard key={product.id} product={product} />
+      ))}
+    </div>
+  );
+}
+
+// This component includes client interactivity
+"use client";
+function ProductCard({ product }) {
+  const [liked, setLiked] = useState(false);
+
+  return (
+    <div>
+      <h3>{product.name}</h3>
+      <button onClick={() => setLiked(!liked)}>
+        {liked ? "❤️" : "🤍"}
+      </button>
+    </div>
+  );
+}
+```
+
+## Key Benefits
+
+1. **Zero client-side data fetching code**: Fetch data where you need it
+2. **Automatic code splitting**: Only ship JavaScript that needs interactivity
+3. **Improved performance**: Smaller bundles, faster initial loads
+
+## Patterns and Best Practices
+
+### Composition Pattern
+
+```jsx
+// Server Component (container)
+async function Dashboard() {
+  const data = await fetchDashboardData();
+
+  return (
+    <DashboardLayout>
+      <DashboardMetrics data={data.metrics} />
+      <InteractiveChart initialData={data.chartData} />
+    </DashboardLayout>
+  );
+}
+
+// Client Component (interactive parts)
+"use client";
+function InteractiveChart({ initialData }) {
+  // Handle user interactions
+}
+```
+
+### Data Flow
+
+- Server Components can import Client Components
+- Client Components cannot import Server Components (except as children)
+- Props flow from Server to Client Components
+
+## Challenges
+
+- **Mental model shift**: Thinking in server/client boundaries
+- **Tooling maturity**: Ecosystem still catching up
+- **Caching complexity**: New caching patterns to learn
+
+React Server Components are not just an optimization—they're a new way to build
+React applications.

--- a/docs/blog/2025-01-webassembly-everywhere.md
+++ b/docs/blog/2025-01-webassembly-everywhere.md
@@ -1,0 +1,68 @@
+# WebAssembly Everywhere: Beyond the Browser
+
+_January 22, 2025_
+
+WebAssembly (Wasm) has broken free from the browser and is revolutionizing how
+we think about portable, secure, and fast code execution.
+
+## Wasm Beyond Browsers
+
+### Edge Computing
+
+```rust
+// Compile to Wasm and run at the edge
+#[no_mangle]
+pub extern "C" fn handle_request(req: Request) -> Response {
+    match req.path() {
+        "/api/transform" => transform_image(req.body()),
+        "/api/validate" => validate_data(req.body()),
+        _ => Response::not_found()
+    }
+}
+```
+
+### Plugin Systems
+
+Many applications now use Wasm for safe, sandboxed plugins:
+
+- **Databases**: Extensions in PostgreSQL, Redis modules
+- **Service meshes**: Envoy proxy filters
+- **Development tools**: VS Code extensions
+
+### Serverless Functions
+
+```javascript
+// JavaScript host running Wasm modules
+const wasmModule = await WebAssembly.instantiate(wasmBuffer);
+const result = wasmModule.exports.processData(input);
+```
+
+## WASI: The System Interface
+
+WebAssembly System Interface (WASI) enables Wasm to:
+
+- Access files (with permissions)
+- Network communication
+- System time and random numbers
+
+## Real-World Applications
+
+1. **Figma**: Rendering engine in C++ compiled to Wasm
+2. **Cloudflare Workers**: Run any language at the edge
+3. **Docker Desktop**: Wasm as a container alternative
+4. **AI/ML inference**: ONNX runtime in browsers
+
+## Getting Started
+
+```bash
+# Compile Rust to Wasm
+cargo build --target wasm32-wasi
+
+# Run with Wasmtime
+wasmtime run target/wasm32-wasi/debug/my_app.wasm
+
+# Or with Node.js
+node --experimental-wasi-unstable-preview1 run-wasm.js
+```
+
+WebAssembly is becoming the universal runtime for portable, secure computation.

--- a/docs/blog/2025-02-sustainable-software-engineering.md
+++ b/docs/blog/2025-02-sustainable-software-engineering.md
@@ -1,0 +1,80 @@
+# Sustainable Software Engineering: Building Green Applications
+
+_February 14, 2025_
+
+As developers, we have a responsibility to consider the environmental impact of
+our software. Sustainable software engineering is becoming a critical skill.
+
+## The Carbon Cost of Code
+
+Every line of code has an environmental footprint:
+
+- **Data centers**: Consume 1% of global electricity
+- **End-user devices**: Billions of devices running our code
+- **Network transmission**: Moving data costs energy
+
+## Green Coding Practices
+
+### 1. Efficient Algorithms
+
+```javascript
+// Inefficient: O(n²)
+function findDuplicatesSlow(arr) {
+  const duplicates = [];
+  for (let i = 0; i < arr.length; i++) {
+    for (let j = i + 1; j < arr.length; j++) {
+      if (arr[i] === arr[j]) duplicates.push(arr[i]);
+    }
+  }
+  return duplicates;
+}
+
+// Efficient: O(n)
+function findDuplicatesFast(arr) {
+  const seen = new Set();
+  const duplicates = new Set();
+  for (const item of arr) {
+    if (seen.has(item)) duplicates.add(item);
+    seen.add(item);
+  }
+  return [...duplicates];
+}
+```
+
+### 2. Smart Caching
+
+- Cache expensive computations
+- Use CDNs to reduce data transmission
+- Implement intelligent cache invalidation
+
+### 3. Optimized Assets
+
+```bash
+# Image optimization
+convert input.png -quality 85 -strip output.jpg
+
+# JavaScript bundling with tree-shaking
+esbuild app.js --bundle --minify --tree-shaking=true
+```
+
+## Architecture for Sustainability
+
+1. **Microservices vs Monoliths**: Consider the overhead of service
+   communication
+2. **Edge computing**: Process data closer to users
+3. **Serverless**: Pay-per-use can incentivize efficiency
+
+## Measuring Impact
+
+- **Carbon footprint tools**: Cloud providers offer emissions dashboards
+- **Performance metrics**: Faster apps use less energy
+- **Green hosting**: Choose renewable-powered data centers
+
+## The Business Case
+
+- **Cost reduction**: Efficient code costs less to run
+- **User experience**: Faster apps make happier users
+- **Compliance**: Increasing regulations on digital emissions
+
+Building sustainable software isn't just good for the planet—it's good
+engineering.

--- a/docs/blog/2025-04-api-design-2025.md
+++ b/docs/blog/2025-04-api-design-2025.md
@@ -1,0 +1,90 @@
+# API Design in 2025: REST, GraphQL, gRPC, and Beyond
+
+_April 8, 2025_
+
+The API landscape continues to evolve with new patterns and technologies. Here's
+a comprehensive guide to modern API design.
+
+## The Current Landscape
+
+### REST: Still Relevant
+
+```typescript
+// Modern REST with TypeScript and OpenAPI
+interface UserAPI {
+  GET: {
+    "/users": { response: User[] };
+    "/users/:id": { params: { id: string }; response: User };
+  };
+  POST: {
+    "/users": { body: CreateUserDto; response: User };
+  };
+}
+```
+
+### GraphQL: Mature and Powerful
+
+```graphql
+type Query {
+  user(id: ID!): User
+  users(filter: UserFilter, pagination: PaginationInput): UserConnection!
+}
+
+type Mutation {
+  createUser(input: CreateUserInput!): CreateUserPayload!
+  updateUser(id: ID!, input: UpdateUserInput!): UpdateUserPayload!
+}
+
+type Subscription {
+  userUpdated(id: ID!): User!
+}
+```
+
+### gRPC: For Service-to-Service
+
+```protobuf
+service UserService {
+  rpc GetUser(GetUserRequest) returns (User);
+  rpc ListUsers(ListUsersRequest) returns (stream User);
+  rpc CreateUser(CreateUserRequest) returns (User);
+}
+```
+
+## Emerging Patterns
+
+### 1. Type-Safe APIs
+
+Using tools like tRPC for end-to-end type safety:
+
+```typescript
+const appRouter = router({
+  user: {
+    list: publicProcedure.query(async () => {
+      return await db.user.findMany();
+    }),
+    create: publicProcedure
+      .input(z.object({ name: z.string() }))
+      .mutation(async ({ input }) => {
+        return await db.user.create({ data: input });
+      }),
+  },
+});
+```
+
+### 2. Event-Driven APIs
+
+WebSockets, Server-Sent Events, and WebTransport for real-time data.
+
+### 3. API Gateways and Mesh
+
+Managing complex API ecosystems with intelligent routing and policies.
+
+## Best Practices for 2025
+
+1. **API-First Design**: Design APIs before implementation
+2. **Versioning Strategy**: Use semantic versioning and sunset policies
+3. **Security by Default**: OAuth 2.0, API keys, rate limiting
+4. **Documentation**: OpenAPI, GraphQL introspection, or gRPC reflection
+5. **Observability**: Structured logging, distributed tracing
+
+The best API is the one that fits your use case and delights your developers.

--- a/docs/blog/2025-05-quantum-computing-developers.md
+++ b/docs/blog/2025-05-quantum-computing-developers.md
@@ -1,0 +1,89 @@
+# Quantum Computing for Developers: Practical Applications Today
+
+_May 20, 2025_
+
+Quantum computing is no longer just theoretical physics. Cloud-based quantum
+computers are available today, and developers can start experimenting with
+quantum algorithms.
+
+## Understanding Quantum Basics
+
+Unlike classical bits (0 or 1), quantum bits (qubits) can be in superposition:
+
+- **Superposition**: A qubit can be both 0 and 1 simultaneously
+- **Entanglement**: Qubits can be correlated in ways classical bits cannot
+- **Interference**: Quantum states can amplify or cancel each other
+
+## Practical Quantum Development
+
+### Getting Started with Qiskit
+
+```python
+from qiskit import QuantumCircuit, execute, Aer
+
+# Create a quantum circuit with 2 qubits
+qc = QuantumCircuit(2, 2)
+
+# Apply Hadamard gate to create superposition
+qc.h(0)
+
+# Create entanglement with CNOT gate
+qc.cx(0, 1)
+
+# Measure both qubits
+qc.measure([0, 1], [0, 1])
+
+# Execute on quantum simulator
+backend = Aer.get_backend('qasm_simulator')
+result = execute(qc, backend, shots=1000).result()
+counts = result.get_counts()
+print(counts)  # {'00': ~500, '11': ~500}
+```
+
+## Current Applications
+
+### 1. Cryptography
+
+Quantum-safe encryption algorithms are being developed and deployed:
+
+```python
+# Post-quantum cryptography example
+from pqcrypto.kem.kyber512 import generate_keypair, encrypt, decrypt
+
+public_key, secret_key = generate_keypair()
+ciphertext, shared_secret_sender = encrypt(public_key)
+shared_secret_receiver = decrypt(secret_key, ciphertext)
+```
+
+### 2. Optimization Problems
+
+- Portfolio optimization in finance
+- Route optimization in logistics
+- Drug discovery simulations
+
+### 3. Machine Learning
+
+Quantum machine learning algorithms can provide speedups for certain problems.
+
+## Cloud Quantum Services
+
+- **IBM Quantum**: Free access to real quantum computers
+- **AWS Braket**: Quantum computing on AWS
+- **Azure Quantum**: Microsoft's quantum platform
+- **Google Quantum AI**: Access to Google's quantum processors
+
+## Challenges and Reality
+
+- **Noise**: Current quantum computers are noisy (NISQ era)
+- **Limited qubits**: Most systems have <100 qubits
+- **Decoherence**: Quantum states are fragile
+
+## Getting Started
+
+1. Learn the basics: Linear algebra and quantum mechanics fundamentals
+2. Try simulators: Start with quantum simulators before real hardware
+3. Focus on algorithms: Understand Shor's, Grover's, and VQE
+4. Join the community: Quantum computing forums and hackathons
+
+Quantum computing won't replace classical computing but will augment it for
+specific problems.

--- a/docs/blog/2025-06-future-of-devops.md
+++ b/docs/blog/2025-06-future-of-devops.md
@@ -1,0 +1,108 @@
+# The Future of DevOps: Platform Engineering and Developer Experience
+
+_June 30, 2025_
+
+DevOps is evolving into Platform Engineering, focusing on creating golden paths
+for developers while maintaining security and compliance.
+
+## From DevOps to Platform Engineering
+
+Traditional DevOps required every developer to be an infrastructure expert.
+Platform Engineering provides:
+
+- **Self-service infrastructure**: Developers provision resources without
+  tickets
+- **Golden paths**: Pre-configured, secure templates for common scenarios
+- **Guardrails, not gates**: Automated compliance and security checks
+
+## Modern Platform Architecture
+
+```yaml
+# Platform service catalog example
+apiVersion: backstage.io/v1alpha1
+kind: Template
+metadata:
+  name: nodejs-microservice
+spec:
+  type: service
+  parameters:
+    - title: Service Configuration
+      properties:
+        name:
+          type: string
+          description: Service name
+        database:
+          type: string
+          enum: ["postgresql", "mysql", "none"]
+  steps:
+    - id: create-repo
+      action: github:create
+    - id: provision-infra
+      action: terraform:apply
+    - id: setup-ci
+      action: github:actions:create
+```
+
+## Key Components
+
+### 1. Internal Developer Portals
+
+- Service catalogs
+- Documentation hubs
+- API directories
+- Deployment dashboards
+
+### 2. Infrastructure as Code 2.0
+
+```typescript
+// Type-safe infrastructure with Pulumi
+import * as aws from "@pulumi/aws";
+
+export class MicroserviceStack {
+  constructor(name: string, config: ServiceConfig) {
+    const cluster = new aws.ecs.Cluster(`${name}-cluster`);
+
+    const service = new aws.ecs.Service(`${name}-service`, {
+      cluster: cluster.id,
+      desiredCount: config.replicas,
+      // Auto-scaling, health checks, etc.
+    });
+
+    // Automatic observability
+    this.setupMonitoring(service);
+    this.setupTracing(service);
+  }
+}
+```
+
+### 3. GitOps Everything
+
+- Declarative infrastructure
+- Automated reconciliation
+- Audit trails for everything
+
+## Developer Experience Metrics
+
+1. **Time to first deploy**: How long for a new developer to ship code?
+2. **Self-service rate**: Percentage of tasks completed without help
+3. **MTTR**: Mean time to recovery when issues occur
+4. **Developer satisfaction**: Regular surveys and feedback
+
+## AI-Powered Operations
+
+- **Predictive scaling**: AI predicts load and scales proactively
+- **Anomaly detection**: Catch issues before they impact users
+- **Smart rollbacks**: Automatic rollback on detected regressions
+- **Cost optimization**: AI suggests infrastructure optimizations
+
+## The Platform Team Mindset
+
+Platform teams are product teams where developers are the customers:
+
+- Regular user research with development teams
+- Feature roadmaps based on developer needs
+- SLAs for platform services
+- Documentation as a first-class citizen
+
+Platform Engineering represents the maturation of DevOps, focusing on developer
+productivity while maintaining operational excellence.

--- a/memos/plans/2025-06-relay-connections-implementation.md
+++ b/memos/plans/2025-06-relay-connections-implementation.md
@@ -1,0 +1,236 @@
+# Relay Connections Implementation Plan
+
+## Overview
+
+This version extends the gqlBuilder to support Relay-style connections, enabling
+any GraphQL type to expose paginated lists following the Relay specification.
+The blog system serves as the first implementation, demonstrating how to use the
+new connection field type to create a paginated blog listing with proper edges,
+nodes, cursors, and page info.
+
+## Goals
+
+| Goal                    | Description                                     | Success Criteria                                             |
+| ----------------------- | ----------------------------------------------- | ------------------------------------------------------------ |
+| Extend gqlBuilder       | Add connection field type to the builder API    | Can define connection fields using gql.connection()          |
+| Implement Relay spec    | Support full Relay connection specification     | Connections have edges, nodes, cursors, and pageInfo         |
+| Prove with blog example | Use BlogPost as first implementation            | Can query `blogPosts` with first/last/after/before arguments |
+| Enable reusability      | Make connections available to all GraphQL types | Other types can use the same connection pattern              |
+
+## Anti-Goals
+
+| Anti-Goal                 | Reason                                                    |
+| ------------------------- | --------------------------------------------------------- |
+| Blog metadata extraction  | Keep blog example simple to focus on connection mechanics |
+| UI implementation         | Focus exclusively on GraphQL schema layer                 |
+| Complex cursor strategies | Start with simple cursor implementation                   |
+| Database integration      | Use filesystem-based BlogPost to avoid storage complexity |
+
+## Technical Approach
+
+The implementation extends gqlBuilder to support connection fields, integrating
+with Nexus's connectionPlugin. The approach involves:
+
+1. **Extending gqlBuilder**: Add a `connection()` method to the builder API that
+   generates proper Nexus connection field definitions
+2. **Type generation**: Update gqlSpecToNexus to handle connection field
+   specifications
+3. **Integration with existing patterns**: Ensure connections work with the
+   current resolver and type system
+
+The BlogPost implementation serves as the test case, using filesystem-based
+posts with date-prefixed naming (YYYY-MM-title.md) to demonstrate reverse
+chronological pagination.
+
+## Components
+
+| Status | Component                  | Purpose                                                            |
+| ------ | -------------------------- | ------------------------------------------------------------------ |
+| [ ]    | gqlBuilder.connection()    | New builder method for defining connection fields                  |
+| [ ]    | Connection field spec type | Type definitions for connection specifications                     |
+| [ ]    | gqlSpecToNexus updates     | Handle connection fields in type conversion                        |
+| [ ]    | BlogPost.listAll()         | List all blog posts from filesystem in reverse chronological order |
+| [ ]    | BlogPost.connection()      | Static method to create Relay connection from post list            |
+| [ ]    | Query.blogPosts connection | GraphQL field using new connection builder                         |
+| [ ]    | Integration tests          | Verify connection queries work correctly                           |
+
+## Technical Decisions
+
+| Decision                   | Reasoning                                   | Alternatives Considered                   |
+| -------------------------- | ------------------------------------------- | ----------------------------------------- |
+| Extend gqlBuilder          | Keep consistent API for all field types     | Direct Nexus usage (breaks abstraction)   |
+| Use Nexus connectionField  | Leverage existing connection infrastructure | Implement custom connection types         |
+| connectionFromArray helper | Standard Relay implementation               | Custom pagination logic                   |
+| Static connection method   | Clean separation of concerns                | Instance methods (requires instantiation) |
+| Support custom args        | Enable sorting, filtering from the start    | Relay args only (too limiting)            |
+
+## Example Usage
+
+The blog implementation will use the new connection builder like this:
+
+```typescript
+// In Query class
+static override gqlSpec = this.defineGqlNode((field) =>
+  field
+    .connection("blogPosts", () => BlogPost, {
+      args: (a) => a
+        .string("sortDirection")  // "ASC" or "DESC", defaults to "DESC" in resolver
+        .string("filterByYear"),  // Optional: "2025" to filter posts from that year
+      resolve: async (_root, args, _ctx) => {
+        // Sort direction defaults to DESC (newest first) for blogs
+        const sortDir = args.sortDirection || "DESC";
+        const posts = await BlogPost.listAll(sortDir);
+        
+        // Apply year filter if provided
+        const filtered = args.filterByYear 
+          ? posts.filter(p => p.id.startsWith(args.filterByYear))
+          : posts;
+        
+        // BlogPost.connection handles Relay pagination
+        return BlogPost.connection(filtered, args);
+      }
+    })
+)
+```
+
+## Design Decisions from Research
+
+### Connection Method Signature
+
+Based on the existing builder pattern, the connection method should follow this
+signature:
+
+```typescript
+connection<N extends string>(
+  name: N,
+  targetThunk: GqlObjectThunk,  // Same pattern as object()
+  opts?: {
+    args?: (ab: ArgsBuilder) => ArgsBuilder;  // Custom args beyond Relay's
+    resolve: (
+      root: ThisNode,
+      args: ConnectionArguments & CustomArgs,  // Merged Relay + custom args
+      ctx: BfGraphqlContext,
+      info: GraphQLResolveInfo,
+    ) => MaybePromise<Connection<TargetType>>;
+  }
+): GqlBuilder<R>;
+```
+
+Note: Connections are always nullable by default (following GraphQL best
+practices). The nonNull modifier is not supported for connection fields.
+
+### Resolver Pattern
+
+The resolver pattern follows the same approach as other fields:
+
+- Custom resolver is always required for connections (no default resolver)
+- Resolver must return a Connection<T> type from graphql-relay library
+- Args are typed as ConnectionArguments merged with any custom args
+
+### Connection Specification Type
+
+The connection field spec should be stored in the GqlNodeSpec under a new
+`connections` property:
+
+```typescript
+interface GqlConnectionDef {
+  type: string; // Target type name (resolved from thunk)
+  args: Record<string, unknown>; // Custom args from builder
+  resolve: ConnectionResolver;
+  _targetThunk: GqlObjectThunk; // For type resolution
+}
+```
+
+### Args Handling
+
+Connection args combine Relay's standard args with custom args:
+
+- Relay provides: first, last, after, before (via ConnectionArguments)
+- Custom args are defined using the same ArgsBuilder pattern as other fields
+- Nexus connectionField automatically merges both sets of args
+- Resolver receives the combined args object
+
+### Integration with gqlSpecToNexus
+
+The conversion to Nexus will:
+
+- Process connections from the new `connections` property in GqlNodeSpec
+- Use `t.connectionField()` instead of `t.field()` for connection fields
+- Pass the resolver directly since Nexus handles the connection wrapping
+- Resolve the target type from the thunk (same as object fields)
+
+## Implementation Order
+
+1. ~~Study existing gqlBuilder patterns and field types~~ ✓
+2. ~~Design connection() method API for gqlBuilder~~ ✓
+3. Write failing tests for gqlBuilder.connection() method
+   - Test that connection() method exists on builder
+   - Test that it accepts name, targetThunk, and options
+   - Test that it returns the builder for chaining
+   - Test that it stores connection in spec.connections
+4. Write failing tests for gqlSpecToNexus connection processing
+   - Test that connections are converted to t.connectionField()
+   - Test that custom args are passed correctly
+   - Test that resolver is wrapped properly
+5. Update GqlNodeSpec interface to add connections property
+6. Implement connection() method in makeGqlBuilder
+7. Add GqlConnectionDef type definition
+8. Update gqlSpecToNexus to process connections using t.connectionField()
+9. Verify all builder tests now pass
+10. Write failing test for BlogPost.listAll() with sort direction
+11. Implement BlogPost.listAll() with sort direction support
+12. Write failing test for BlogPost.connection()
+13. Add BlogPost.connection() static method using connectionFromArray
+14. Update Query to use gql.connection() for blogPosts
+15. Write integration test for GraphQL connection query
+16. Build and verify schema generation
+17. Test in GraphQL playground with various arg combinations
+
+## Test Plan
+
+### Builder Tests (Core functionality)
+
+- gqlBuilder.connection() method behavior
+  - Accepts connection field definition
+  - Supports custom args via ArgsBuilder
+  - Stores connection spec correctly
+  - Returns builder for chaining
+- gqlSpecToNexus connection processing
+  - Converts to Nexus connectionField
+  - Handles type resolution from thunk
+  - Merges custom args with Relay args
+  - Wraps resolver correctly
+
+### Blog Implementation Tests (Proof of concept)
+
+- Unit test for BlogPost.listAll() reverse chronological sorting
+- Unit test for BlogPost.connection() pagination
+- Integration test for GraphQL query with various arguments
+- Manual test in GraphQL playground to verify newest posts appear first
+
+### Expected GraphQL Query
+
+```graphql
+query BlogListing {
+  blogPosts(
+    first: 10,
+    sortDirection: "DESC",
+    filterByYear: "2025"
+  ) {
+    edges {
+      cursor
+      node {
+        id
+        content
+      }
+    }
+    pageInfo {
+      hasNextPage
+      hasPreviousPage
+      startCursor
+      endCursor
+    }
+    count  # Extended by our connectionPlugin config
+  }
+}
+```

--- a/test-blogposts-connection.sh
+++ b/test-blogposts-connection.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Test the blogPosts connection with various arguments
+
+echo "=== Testing blogPosts connection ==="
+echo
+
+echo "1. Basic query with first 2 posts (default DESC order):"
+curl -X POST http://localhost:9999/graphql \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "query TestConnection { blogPosts(first: 2) { pageInfo { hasNextPage hasPreviousPage startCursor endCursor } edges { cursor node { id content } } nodes { id } } }"
+  }' | jq .
+
+echo
+echo "2. Query with sortDirection ASC:"
+curl -X POST http://localhost:9999/graphql \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "query TestAscending { blogPosts(first: 3, sortDirection: \"ASC\") { edges { node { id } } } }"
+  }' | jq .
+
+echo
+echo "3. Query with filterByYear for 2024:"
+curl -X POST http://localhost:9999/graphql \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "query TestFilter { blogPosts(filterByYear: \"2024\", first: 10) { edges { node { id } } pageInfo { hasNextPage } } }"
+  }' | jq .
+
+echo
+echo "4. Query with last 2 posts:"
+curl -X POST http://localhost:9999/graphql \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "query TestLast { blogPosts(last: 2) { edges { node { id } } pageInfo { hasNextPage hasPreviousPage } } }"
+  }' | jq .
+
+echo
+echo "5. Test cursor pagination - get first post and its cursor:"
+CURSOR=$(curl -s -X POST http://localhost:9999/graphql \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "query GetCursor { blogPosts(first: 1) { edges { cursor node { id } } } }"
+  }' | jq -r '.data.blogPosts.edges[0].cursor')
+
+echo "Got cursor: $CURSOR"
+echo "Now fetching posts after this cursor:"
+curl -X POST http://localhost:9999/graphql \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"query\": \"query TestAfterCursor(\$after: String) { blogPosts(first: 2, after: \\\"\$after\\\") { edges { node { id } } pageInfo { hasPreviousPage } } }\",
+    \"variables\": { \"after\": \"$CURSOR\" }
+  }" | jq .
+
+echo
+echo "6. Schema introspection for blogPosts field:"
+curl -X POST http://localhost:9999/graphql \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "query IntrospectField { __type(name: \"Query\") { fields { name args { name type { name } } } } }"
+  }' | jq '.data.__type.fields[] | select(.name == "blogPosts")'

--- a/test-connection-clean.sh
+++ b/test-connection-clean.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+echo "=== Testing blogPosts Relay Connection ==="
+echo
+
+# Test 1: Basic connection with pageInfo
+echo "1. Basic connection query with first 2 posts:"
+curl -s -X POST http://localhost:9999/graphql \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "{ blogPosts(first: 2) { pageInfo { hasNextPage hasPreviousPage } edges { cursor node { id } } } }"
+  }' | jq .
+
+echo -e "\n2. Custom arg - sortDirection ASC:"
+curl -s -X POST http://localhost:9999/graphql \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "{ blogPosts(first: 3, sortDirection: \"ASC\") { edges { node { id } } } }"
+  }' | jq .
+
+echo -e "\n3. Custom arg - filterByYear:"
+curl -s -X POST http://localhost:9999/graphql \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "{ blogPosts(filterByYear: \"2025\", first: 10) { edges { node { id } } } }"
+  }' | jq .
+
+echo -e "\n4. Cursor-based pagination:"
+# Get the first post's cursor
+RESPONSE=$(curl -s -X POST http://localhost:9999/graphql \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ blogPosts(first: 1) { edges { cursor node { id } } } }"}')
+
+CURSOR=$(echo $RESPONSE | jq -r '.data.blogPosts.edges[0].cursor')
+echo "First post cursor: $CURSOR"
+
+# Use the cursor to get next posts
+echo "Fetching posts after cursor:"
+curl -s -X POST http://localhost:9999/graphql \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"query\": \"query GetAfterCursor { blogPosts(first: 2, after: \\\"$CURSOR\\\") { edges { node { id } } pageInfo { hasPreviousPage } } }\"
+  }" | jq .

--- a/test-full-pagination.sh
+++ b/test-full-pagination.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+echo "=== Full Pagination Demo with 16 Blog Posts ==="
+echo
+
+# Color codes for output
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}Total posts available:${NC}"
+TOTAL=$(curl -s -X POST http://localhost:9999/graphql \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ blogPosts { edges { node { id } } } }"}' | jq '.data.blogPosts.edges | length')
+echo "Found $TOTAL posts (default limit: 10)"
+
+echo -e "\n${BLUE}Paginating through all posts (3 per page):${NC}"
+
+# Page 1
+echo -e "\n${GREEN}Page 1 (first 3):${NC}"
+PAGE1=$(curl -s -X POST http://localhost:9999/graphql \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "{ blogPosts(first: 3) { edges { cursor node { id } } pageInfo { hasNextPage endCursor } } }"
+  }')
+echo "$PAGE1" | jq '.data.blogPosts.edges[].node.id'
+CURSOR1=$(echo "$PAGE1" | jq -r '.data.blogPosts.pageInfo.endCursor')
+HAS_NEXT1=$(echo "$PAGE1" | jq -r '.data.blogPosts.pageInfo.hasNextPage')
+echo "Has next page: $HAS_NEXT1"
+
+# Page 2
+echo -e "\n${GREEN}Page 2 (next 3 after cursor):${NC}"
+PAGE2=$(curl -s -X POST http://localhost:9999/graphql \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"query\": \"{ blogPosts(first: 3, after: \\\"$CURSOR1\\\") { edges { cursor node { id } } pageInfo { hasNextPage hasPreviousPage endCursor } } }\"
+  }")
+echo "$PAGE2" | jq '.data.blogPosts.edges[].node.id'
+CURSOR2=$(echo "$PAGE2" | jq -r '.data.blogPosts.pageInfo.endCursor')
+HAS_NEXT2=$(echo "$PAGE2" | jq -r '.data.blogPosts.pageInfo.hasNextPage')
+HAS_PREV2=$(echo "$PAGE2" | jq -r '.data.blogPosts.pageInfo.hasPreviousPage')
+echo "Has next page: $HAS_NEXT2, Has previous page: $HAS_PREV2"
+
+# Page 3
+echo -e "\n${GREEN}Page 3 (next 3 after cursor):${NC}"
+PAGE3=$(curl -s -X POST http://localhost:9999/graphql \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"query\": \"{ blogPosts(first: 3, after: \\\"$CURSOR2\\\") { edges { node { id } } pageInfo { hasNextPage hasPreviousPage endCursor } } }\"
+  }")
+echo "$PAGE3" | jq '.data.blogPosts.edges[].node.id'
+CURSOR3=$(echo "$PAGE3" | jq -r '.data.blogPosts.pageInfo.endCursor')
+
+# Continue until no more pages
+echo -e "\n${GREEN}Continuing to page through remaining posts...${NC}"
+CURRENT_CURSOR=$CURSOR3
+PAGE_NUM=4
+while true; do
+  RESPONSE=$(curl -s -X POST http://localhost:9999/graphql \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"query\": \"{ blogPosts(first: 3, after: \\\"$CURRENT_CURSOR\\\") { edges { node { id } } pageInfo { hasNextPage endCursor } } }\"
+    }")
+  
+  POSTS=$(echo "$RESPONSE" | jq -r '.data.blogPosts.edges[].node.id')
+  if [ -z "$POSTS" ]; then
+    echo "No more posts!"
+    break
+  fi
+  
+  echo -e "\n${GREEN}Page $PAGE_NUM:${NC}"
+  echo "$POSTS"
+  
+  HAS_NEXT=$(echo "$RESPONSE" | jq -r '.data.blogPosts.pageInfo.hasNextPage')
+  if [ "$HAS_NEXT" = "false" ]; then
+    echo "Reached the end!"
+    break
+  fi
+  
+  CURRENT_CURSOR=$(echo "$RESPONSE" | jq -r '.data.blogPosts.pageInfo.endCursor')
+  ((PAGE_NUM++))
+done
+
+echo -e "\n${BLUE}Filtering tests:${NC}"
+
+echo -e "\n${GREEN}2024 posts (showing max 5):${NC}"
+curl -s -X POST http://localhost:9999/graphql \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "{ blogPosts(filterByYear: \"2024\", first: 5) { edges { node { id } } pageInfo { hasNextPage } } }"
+  }' | jq '.data.blogPosts | {posts: [.edges[].node.id], hasMore: .pageInfo.hasNextPage}'
+
+echo -e "\n${GREEN}2023 posts (all):${NC}"
+curl -s -X POST http://localhost:9999/graphql \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "{ blogPosts(filterByYear: \"2023\") { edges { node { id } } } }"
+  }' | jq '.data.blogPosts.edges[].node.id'
+
+echo -e "\n${BLUE}Backward pagination demo:${NC}"
+echo -e "\n${GREEN}Last 3 posts:${NC}"
+LAST_PAGE=$(curl -s -X POST http://localhost:9999/graphql \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "{ blogPosts(last: 3) { edges { node { id } } pageInfo { hasPreviousPage startCursor } } }"
+  }')
+echo "$LAST_PAGE" | jq '.data.blogPosts.edges[].node.id'
+START_CURSOR=$(echo "$LAST_PAGE" | jq -r '.data.blogPosts.pageInfo.startCursor')
+
+echo -e "\n${GREEN}3 posts before the last group:${NC}"
+curl -s -X POST http://localhost:9999/graphql \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"query\": \"{ blogPosts(last: 3, before: \\\"$START_CURSOR\\\") { edges { node { id } } } }\"
+  }" | jq '.data.blogPosts.edges[].node.id'

--- a/test-pagination.sh
+++ b/test-pagination.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+echo "=== Testing blogPosts Pagination with 16 posts ==="
+echo
+
+# Test 1: Get total count
+echo "1. Get all posts to see total count:"
+curl -s -X POST http://localhost:9999/graphql \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "{ blogPosts { edges { node { id } } pageInfo { hasNextPage hasPreviousPage } } }"
+  }' | jq '.data.blogPosts | {totalPosts: (.edges | length), pageInfo}'
+
+echo -e "\n2. First page (5 posts, DESC order - newest first):"
+curl -s -X POST http://localhost:9999/graphql \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "{ blogPosts(first: 5) { edges { cursor node { id } } pageInfo { hasNextPage hasPreviousPage startCursor endCursor } } }"
+  }' | jq '
+    .data.blogPosts | {
+      posts: [.edges[].node.id],
+      hasNextPage: .pageInfo.hasNextPage,
+      hasPreviousPage: .pageInfo.hasPreviousPage,
+      endCursor: .pageInfo.endCursor
+    }'
+
+# Get the end cursor for next page
+END_CURSOR=$(curl -s -X POST http://localhost:9999/graphql \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ blogPosts(first: 5) { pageInfo { endCursor } } }"}' | jq -r '.data.blogPosts.pageInfo.endCursor')
+
+echo -e "\n3. Second page (5 posts after cursor):"
+curl -s -X POST http://localhost:9999/graphql \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"query\": \"{ blogPosts(first: 5, after: \\\"$END_CURSOR\\\") { edges { node { id } } pageInfo { hasNextPage hasPreviousPage } } }\"
+  }" | jq '
+    .data.blogPosts | {
+      posts: [.edges[].node.id],
+      hasNextPage: .pageInfo.hasNextPage,
+      hasPreviousPage: .pageInfo.hasPreviousPage
+    }'
+
+echo -e "\n4. Last page (last 3 posts):"
+curl -s -X POST http://localhost:9999/graphql \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "{ blogPosts(last: 3) { edges { node { id } } pageInfo { hasNextPage hasPreviousPage } } }"
+  }' | jq '
+    .data.blogPosts | {
+      posts: [.edges[].node.id],
+      hasNextPage: .pageInfo.hasNextPage,
+      hasPreviousPage: .pageInfo.hasPreviousPage
+    }'
+
+echo -e "\n5. Filter by year 2024 with pagination:"
+curl -s -X POST http://localhost:9999/graphql \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "{ blogPosts(filterByYear: \"2024\", first: 3) { edges { node { id } } pageInfo { hasNextPage } } }"
+  }' | jq '
+    .data.blogPosts | {
+      posts2024: [.edges[].node.id],
+      hasNextPage: .pageInfo.hasNextPage
+    }'
+
+echo -e "\n6. Sort ASC (oldest first) with pagination:"
+curl -s -X POST http://localhost:9999/graphql \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "{ blogPosts(sortDirection: \"ASC\", first: 3) { edges { node { id } } } }"
+  }' | jq '.data.blogPosts.edges[].node.id'
+
+echo -e "\n7. Middle page using before cursor:"
+# First get the last 10 posts
+LAST_CURSOR=$(curl -s -X POST http://localhost:9999/graphql \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ blogPosts(last: 10) { pageInfo { startCursor } } }"}' | jq -r '.data.blogPosts.pageInfo.startCursor')
+
+echo "Getting 3 posts before cursor $LAST_CURSOR:"
+curl -s -X POST http://localhost:9999/graphql \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"query\": \"{ blogPosts(last: 3, before: \\\"$LAST_CURSOR\\\") { edges { node { id } } pageInfo { hasNextPage hasPreviousPage } } }\"
+  }" | jq '
+    .data.blogPosts | {
+      posts: [.edges[].node.id],
+      hasNextPage: .pageInfo.hasNextPage,
+      hasPreviousPage: .pageInfo.hasPreviousPage
+    }'


### PR DESCRIPTION

Implement Relay-style pagination with connections, edges, and page info
for GraphQL APIs. This enables efficient cursor-based pagination.

Changes:
- Add connection method to makeGqlBuilder for defining connection fields
- Implement connection processing in gqlSpecToNexus with Nexus integration
- Add BlogPost.listAll() and BlogPost.connection() methods
- Add blogPosts connection field to Query root with filtering/sorting
- Add comprehensive tests for connection implementation
- Add blog post fixtures for testing pagination
- Add test scripts for validating connection behavior

Test plan:
1. Run tests: bff test apps/bfDb
2. Run connection tests: ./test-blogposts-connection.sh
3. Verify GraphQL schema includes connection types
4. Test pagination with first/last/after/before args

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/1040).
* #1051
* #1047
* __->__ #1040