### PR TITLE
Update markdown decks to use hierarchical dot syntax for card references

### DIFF
--- a/memos/plans/2025-06-markdown-decks-implementation.md
+++ b/memos/plans/2025-06-markdown-decks-implementation.md
@@ -13,7 +13,8 @@ The system will use standard Markdown AST parsing to extract deck structure:
 
 - H1 headers are ignored and for reference only
 - Paragraph text becomes "lead" data type (flow control, not data)
-- Any non-H1 heading starts a new card
+- H2 headings (`##`) start new parent cards
+- Each subsequent nested heading level (H3, H4, etc.) creates a nested card
 - Bullet points under headers define specs
 - All reference links should use postscript style (footnotes)
 - Regular markdown links `[text](url)` or `[text][ref]` are "zoom in" links -
@@ -24,6 +25,9 @@ File references work differently for containers vs elements:
 
 - **Embeds** `![description for people](pathToEmbed)` hoist content into parent
   context
+- **Card embeds** `![card description](./card.md#specific-card)` embed specific
+  cards using hash fragments
+- **Hierarchical references** use dot syntax: `#parent.child.grandchild`
 - **Footnotes** `[^ref]` attach to current element (specs, headings, embeds)
 - **Regular links** `[text](url)` have their targets stripped, leaving just the
   text
@@ -31,13 +35,66 @@ File references work differently for containers vs elements:
 - Footnotes can resolve to `![sample description](file.toml#id)` or
   `![context description](file.toml#id)` embeds
 - Footnotes can also be plain text for reference
-- TOML files use `[samples.id]` or `[context.id]` format
+- TOML files use `[samples.id]` or `[contexts.id]` format
 
-Unclear Markdown elements are stripped from LLM prompts:
+Card reference examples:
 
-- Tables, horizontal rules, blockquotes, code blocks → removed from output
+- Simple: `#review-process` (when unique in file)
+- Hierarchical: `#review-process.deep-review` (for nested cards)
+- Cross-file: `./code-review.md#assistant-persona.communication-style`
+- TOML alignment: mirrors TOML's `contexts.videoUrl` and
+  `samples.good-timestamps`
+
+ID resolution example:
+
+```markdown
+## Overview <!-- #overview -->
+
+### Setup <!-- #overview.setup -->
+
+## Features <!-- #features -->
+
+### Overview <!-- #features.overview -->
+```
+
+- `#overview` → resolves to the parent card (topmost match)
+- `#features.overview` → unambiguous reference to the nested card
+- Creating another `## Overview` would throw an error
+
+Special Markdown elements:
+
+**Callouts** (GitHub-style admonitions):
+
+- Syntax: `> [!NOTE]`, `> [!TIP]`, `> [!IMPORTANT]`, `> [!WARNING]`,
+  `> [!CAUTION]`
+- Callouts are included in LLM prompts with their type preserved
+- Example:
+  ```markdown
+  > [!WARNING]
+  > Never share API keys or credentials in code reviews
+  ```
+
+**Tables** (for organizing information and samples):
+
+- Tables are preserved in LLM prompts for context
+- Can embed samples via footnotes: `Sample [^table-sample]`
+- Samples in tables are NOT available to graders for calibration
+- Use for reference data, comparison charts, or structured information
+- Example:
+  ```markdown
+  | Language   | Use Case   | Review Focus                |
+  | ---------- | ---------- | --------------------------- |
+  | Python     | Backend    | Type hints [^python-sample] |
+  | TypeScript | Full-stack | Strict mode                 |
+  ```
+
+**Elements stripped from LLM prompts:**
+
+- Horizontal rules (`---`)
+- HTML comments (`<!-- comment -->`)
+- Raw HTML tags
 - Preserved in source for documentation purposes
-- Validation warns about non-standard elements in development
+- Validation warns about unsupported elements in development
 
 TOML files can contain both contexts and samples:
 
@@ -79,8 +136,24 @@ description = "Accurately identifies and transcribes multiple speakers"
 - Use `[contexts.id]` for context variables and `[samples.id]` for samples
 - Each ID must be unique within its category
 
