### PR TITLE
Remove project-level versioning concept

### DIFF
--- a/decks/cards/implementation-planning.card.md
+++ b/decks/cards/implementation-planning.card.md
@@ -3,7 +3,7 @@
 Implementation plans are temporary guides that provide just enough structure to
 keep development on track. They start simple and evolve with technical
 discoveries, eventually serving as source material for user-facing documentation
-when the version is complete.
+when the work is complete.
 
 ## Purpose
 
@@ -20,8 +20,8 @@ developers (human or AI) verify they're:
 
 ### Overview
 
-Start with 1-2 paragraphs explaining what this version delivers and why it
-matters. Keep it conceptual and focused on outcomes.
+Start with 1-2 paragraphs explaining what this work delivers and why it matters.
+Keep it conceptual and focused on outcomes.
 
 ### Goals
 
@@ -76,7 +76,7 @@ patterns. This should give readers the "why" behind technical choices.
 - Try to answer every question upfront
 - Create documentation for documentation's sake
 - Make the plan so detailed it becomes rigid
-- Keep plans around after version completion
+- Keep plans around after work completion
 - Separate planning from doing
 
 ## Evolution Cycle
@@ -87,7 +87,7 @@ patterns. This should give readers the "why" behind technical choices.
 3. **Scaffolding**: Create minimal structure based on plan
 4. **Discovery**: Update plan with technical findings
 5. **Iteration**: Repeat steps 2-4 until complete
-6. **Completion**: Mine for user-facing documentation
+6. **Archive**: Mine for user-facing documentation
 
 The test creation and scaffolding phases follow our Test-Driven Development
 workflow - see [testing.card.md](./testing.card.md) for detailed TDD practices.
@@ -99,7 +99,7 @@ An implementation plan is ready to be archived when:
 - All goals have been achieved
 - Tests are passing
 - Technical decisions are documented
-- The version is ready to ship
+- The work is ready to ship
 
 At this point, the implementation plan becomes source material for creating
 user-facing documentation, changelogs, and other public artifacts.

--- a/decks/cards/project-planning.card.md
+++ b/decks/cards/project-planning.card.md
@@ -38,13 +38,6 @@ decisions.
 | -------------------- | ------------------------- | ------------------- |
 | [Current work items] | [Active/Complete/Blocked] | [Brief description] |
 
-**Versions**
-
-| Version         | Status                     | Description                                   |
-| --------------- | -------------------------- | --------------------------------------------- |
-| [v0.0](V0.0.md) | [Current/Complete/Planned] | [Brief summary of what this version delivers] |
-| [v0.1](V0.1.md) | [Planned]                  | [What this version will add]                  |
-
 **Future work**
 
 | Task             | Description             |
@@ -58,13 +51,6 @@ decisions.
 | [What we track] | [Why we track it] | [How we measure] |
 
 ### Supporting Documents
-
-**V[version].md** (e.g., `V0.0.md`, `V0.1.md`)
-
-- Technical details and implementation approaches for each version
-- More detailed than the README
-- Preserved for each version to maintain decision history
-- Linked from the Versions table in README.md
 
 **BACKLOG.md**
 
@@ -85,10 +71,9 @@ decisions.
 
 - Create the README early, even with empty sections
 - Write conversationally, especially in the first two sections
-- Use tables for structured information (status, versions, future work, metrics)
+- Use tables for structured information (status, future work, metrics)
 - Keep the README high-level and less technical
 - Update documents as conversations with AI evolve
-- Track version progression to show project evolution
 - Point AI to docs/README.md as the starting point
 
 ### Don't:

--- a/examples/docs/README.md
+++ b/examples/docs/README.md
@@ -16,13 +16,9 @@ add examples. Takes forever to see anything work.
 
 ## Status
 
-Working on v0.1.0.
-
-## Versions
-
-| Version           | Status | Description       |
-| ----------------- | ------ | ----------------- |
-| [v0.1.0](V0.1.md) | Active | Fix nextjs-sample |
+| Task | Status | Description |
+| --- | --- | --- |
+| Fix nextjs-sample | Active | Add TypeScript, fix formatting |
 
 ## Future work
 

--- a/examples/nextjs-minimal/docs/README.md
+++ b/examples/nextjs-minimal/docs/README.md
@@ -27,12 +27,6 @@ Based on the product plan's v0.1 focus on "Interactive Documentation & Examples,
 | Test and validate | Pending | Ensure it runs cleanly |
 | Add inline documentation | Pending | Clear comments explaining each part |
 
-## Versions
-
-| Version | Status | Description |
-| --- | --- | --- |
-| [v0.1](V0.1.md) | Current | Initial minimal example with basic chat |
-
 ## Future work
 
 | Task | Description |

--- a/memos/guides/deck-system.md
+++ b/memos/guides/deck-system.md
@@ -16,7 +16,7 @@ specifications:
 - **Semantic**: Clear meaning and purpose
 - **Composable**: Combine to create complex behaviors
 - **Testable**: Validate in isolation
-- **Versionable**: Evolve without breaking combinations
+- **Evolvable**: Can be updated without breaking existing combinations
 - **Shareable**: Publish and reuse across projects
 
 ### Deck structure


### PR DESCRIPTION

Simplify project management by removing version tables and version-specific documentation. Projects now track current work status and future tasks without maintaining version histories.

Changes:
- Remove Versions table from project-planning.card.md
- Remove references to V[version].md files from project planning
- Update implementation-planning.card.md to use "work" instead of "version"
- Change "Versionable" to "Evolvable" in deck-system.md
- Update example projects to remove version tables

Test plan:
1. Run tests: `bff test`
2. Verify documentation builds correctly
3. Check that project planning still provides clear structure

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/1041).
* #1043
* #1045
* __->__ #1041