### PR TITLE
Add markdown deck embed types and grader base deck

### DIFF
--- a/decks/example-tone-grader.deck.md
+++ b/decks/example-tone-grader.deck.md
@@ -1,0 +1,34 @@
+# Example Tone Grader
+
+This is an example grader deck using the postfix embed syntax to demonstrate how
+user criteria come first, followed by the grader framework.
+
+## Tone Evaluation
+
+![tone grader context](./example-tone-grader.deck.toml#contexts)
+
+### Main Criteria
+
+- Evaluate whether the response is concise without being curt
+- Consider the balance between brevity and helpfulness
+- Assess if the tone is appropriate for the context
+
+### Scoring Guidelines
+
+- Score 3: Perfectly concise while remaining helpful and warm [^perfect-concise]
+- Score 2: Good balance with minor improvements possible [^good-balance]
+- Score 1: Slightly too verbose or slightly too terse
+- Score 0: Neutral - acceptable but not optimal
+- Score -1: Noticeably too verbose or curt
+- Score -2: Significantly problematic tone [^too-verbose]
+- Score -3: Extremely verbose or rudely brief [^too-curt]
+
+[^perfect-concise]: ![](./example-tone-grader.deck.toml#samples.perfect-concise)
+
+[^good-balance]: ![](./example-tone-grader.deck.toml#samples.good-balance)
+
+[^too-verbose]: ![](./example-tone-grader.deck.toml#samples.too-verbose)
+
+[^too-curt]: ![](./example-tone-grader.deck.toml#samples.too-curt)
+
+> ![grader evaluation framework](./grader-base.deck.md#grader-evaluation)

--- a/decks/example-tone-grader.deck.toml
+++ b/decks/example-tone-grader.deck.toml
@@ -1,0 +1,38 @@
+# example-tone-grader.toml
+# Context and samples for tone evaluation
+
+[contexts.requestType]
+type = "string"
+question = "What type of request is this?"
+description = "The nature of the user's request (e.g., technical help, general inquiry, complaint)"
+example = "technical help"
+
+[contexts.userExpertise]
+type = "string"
+question = "What is the user's expertise level?"
+description = "The user's apparent technical knowledge level"
+example = "beginner"
+
+[samples.perfect-concise]
+userMessage = "How do I save a file?"
+assistantResponse = "Press Ctrl+S (Windows/Linux) or Cmd+S (Mac) to save your file."
+score = 3
+description = "Perfectly concise while being complete and helpful"
+
+[samples.too-verbose]
+userMessage = "What's 2+2?"
+assistantResponse = "Well, that's an interesting mathematical question! When we add the number 2 to itself, we perform the operation of addition. In this case, if we take 2 and add another 2, we get 4. This is one of the fundamental arithmetic operations that forms the basis of mathematics."
+score = -2
+description = "Way too verbose for a simple question"
+
+[samples.too-curt]
+userMessage = "I'm having trouble understanding how this function works. Could you help me?"
+assistantResponse = "Read the docs."
+score = -3
+description = "Rudely brief and unhelpful"
+
+[samples.good-balance]
+userMessage = "Can you explain what a variable is?"
+assistantResponse = "A variable is a container that stores data in your program. You can think of it like a labeled box where you put values that you want to use later."
+score = 2
+description = "Good balance of brevity and clarity"

--- a/decks/grader-base.deck.md
+++ b/decks/grader-base.deck.md
@@ -1,0 +1,22 @@
+# Grader Base Deck
+
+This deck represents the base evaluation framework that is automatically
+injected by the makeGraderDeckBuilder function into all grader decks.
+
+## Grader Evaluation
+
+### Evaluation Task
+
+- Evaluate the following AI assistant response based on the provided criteria
+
+### Output Format
+
+Return your evaluation as a JSON object with the following structure:
+
+- score: number between -3 and 3
+- notes: string explaining the evaluation
+- Return ONLY the JSON object, no other text
+
+## Context Variables
+
+![grader contexts](./grader-base.deck.toml)

--- a/decks/grader-base.deck.toml
+++ b/decks/grader-base.deck.toml
@@ -1,0 +1,20 @@
+# grader-base.toml
+# Context variables automatically injected by makeGraderDeckBuilder
+
+[contexts.userMessage]
+type = "string"
+question = "What was the user's original message?"
+description = "The original message from the user that prompted the assistant's response"
+example = "Can you help me write a Python function to sort a list?"
+
+[contexts.assistantResponse]
+type = "string"
+question = "What was the assistant's response?"
+description = "The AI assistant's response to be evaluated against the grading criteria"
+example = "Here's a Python function that sorts a list:\n\n```python\ndef sort_list(lst):\n    return sorted(lst)\n```"
+
+[contexts.expected]
+type = "string"
+question = "What was the expected response? (optional)"
+description = "Optional expected response for comparison during evaluation"
+example = "A detailed explanation with code examples showing both built-in and custom sorting approaches"


### PR DESCRIPTION
Extend markdown decks implementation to support positional embed types:
- Regular embeds (![...]) - in place within current context
- Prefix embeds (<![...]) - prepend before current block
- Postfix embeds (>![...]) - append after current block
- Parent embeds (^![...]) - hoist up to parent level

Create grader base deck that demonstrates the postfix embed pattern:
- grader-base.deck.md defines the evaluation framework
- grader-base.deck.toml contains context variables
- example-tone-grader shows how to use postfix embeds for graders

Changes:
- Update markdown decks implementation plan with all embed types
- Add philosophy note about reference syntax for human readability
- Create grader-base deck matching makeGraderDeckBuilder output
- Create example tone grader with own context, samples, and postfix embed
- Use consistent .deck.toml naming for deck-related TOML files

Test plan:
1. Review updated implementation plan for clarity
2. Verify grader deck structure matches TypeScript grader pattern
3. Check that example demonstrates all key features (context, samples, postfix)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/1070)
<!-- GitContextEnd -->