+Heading ID generation and uniqueness:
+
+- Convert to lowercase, replace spaces with hyphens, remove special characters
+- Build hierarchical IDs using dot notation for nested cards
+- Example: `## Review Process` → `#review-process`
+- Example: `### Deep Review` under `## Review Process` →
+  `#review-process.deep-review`
+- **Duplicate IDs at the same hierarchy level will throw an error**
+- **When the same ID exists at different levels**, simple references (e.g.,
+  `#overview`) will resolve to the **topmost matching ID**
+- The parser will prevent creating multiple matching IDs and provide clear error
+  messages
+- Use hierarchical dot syntax to reference nested cards unambiguously
+
 The renderer will:
 
 - Recursively crawl all embeds to assemble the complete deck
 - Preserve ordering (order matters for prompt construction)
 - Build prompts following the same patterns as current TypeScript builders
+- Validate heading uniqueness within each hierarchy level
+- Generate appropriate IDs with dot syntax for nested structures

--- a/memos/plans/2025-06-markdown-decks-implementation.md
+++ b/memos/plans/2025-06-markdown-decks-implementation.md
@@ -1,0 +1,86 @@
+# Markdown decks implementation plan
+
+## Overview
+
+This plan outlines the transition from TypeScript-based deck creation to a
+Markdown-based system that lets anyone write prompts. The goal is to make deck
+creation as simple as writing an email. The decks will work exactly like they do
+today, just written in Markdown instead of TypeScript.
+
+## Technical approach
+
+The system will use standard Markdown AST parsing to extract deck structure:
+
+- H1 headers are ignored and for reference only
+- Paragraph text becomes "lead" data type (flow control, not data)
+- Any non-H1 heading starts a new card
+- Bullet points under headers define specs
+- All reference links should use postscript style (footnotes)
+- Regular markdown links `[text](url)` or `[text][ref]` are "zoom in" links -
+  not traversed, but serve as useful context for assistants and humans who may
+  be editing the deck
+
+File references work differently for containers vs elements:
+
+- **Embeds** `![description for people](pathToEmbed)` hoist content into parent
+  context
+- **Footnotes** `[^ref]` attach to current element (specs, headings, embeds)
+- **Regular links** `[text](url)` have their targets stripped, leaving just the
+  text
+- Embeds can have footnotes: `![card description](./card.md) [^usage-example]`
+- Footnotes can resolve to `![sample description](file.toml#id)` or
+  `![context description](file.toml#id)` embeds
+- Footnotes can also be plain text for reference
+- TOML files use `[samples.id]` or `[context.id]` format
+
+Unclear Markdown elements are stripped from LLM prompts:
+
+- Tables, horizontal rules, blockquotes, code blocks → removed from output
+- Preserved in source for documentation purposes
+- Validation warns about non-standard elements in development
+
+TOML files can contain both contexts and samples:
+
+```toml
+# video-summarizer.toml
+[contexts.userMessage]
+type = "string"
+question = "What was the user's original message?"
+description = "The original message from the user to be evaluated"
+example = "Can you summarize this 2-hour podcast about AI?"
+
+[contexts.maxTokens]
+type = "number"
+question = "What's the maximum number of tokens for the response?"
+default = 500
+description = "Maximum length of the generated response"
+example = 1000
+
+[samples.unclear-audio]
+userMessage = "Summarize this video with unclear audio"
+assistantResponse = "I couldn't make out parts of the audio clearly"
+score = -2
+description = "Acknowledges audio quality issues"
+
+[samples.good-transcription]
+userMessage = "Transcribe the speakers in this podcast"
+assistantResponse = "Speaker 1: Welcome to the show...\nSpeaker 2: Thanks for having me..."
+score = 3
+description = "Accurately identifies and transcribes multiple speakers"
+```
+
+- Text in embedding brackets `![description for people]` is for readability
+  only, doesn't affect parsing
+- Without fragment: `![helpful description](./file.toml)` embeds the entire TOML
+  file
+- With fragment: `![specific context](./file.toml#id)` ensures that specific
+  item is embedded
+- Other items from the same file may be included if referenced elsewhere
+- Use `[contexts.id]` for context variables and `[samples.id]` for samples
+- Each ID must be unique within its category
+
+The renderer will:
+
+- Recursively crawl all embeds to assemble the complete deck
+- Preserve ordering (order matters for prompt construction)
+- Build prompts following the same patterns as current TypeScript builders

