### PR TITLE
Add merge queue support and improve Deno caching in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+  merge_group: # 👈 add this
+    types: [checks_requested] # optional but keeps the run list tidy
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION

Enable GitHub merge queue workflow by adding merge_group trigger with
checks_requested type. This allows the CI to run when PRs are added to
the merge queue.

Improvements to Deno caching:
- Set explicit DENO_DIR environment variable for cache location
- Add deno cache and deno install commands before running tests
- Add comprehensive debugging output to troubleshoot cache issues
- Improve cache path configuration for better hit rates

These changes should help with both enabling merge queue functionality
and resolving the Deno dependency caching issues we've been experiencing.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
