### PR TITLE
Run format before amending commits in bff amend

### DIFF
--- a/infra/bff/friends/amend.bff.ts
+++ b/infra/bff/friends/amend.bff.ts
@@ -9,6 +9,17 @@ import { getLogger } from "packages/logger/logger.ts";
 const logger = getLogger(import.meta);
 
 export async function amend(args: Array<string>): Promise<number> {
+  // Run format first
+  logger.info("Running format before amending...");
+  const formatResult = await runShellCommand(["deno", "fmt"]);
+
+  if (formatResult !== 0) {
+    logger.error("❌ Format failed");
+    return formatResult;
+  }
+
+  logger.info("✅ Format completed successfully");
+
   // Check for --no-submit flag
   let submitPR = true;
   const filteredArgs = args.filter((arg) => {


### PR DESCRIPTION
Ensure code is properly formatted before amending commits by running
deno fmt automatically at the start of the amend process.

Changes:
- Add format step at the beginning of amend function
- Check format result and exit early if formatting fails
- Add logging to show format progress

Test plan:
1. Run bff amend on a file with formatting issues
2. Verify format runs first and fixes issues before amending
3. Verify amend fails if format fails

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/1058)
<!-- GitContextEnd -->