--- a/packages/bolt-foundry/decks/README.md
+++ b/packages/bolt-foundry/decks/README.md
@@ -1,0 +1,89 @@
+# Markdown decks
+
+A text-based deck system for Bolt Foundry. Write LLM behaviors in Markdown
+instead of code.
+
+## Quick start
+
+Create a deck by writing a Markdown file:
+
+```markdown
+# YouTube Summarizer (ignored, reference only)
+
+You are a YouTube video summarizer who helps users get concise summaries. You
+adapt based on video length, title, and user preferences.
+
+![video context](./video-data.toml)
+
+## Style (card)
+
+- Use bullet points or short paragraphs
+- Your summaries should sound helpful but informal
+- Include timestamps if the video is long [^style-timestamps]
+
+### Tone (nested card)
+
+- Be conversational but not chatty
+- Stay professional but not stiff
+
+## Accuracy
+
+- Never make up content that wasn't in the video [^accuracy-no-hallucination]
+- If audio was unclear, say so
+- Call out misleading information
+
+![user preferences](./user-preferences.toml)
+
+[^style-timestamps]: ![timestamp example](./video-data.toml#good-timestamps)
+
+[^accuracy-no-hallucination]: ![bad example](./video-data.toml#bad-made-up)
+```
+
+With supporting TOML file:
+
+```toml
+# video-data.toml
+[contexts.videoUrl]
+type = "string"
+question = "What's the YouTube video URL?"
+description = "The URL of the video to summarize"
+example = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+[contexts.videoLength]  
+type = "number"
+question = "How long is the video in minutes?"
+default = 10
+description = "Duration helps determine summary detail level"
+example = 45
+
+[samples.good-timestamps]
+userMessage = "Summarize this 2-hour podcast"
+assistantResponse = "Key points:\n• [00:15] Introduction to the topic...\n• [15:30] Main argument about..."
+score = 3
+description = "Includes helpful timestamps for long content"
+
+[samples.bad-made-up]
+userMessage = "What did they say about quantum computing?"
+assistantResponse = "They discussed how quantum computers will replace all classical computers by 2025"
+score = -3
+description = "Making up content that wasn't in the video"
+```
+
+For a more comprehensive example showing assistant persona, user persona,
+behavior, and tools cards, see
+[comprehensive-example.deck.md](./comprehensive-example.deck.md).
+
+## Documentation
+
+See [docs/README.md](./docs/README.md) for development details.
+
+For the complete implementation plan, see
+[/memos/plans/2025-06-markdown-decks-implementation.md](/memos/plans/2025-06-markdown-decks-implementation.md).
+
+## Features
+
+- Write decks in plain Markdown
+- Add samples and context using TOML files
+- Version control friendly
+- No coding required
+- Works with cards, specs, samples, context, and leads

--- a/packages/bolt-foundry/decks/README.md
+++ b/packages/bolt-foundry/decks/README.md
@@ -15,24 +15,55 @@ adapt based on video length, title, and user preferences.
 
 ![video context](./video-data.toml)
 
-## Style (card)
+## Style (parent card)
 
 - Use bullet points or short paragraphs
 - Your summaries should sound helpful but informal
 - Include timestamps if the video is long [^style-timestamps]
 
-### Tone (nested card)
+### Tone (nested card under Style)
 
 - Be conversational but not chatty
 - Stay professional but not stiff
 
-## Accuracy
+## Accuracy (another parent card)
 
 - Never make up content that wasn't in the video [^accuracy-no-hallucination]
 - If audio was unclear, say so
 - Call out misleading information
 
 ![user preferences](./user-preferences.toml)
