### PR TITLE
Integrate full precommit checks into commit and amend commands

### DIFF
--- a/infra/bff/friends/commit.bff.ts
+++ b/infra/bff/friends/commit.bff.ts
@@ -67,36 +67,16 @@ async function stageAllFiles(): Promise<number> {
 }
 
 /**
- * Run the standard precommit checks (format, lint, type checking)
+ * Run the full precommit checks
  */
 async function runPrecommitChecks(): Promise<boolean> {
-  // Step 1: Run bff format
-  logger.info("Step 1/3: Formatting code...");
-  const formatResult = await runShellCommand(["bff", "format"]);
-  if (formatResult !== 0) {
-    logger.error("❌ Failed to format code");
+  logger.info("Running precommit checks...");
+  const precommitResult = await runShellCommand(["bff", "precommit"]);
+  if (precommitResult !== 0) {
+    logger.error("❌ Precommit checks failed");
     return false;
   }
-  logger.info("✅ Code formatted successfully");
-
-  // Step 2: Run bff lint
-  logger.info("Step 2/3: Linting code...");
-  const lintResult = await runShellCommand(["bff", "lint"]);
-  if (lintResult !== 0) {
-    logger.error("❌ Failed linting checks");
-    return false;
-  }
-  logger.info("✅ Linting passed");
-
-  // Step 3: Run bff check
-  logger.info("Step 3/3: Type checking...");
-  const checkResult = await runShellCommand(["bff", "check"]);
-  if (checkResult !== 0) {
-    logger.error("❌ Failed type checking");
-    return false;
-  }
-  logger.info("✅ Type checking passed");
-
+  logger.info("✅ Precommit checks passed");
   return true;
 }
 
@@ -107,7 +87,7 @@ export async function commit(args: Array<string>): Promise<number> {
   let runPreCheck = true; // Default to true - run pre-checks by default
   let submitPR = true; // Default to true - submit PR by default
 
-  // Parse arguments - look for -m flag, --skip-pre-check flag, and --no-submit flag
+  // Parse arguments - look for -m flag, --skip-precommit flag, and --no-submit flag
   const skipIndices = new Set<number>();
 
   for (let i = 0; i < args.length; i++) {
@@ -115,7 +95,7 @@ export async function commit(args: Array<string>): Promise<number> {
       commitMessage = args[i + 1];
       skipIndices.add(i);
       skipIndices.add(i + 1);
-    } else if (args[i] === "--skip-pre-check") {
+    } else if (args[i] === "--skip-precommit") {
       runPreCheck = false;
       skipIndices.add(i);
     } else if (args[i] === "--no-submit") {
@@ -124,7 +104,7 @@ export async function commit(args: Array<string>): Promise<number> {
     }
   }
 
-  // Get files to commit (all args except -m, the message, and --skip-pre-check)
+  // Get files to commit (all args except -m, the message, and --skip-precommit)
   for (let i = 0; i < args.length; i++) {
     if (!skipIndices.has(i)) {
       filesToCommit.push(args[i]);
@@ -133,7 +113,7 @@ export async function commit(args: Array<string>): Promise<number> {
 
   if (!commitMessage) {
     logger.error(
-      '❌ No commit message provided. Usage: bff commit -m "Your message" [--skip-pre-check] [--no-submit] [files...]',
+      '❌ No commit message provided. Usage: bff commit -m "Your message" [--skip-precommit] [--no-submit] [files...]',
     );
     return 1;
   }
@@ -234,9 +214,9 @@ register(
       description: "Commit message.",
     },
     {
-      option: "--skip-pre-check",
+      option: "--skip-precommit",
       description:
-        "Skip precommit checks (format, lint, type check). By default, pre-checks run automatically.",
+        "Skip precommit checks (format, lint, type check, test). By default, pre-checks run automatically.",
     },
     {
       option: "--no-submit",


### PR DESCRIPTION

Update both bff commit and bff amend to use the full bff precommit
command instead of partial or minimal checks.

Changes:
- bff commit: Replace inline format/lint/check with bff precommit
- bff amend: Replace format-only with full bff precommit
- Both commands now use --skip-precommit flag (was --skip-pre-check)
- Precommit runs by default, includes staging, format, lint --fix, check, test

Benefits:
- Consistent pre-commit behavior across all commit operations
- Automatic staging of new/deleted files
- Full test suite runs before commits
- Single source of truth for pre-commit logic

Test plan:
- Run bff commit with and without --skip-precommit
- Run bff amend with and without --skip-precommit
- Verify all checks run in correct order
- Verify --no-submit still works as expected