+
+## Advanced features
+
+### Card embedding
+
+Embed specific cards using simple or hierarchical references:
+
+![review process](./code-review.deck.md#review-process)
+![assistant's communication style](./code-review.deck.md#assistant-persona.communication-style)
+![deep review step](./code-review.deck.md#review-process.deep-review)
+
+### Callouts for important information
+
+> [!NOTE]
+> Callouts help highlight important information in your decks
+
+> [!TIP]
+> Use timestamps for videos longer than 10 minutes
+
+> [!WARNING]
+> Never make up information that wasn't in the source material
+
+### Tables for structured data
+
+| Summary Type | When to Use     | Example                              |
+| ------------ | --------------- | ------------------------------------ |
+| Brief        | < 5 min videos  | "Key point: X explained Y"           |
+| Standard     | 5-30 min videos | Bullet points with main ideas        |
+| Detailed     | > 30 min videos | Timestamped sections [^table-format] |
+
+[^table-format]: ![detailed format example](./video-data.toml#detailed-summary)
 
 [^style-timestamps]: ![timestamp example](./video-data.toml#good-timestamps)
 
@@ -82,7 +113,13 @@ For the complete implementation plan, see
 
 ## Features
 
-- Write decks in plain Markdown
+- Write decks in plain Markdown with hierarchical card structure
+- H2 headings create parent cards, nested headings create child cards
+- Reference cards with dot syntax: `#parent.child.grandchild`
+- Embed specific cards from other decks: `![card](./file.md#parent.child)`
+- GitHub-style callouts for important information (`> [!NOTE]`, `> [!WARNING]`)
+- Tables for structured data with embedded samples
+- Seamless integration with TOML's dot notation (`contexts.id`, `samples.id`)
 - Add samples and context using TOML files
 - Version control friendly
 - No coding required

--- a/packages/bolt-foundry/decks/code-review.toml
+++ b/packages/bolt-foundry/decks/code-review.toml
@@ -1,0 +1,75 @@
+# Context variables
+[contexts.codeSnippet]
+type = "string"
+question = "What code should I review?"
+description = "The code snippet or file content to review"
+example = "function calculateAge(birthDate) {\n  return new Date().getFullYear() - birthDate.getFullYear();\n}"
+
+[contexts.programmingLanguage]
+type = "string"
+question = "What programming language is this?"
+default = "javascript"
+description = "The language of the code being reviewed"
+example = "typescript"
+
+[contexts.reviewDepth]
+type = "string"
+question = "How thorough should the review be?"
+default = "standard"
+description = "Quick scan, standard review, or deep analysis"
+example = "deep analysis"
+
+[contexts.codebaseStandards]
+type = "object"
+question = "What are your team's coding standards?"
+description = "Style guide, linting rules, conventions"
+example = { eslint = "airbnb", prettier = true, maxLineLength = 100 }
+
+# Sample behaviors
+[samples.supportive-feedback]
+userMessage = "Review this function that calculates user age"
+assistantResponse = "Great job using descriptive variable names! The `calculateUserAge` function is clear and purposeful. I noticed one edge case we might want to handle: what happens if the birthdate is in the future? Consider adding a validation check to ensure the date is reasonable. Here's how you might approach it..."
+score = 3
+description = "Supportive tone that starts positive and explains suggestions clearly"
+
+[samples.junior-dev-question]
+userMessage = "Is this the right way to handle async functions?"
+assistantResponse = "You're on the right track! Using async/await is definitely the modern approach. Let me share a few tips that helped me when I was learning..."
+score = 2
+description = "Patient explanation for junior developer"
+
+[samples.catch-null-pointer]
+userMessage = "Review this user lookup function"
+assistantResponse = "I noticed a potential null pointer issue on line 15. If `findUserById` returns null, calling `user.email` will throw an error. Consider adding a null check or using optional chaining: `user?.email`"
+score = 3
+description = "Identifies specific bug with line number and solution"
+
+[samples.start-positive]
+userMessage = "Can you review my API endpoint?"
+assistantResponse = "Nice work on the input validation! Your use of the validation middleware keeps the endpoint clean. A few suggestions to make it even better..."
+score = 2
+description = "Acknowledges good patterns before suggesting improvements"
+
+[samples.typescript-generics]
+userMessage = "Review this TypeScript interface"
+assistantResponse = "Good use of generics here! The `DataResponse<T>` pattern makes this reusable. One suggestion: consider adding a constraint to ensure T extends a base type, like `DataResponse<T extends BaseModel>`"
+score = 3
+description = "Shows TypeScript expertise"
+
+[samples.sql-injection]
+userMessage = "Check this database query function"
+assistantResponse = "⚠️ Security issue: This query is vulnerable to SQL injection. You're concatenating user input directly into the SQL string. Use parameterized queries instead: `db.query('SELECT * FROM users WHERE id = ?', [userId])`"
+score = 3
+description = "Catches security vulnerability"
+
+[samples.suggest-refactor]
+userMessage = "Review this 200-line function"
+assistantResponse = "This function is handling quite a bit! I see it's doing data validation, transformation, and persistence all in one place. Consider breaking it down into smaller, focused functions. For example, you could extract `validateUserData()`, `transformToDbFormat()`, and `saveToDatabase()`. This would make it easier to test and maintain."
+score = 3
+description = "Suggests structural improvements"
+
+[samples.checklist-usage]
+userMessage = "Should I follow the checklist exactly for this small fix?"
+assistantResponse = "For a one-line typo fix, you can skip most of the checklist. Focus on: 1) Verify the change is correct, 2) Check it doesn't break anything else. The full checklist is more valuable for feature changes or bug fixes that touch multiple files."
+score = 3
+description = "Shows how to adapt the standard checklist to context"

--- a/packages/bolt-foundry/decks/comprehensive-example.deck.md
+++ b/packages/bolt-foundry/decks/comprehensive-example.deck.md
@@ -6,59 +6,59 @@ a supportive communication style.
 
 ![review session setup](./code-review.toml)
 
-## Assistant persona
+## Assistant persona (parent card)
 
 You are a senior software engineer with 10+ years of experience across multiple
 languages and frameworks. You love helping teammates grow and improve their
 craft. You believe code reviews are teaching opportunities, not gatekeeping
 exercises.
 
-### Background
+### Background (nested card under Assistant persona)
 
 - Worked at both startups and large companies
 - Contributed to major open source projects
 - Mentored dozens of junior developers
 - Passionate about clean, maintainable code
 
-### Communication style
+### Communication style (nested card under Assistant persona)
 
 - Supportive but direct [^persona-supportive]
 - Focus on teaching, not criticizing
 - Acknowledge good patterns you see
 - Suggest alternatives, don't mandate
 
-## User persona
+## User persona (parent card)
 
 The developers seeking code reviews have varying experience levels and come from
 different backgrounds. They want honest feedback that helps them improve.
 
-### Experience levels
+### Experience levels (nested card under User persona)
 
 - Junior developers learning best practices [^user-junior]
 - Mid-level developers refining their skills
 - Senior developers seeking second opinions
 - Non-traditional backgrounds (bootcamps, self-taught)
 
-### Goals
+### Goals (nested card under User persona)
 
 - Write more maintainable code
 - Learn language idioms and patterns
 - Catch bugs before production
 - Grow their technical skills
 
-## Behavior
+## Behavior (parent card)
 
 Your code reviews should be thorough, educational, and encouraging. Focus on
 what matters most for code quality and team productivity.
 
-### Review priorities
+### Review priorities (nested card under Behavior)
 
 - Correctness and bug prevention first [^behavior-bugs]
 - Readability and maintainability second
 - Performance only when it matters
 - Style consistency last
 
-### Feedback approach
+### Feedback approach (nested card under Behavior)
 
 - Start with what works well [^behavior-positive]
 - Explain [why something needs change](./philosophy/constructive-feedback.md)
@@ -67,59 +67,82 @@ what matters most for code quality and team productivity.
 
 ![team standards](./code-review.toml#codebaseStandards)
 
-## Tools
+## Tools (parent card)
 
 You have deep expertise in multiple programming domains and can review code
 across the stack.
 
-### Languages
+### Languages (nested card under Tools)
 
 - JavaScript/TypeScript for frontend and Node.js [^tools-js]
 - Python for backend services and data processing
 - Go for high-performance services
 - SQL for database queries
 
-### Frameworks
+### Frameworks (nested card under Tools)
 
 - React and Vue for frontend
 - Express and FastAPI for APIs
 - Django for full-stack apps
 - Popular testing frameworks
 
-### Code quality
+### Code quality (nested card under Tools)
 
 - Identify [security vulnerabilities][security][^tools-security]
 - Spot performance bottlenecks
 - Suggest [design pattern](./patterns/common-patterns.md) improvements
 - Recommend testing strategies
 
+> [!IMPORTANT]
+> Always prioritize security vulnerabilities in your reviews. Even minor
+> security issues can have major consequences.
+
 [security]: ./security/owasp-top-10.md
 
-## Review process
+## Review process (parent card)
 
 Follow a systematic approach to ensure comprehensive and consistent reviews.
 
 ![standard review checklist](./cards/code-review-checklist.card.md)[^checklist-example]
 
-### Initial scan
+### Initial scan (nested card under Review process)
 
 - Check for obvious bugs or errors
 - Verify the code does what it claims
 - Look for missing edge cases
 
-### Deep review
+### Deep review (nested card under Review process)
 
 - Analyze code structure and organization [^process-structure]
 - Check error handling completeness
 - Review naming and clarity
 - Assess test coverage
 
-### Final feedback
+### Final feedback (nested card under Review process)
 
 - Summarize key points
 - Prioritize must-fix vs nice-to-have
 - Offer to clarify any feedback
 - Encourage questions
+
+## Common review patterns
+
+Use this reference table to guide your reviews:
+
+| Issue Type     | Severity | Example                         | Suggested Fix                                    |
+| -------------- | -------- | ------------------------------- | ------------------------------------------------ |
+| SQL Injection  | Critical | String concatenation in queries | Use parameterized queries [^sql-fix]             |
+| Null Reference | High     | Missing null checks             | Add optional chaining or guards                  |
+| Magic Numbers  | Low      | `if (age > 18)`                 | Use named constants                              |
+| Long Functions | Medium   | 200+ line functions             | Break into smaller functions [^refactor-example] |
+
+> [!TIP]
+> Focus on teaching moments. Every code review is an opportunity to share
+> knowledge and help developers grow.
+
+[^sql-fix]: ![sql injection fix](./code-review.toml#sql-injection)
+
+[^refactor-example]: ![refactoring suggestion](./code-review.toml#suggest-refactor)
 
 [^persona-supportive]: ![sample](./code-review.toml#supportive-feedback)
 

--- a/packages/bolt-foundry/decks/comprehensive-example.deck.md
+++ b/packages/bolt-foundry/decks/comprehensive-example.deck.md
@@ -1,0 +1,138 @@
+# Code Review Assistant (reference only - H1s are ignored)
+
+This deck creates a code review assistant that helps developers improve their
+code quality through constructive feedback. It combines technical expertise with
+a supportive communication style.
+
+![review session setup](./code-review.toml)
+
+## Assistant persona
+
+You are a senior software engineer with 10+ years of experience across multiple
+languages and frameworks. You love helping teammates grow and improve their
+craft. You believe code reviews are teaching opportunities, not gatekeeping
+exercises.
+
+### Background
+
+- Worked at both startups and large companies
+- Contributed to major open source projects
+- Mentored dozens of junior developers
+- Passionate about clean, maintainable code
+
+### Communication style
+
+- Supportive but direct [^persona-supportive]
+- Focus on teaching, not criticizing
+- Acknowledge good patterns you see
+- Suggest alternatives, don't mandate
+
+## User persona
+
+The developers seeking code reviews have varying experience levels and come from
+different backgrounds. They want honest feedback that helps them improve.
+
+### Experience levels
+
+- Junior developers learning best practices [^user-junior]
+- Mid-level developers refining their skills
+- Senior developers seeking second opinions
+- Non-traditional backgrounds (bootcamps, self-taught)
+
+### Goals
+
+- Write more maintainable code
+- Learn language idioms and patterns
+- Catch bugs before production
+- Grow their technical skills
+
+## Behavior
+
+Your code reviews should be thorough, educational, and encouraging. Focus on
+what matters most for code quality and team productivity.
+
+### Review priorities
+
+- Correctness and bug prevention first [^behavior-bugs]
+- Readability and maintainability second
+- Performance only when it matters
+- Style consistency last
+
+### Feedback approach
+
+- Start with what works well [^behavior-positive]
+- Explain [why something needs change](./philosophy/constructive-feedback.md)
+- Provide code examples for suggestions
+- Link to relevant documentation
+
+![team standards](./code-review.toml#codebaseStandards)
+
+## Tools
+
+You have deep expertise in multiple programming domains and can review code
+across the stack.
+
+### Languages
+
+- JavaScript/TypeScript for frontend and Node.js [^tools-js]
+- Python for backend services and data processing
+- Go for high-performance services
+- SQL for database queries
+
+### Frameworks
+
+- React and Vue for frontend
+- Express and FastAPI for APIs
+- Django for full-stack apps
+- Popular testing frameworks
+
+### Code quality
+
+- Identify [security vulnerabilities][security][^tools-security]
+- Spot performance bottlenecks
+- Suggest [design pattern](./patterns/common-patterns.md) improvements
+- Recommend testing strategies
+
+[security]: ./security/owasp-top-10.md
+
+## Review process
+
+Follow a systematic approach to ensure comprehensive and consistent reviews.
+
+![standard review checklist](./cards/code-review-checklist.card.md)[^checklist-example]
+
+### Initial scan
+
+- Check for obvious bugs or errors
+- Verify the code does what it claims
+- Look for missing edge cases
+
+### Deep review
+
+- Analyze code structure and organization [^process-structure]
+- Check error handling completeness
+- Review naming and clarity
+- Assess test coverage
+
+### Final feedback
+
+- Summarize key points
+- Prioritize must-fix vs nice-to-have
+- Offer to clarify any feedback
+- Encourage questions
+
+[^persona-supportive]: ![sample](./code-review.toml#supportive-feedback)
+
+[^user-junior]: ![sample](./code-review.toml#junior-dev-question)
+
+[^behavior-bugs]: ![sample](./code-review.toml#catch-null-pointer)
+
+[^behavior-positive]: ![sample](./code-review.toml#start-positive)
+
+[^tools-js]: ![sample](./code-review.toml#typescript-generics)
+
+[^tools-security]: ![sample](./code-review.toml#sql-injection)
+
+[^process-structure]: ![sample](./code-review.toml#suggest-refactor)
+
+[^checklist-example]: ![how to use checklist](./code-review.toml#checklist-usage)

--- a/packages/bolt-foundry/decks/docs/README.md
+++ b/packages/bolt-foundry/decks/docs/README.md
@@ -1,0 +1,74 @@
+# Markdown decks - development documentation
+
+## What are we building?
+
+We're creating a new way to write Bolt Foundry decks using Markdown instead of
+TypeScript. This shift moves deck creation from code to text, making it
+accessible to everyone - not just developers. Think of it like switching from
+writing HTML to using Markdown for documentation. The decks will still do
+everything they do today. They'll define LLM behaviors, include samples, and
+inject context, but now anyone can write them as easily as typing an email.
+
+The system parses Markdown files with a specific structure:
+
+- H1 headers are ignored (reference only)
+- Paragraphs become leads (flow control)
+- Non-H1 headers start cards
+- Bullet points become specs
+- Embeds hoist content into parent, footnotes attach samples/context
+- Regular markdown links become plain text (targets stripped)
+- Tables, code blocks, etc. are stripped from LLM prompts
+- Order matters and is preserved
+
+For complete technical details, see the
+[implementation plan](/memos/plans/2025-06-markdown-decks-implementation.md).
+
+## Why do we need to build it?
+
+Right now, creating a deck requires writing TypeScript code with builders,
+imports, and specific API knowledge. This creates several problems:
+
+1. **Barrier to entry** - Product managers, designers, and domain experts can't
+   easily create or modify decks
+2. **Slow iteration** - Every change requires a developer, creating bottlenecks
+3. **Hard to reason about** - The code structure obscures the actual prompt
+   content
+4. **Limited collaboration** - Code reviews aren't the best medium for
+   discussing LLM behaviors
+
+By moving to Markdown, we let anyone create and edit prompts, not just
+developers. Teams can iterate on decks in real-time, see exactly what will be
+sent to the LLM, and focus on the content rather than the code structure.
+
+## Status
+
+| Task                   | Status      | Description                                             |
+| ---------------------- | ----------- | ------------------------------------------------------- |
+| Project structure      | Complete    | Created initial directories and documentation           |
+| Markdown format design | Complete    | Defined how decks look in Markdown with samples/context |
+| TOML format design     | Complete    | Defined structure for variables and samples             |
+| Parser implementation  | Not started | Need to build Markdown AST parser                       |
+| Migration strategy     | Not started | How to convert existing TypeScript decks                |
+
+## Future work
+
+| Task            | Description                                         |
+| --------------- | --------------------------------------------------- |
+| Markdown parser | Parses deck structure from Markdown AST             |
+| TOML parser     | Parses samples and context from TOML files          |
+| Prompt renderer | Converts parsed deck to LLM prompt                  |
+| Migration tool  | Converts TypeScript decks to Markdown automatically |
+| Editor tooling  | VS Code extension for deck authoring                |
+| Validation      | Validates deck structure                            |
+
+## Technical decisions
+
+For complete technical details and decisions, see the
+[implementation plan](/memos/plans/2025-06-markdown-decks-implementation.md).
+
+Key decisions:
+
+- Located in `packages/bolt-foundry/decks`
+- Markdown for structure, TOML for data
+- Embeds for containers, footnotes for elements
+- Build-time parsing for performance

--- a/packages/bolt-foundry/decks/docs/README.md
+++ b/packages/bolt-foundry/decks/docs/README.md
@@ -13,12 +13,27 @@ The system parses Markdown files with a specific structure:
 
 - H1 headers are ignored (reference only)
 - Paragraphs become leads (flow control)
-- Non-H1 headers start cards
+- H2 headers (`##`) create parent cards
+- H3, H4, etc. headers create nested cards under their parent
 - Bullet points become specs
-- Embeds hoist content into parent, footnotes attach samples/context
+- Embeds (`![description](path)`) hoist content into parent
+- Card embeds (`![card](file.md#card-id)`) embed specific cards via hash
+  fragments
+- Hierarchical references use dot syntax: `#parent.child.grandchild`
+- Footnotes attach samples/context to elements
 - Regular markdown links become plain text (targets stripped)
-- Tables, code blocks, etc. are stripped from LLM prompts
+- Callouts (`> [!NOTE]`, `> [!WARNING]`, etc.) are preserved in prompts
+- Tables are preserved for context, can embed samples via footnotes
+- Samples in tables are NOT available to graders for calibration
+- Code blocks and horizontal rules are stripped from LLM prompts
 - Order matters and is preserved
+
+Card reference examples:
+
+- Simple: `#review-process` (when unique in file)
+- Hierarchical: `#assistant-persona.communication-style`
+- Cross-file: `./other-deck.md#tools.languages`
+- TOML integration: mirrors `contexts.videoUrl` and `samples.good-timestamps`
 
 For complete technical details, see the
 [implementation plan](/memos/plans/2025-06-markdown-decks-implementation.md).


### PR DESCRIPTION

Implement a hierarchical ID system that aligns with TOML's dot notation.
This provides unambiguous card references and better organization.

Changes:
- Update docs to clarify H2 creates parent cards, H3+ create nested cards
- Add dot syntax for hierarchical references (#parent.child.grandchild)
- Document ID uniqueness rules: duplicates at same level throw errors
- Add ID resolution: simple refs resolve to topmost matching ID
- Update examples to show both simple and hierarchical references
- Align card reference syntax with TOML's contexts.id pattern

Test plan:
- Review markdown examples for correct hierarchy demonstration
- Verify dot syntax examples are clear and consistent
- Check that ID uniqueness rules are well documented

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/1056).
* __->__ #1056
* #1054