### PR TITLE
Add Deno MCP server for exposing LSP diagnostics

### DIFF
--- a/apps/denomcp/README.md
+++ b/apps/denomcp/README.md
@@ -1,0 +1,75 @@
+# Deno MCP Server
+
+A Model Context Protocol (MCP) server that exposes Deno's language server
+diagnostics to AI assistants.
+
+## Features
+
+- On-demand diagnostics for TypeScript, JavaScript, JSX, TSX, JSON, and Markdown
+  files
+- Batch operations for checking multiple files efficiently
+- Persistent Deno LSP process for fast response times
+- Simple JSON-RPC over stdio communication
+
+## Usage
+
+Run the server:
+
+```bash
+deno run --allow-read --allow-write --allow-run apps/denomcp/mod.ts
+```
+
+The server communicates via stdio using JSON-RPC messages.
+
+## API
+
+### Tools
+
+#### `deno/diagnostics`
+
+Get diagnostics for one or more files.
+
+**Input:**
+
+```json
+{
+  "files": ["path/to/file1.ts", "path/to/file2.ts"]
+}
+```
+
+**Output:**
+
+```json
+{
+  "results": [
+    {
+      "file": "path/to/file1.ts",
+      "diagnostics": [
+        {
+          "range": {
+            "start": { "line": 0, "character": 0 },
+            "end": { "line": 0, "character": 10 }
+          },
+          "severity": 1,
+          "message": "Type 'string' is not assignable to type 'number'."
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Testing
+
+Run tests:
+
+```bash
+bff test apps/denomcp/
+```
+
+## Implementation Notes
+
+- Uses Deno's built-in `deno lsp` subprocess
+- Implements minimal JSON-RPC handling without external dependencies
+- Returns partial results when some files fail (e.g., file not found)
+- Automatically detects file types based on extension

--- a/apps/denomcp/debug-lsp-test.ts
+++ b/apps/denomcp/debug-lsp-test.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env -S deno run --allow-read --allow-write --allow-run
+
+// Direct test of LSP client
+import { LSPClient } from "./lsp-client.ts";
+import { getLogger } from "packages/logger/logger.ts";
+
+const logger = getLogger(import.meta);
+const client = new LSPClient();
+
+try {
+  // Create test file
+  const testFile = `${Deno.cwd()}/apps/denomcp/test-debug.ts`;
+  await Deno.writeTextFile(
+    testFile,
+    `
+const x: number = "this should be an error";
+console.log(x);
+  `,
+  );
+
+  logger.info("Getting diagnostics for:", testFile);
+  const diagnostics = await client.getDiagnostics(testFile);
+
+  logger.info("Diagnostics count:", diagnostics.length);
+  logger.info("Diagnostics:", JSON.stringify(diagnostics, null, 2));
+
+  // Cleanup
+  await Deno.remove(testFile);
+} finally {
+  await client.close();
+}

--- a/apps/denomcp/lsp-client.ts
+++ b/apps/denomcp/lsp-client.ts
@@ -1,0 +1,331 @@
+import type {
+  Diagnostic,
+  DidOpenTextDocumentParams,
+  InitializeParams,
+  LSPMessage,
+  PublishDiagnosticsParams,
+} from "./types.ts";
+import { getLogger } from "packages/logger/logger.ts";
+
+const logger = getLogger(import.meta);
+
+export class LSPClient {
+  private process: Deno.ChildProcess;
+  private encoder = new TextEncoder();
+  private decoder = new TextDecoder();
+  private messageId = 0;
+  private pendingRequests = new Map<number, {
+    resolve: (value: unknown) => void;
+    reject: (reason: unknown) => void;
+  }>();
+  private diagnosticsMap = new Map<string, Array<Diagnostic>>();
+  private initialized = false;
+  private initPromise: Promise<void>;
+  private writer: WritableStreamDefaultWriter<Uint8Array>;
+
+  constructor() {
+    this.process = new Deno.Command("deno", {
+      args: ["lsp"],
+      stdin: "piped",
+      stdout: "piped",
+      stderr: "null",
+    }).spawn();
+
+    this.writer = this.process.stdin.getWriter();
+    this.initPromise = this.initialize();
+    this.startReading();
+  }
+
+  private async initialize(): Promise<void> {
+    const initParams: InitializeParams = {
+      processId: Deno.pid,
+      rootUri: `file://${Deno.cwd()}`,
+      capabilities: {
+        textDocument: {
+          publishDiagnostics: {
+            relatedInformation: true,
+            versionSupport: false,
+            codeDescriptionSupport: true,
+            dataSupport: true,
+          },
+          synchronization: {
+            didOpen: true,
+            didClose: true,
+          },
+        },
+        workspace: {
+          configuration: true,
+        },
+      },
+    };
+
+    const initResult = await this.sendRequest("initialize", initParams);
+    logger.debug("LSP initialized:", JSON.stringify(initResult, null, 2));
+
+    await this.sendNotification("initialized", {});
+    this.initialized = true;
+  }
+
+  private async startReading(): Promise<void> {
+    const reader = this.process.stdout.getReader();
+    let buffer = "";
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += this.decoder.decode(value);
+
+      // Parse LSP messages (header + content)
+      while (true) {
+        const headerEnd = buffer.indexOf("\r\n\r\n");
+        if (headerEnd === -1) break;
+
+        const header = buffer.slice(0, headerEnd);
+        const contentLengthMatch = header.match(/Content-Length: (\d+)/);
+        if (!contentLengthMatch) {
+          buffer = buffer.slice(headerEnd + 4);
+          continue;
+        }
+
+        const contentLength = parseInt(contentLengthMatch[1]);
+        const contentStart = headerEnd + 4;
+
+        if (buffer.length < contentStart + contentLength) break;
+
+        const content = buffer.slice(
+          contentStart,
+          contentStart + contentLength,
+        );
+        buffer = buffer.slice(contentStart + contentLength);
+
+        try {
+          const message = JSON.parse(content) as LSPMessage;
+          this.handleMessage(message);
+        } catch (e) {
+          logger.error("Failed to parse LSP message:", e);
+        }
+      }
+    }
+  }
+
+  private handleMessage(message: LSPMessage): void {
+    // Debug log
+    if (message.method) {
+      logger.debug("LSP notification:", message.method);
+    }
+
+    // Handle responses to our requests
+    if (message.id !== undefined && message.method === undefined) {
+      const pending = this.pendingRequests.get(message.id as number);
+      if (pending) {
+        this.pendingRequests.delete(message.id as number);
+        if (message.error) {
+          pending.reject(message.error);
+        } else {
+          pending.resolve(message.result);
+        }
+      }
+    }
+
+    // Handle server requests that need responses
+    if (message.id !== undefined && message.method !== undefined) {
+      this.handleServerRequest(message);
+    }
+
+    // Handle notifications from server
+    if (message.method === "textDocument/publishDiagnostics") {
+      const params = message.params as PublishDiagnosticsParams;
+      logger.info(
+        "Got diagnostics for:",
+        params.uri,
+        "count:",
+        params.diagnostics.length,
+      );
+      this.diagnosticsMap.set(params.uri, params.diagnostics);
+    }
+  }
+
+  private async handleServerRequest(message: LSPMessage): Promise<void> {
+    logger.debug("Server request:", message.method, message.id);
+
+    switch (message.method) {
+      case "workspace/configuration": {
+        // Return empty configuration
+        const response: LSPMessage = {
+          jsonrpc: "2.0",
+          id: message.id,
+          result: [{}, {}, {}], // Return empty configs
+        };
+        await this.sendMessage(response);
+        break;
+      }
+      default: {
+        // Send error for unhandled requests
+        const errorResponse: LSPMessage = {
+          jsonrpc: "2.0",
+          id: message.id,
+          error: {
+            code: -32601,
+            message: `Method not found: ${message.method}`,
+          },
+        };
+        await this.sendMessage(errorResponse);
+      }
+    }
+  }
+
+  private async sendMessage(message: LSPMessage): Promise<void> {
+    const content = JSON.stringify(message);
+    const header = `Content-Length: ${content.length}\r\n\r\n`;
+    const fullMessage = this.encoder.encode(header + content);
+
+    await this.writer.write(fullMessage);
+  }
+
+  private async sendRequest(
+    method: string,
+    params?: unknown,
+  ): Promise<unknown> {
+    const id = ++this.messageId;
+    const message: LSPMessage = {
+      jsonrpc: "2.0",
+      id,
+      method,
+      params,
+    };
+
+    const promise = new Promise((resolve, reject) => {
+      this.pendingRequests.set(id, { resolve, reject });
+    });
+
+    await this.sendMessage(message);
+    return promise;
+  }
+
+  private async sendNotification(
+    method: string,
+    params?: unknown,
+  ): Promise<void> {
+    const message: LSPMessage = {
+      jsonrpc: "2.0",
+      method,
+      params,
+    };
+    await this.sendMessage(message);
+  }
+
+  async getDiagnostics(filePath: string): Promise<Array<Diagnostic>> {
+    // Ensure initialization is complete
+    await this.initPromise;
+
+    const uri = `file://${filePath}`;
+    logger.debug(`Getting diagnostics for: ${uri}`);
+
+    // Read file content
+    let content: string;
+    try {
+      content = await Deno.readTextFile(filePath);
+    } catch (e) {
+      const error = e as Error;
+      throw new Error(`Failed to read file: ${error.message}`);
+    }
+
+    // Clear existing diagnostics
+    this.diagnosticsMap.delete(uri);
+
+    // Open document to trigger diagnostics
+    const params: DidOpenTextDocumentParams = {
+      textDocument: {
+        uri,
+        languageId: this.getLanguageId(filePath),
+        version: 1,
+        text: content,
+      },
+    };
+
+    logger.debug(`Sending textDocument/didOpen for ${uri}`);
+    await this.sendNotification("textDocument/didOpen", params);
+
+    // Wait for diagnostics (with timeout)
+    const timeout = 5000;
+    const startTime = Date.now();
+
+    // Give LSP some time to process
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    while (Date.now() - startTime < timeout) {
+      const diagnostics = this.diagnosticsMap.get(uri);
+      if (diagnostics !== undefined) {
+        logger.debug(
+          `Got diagnostics for ${uri}, count: ${diagnostics.length}`,
+        );
+        // Close document
+        await this.sendNotification("textDocument/didClose", {
+          textDocument: { uri },
+        });
+        return diagnostics;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+
+    // Timeout - check one more time
+    const finalCheck = this.diagnosticsMap.get(uri);
+    logger.warn(
+      `Timeout waiting for diagnostics for ${uri}, final check: ${
+        finalCheck?.length || 0
+      }`,
+    );
+
+    // Close document
+    await this.sendNotification("textDocument/didClose", {
+      textDocument: { uri },
+    });
+
+    return finalCheck || [];
+  }
+
+  private getLanguageId(filePath: string): string {
+    const ext = filePath.split(".").pop()?.toLowerCase();
+    switch (ext) {
+      case "ts":
+        return "typescript";
+      case "tsx":
+        return "typescriptreact";
+      case "js":
+        return "javascript";
+      case "jsx":
+        return "javascriptreact";
+      case "json":
+        return "json";
+      case "md":
+        return "markdown";
+      default:
+        return "plaintext";
+    }
+  }
+
+  async close(): Promise<void> {
+    try {
+      await this.sendNotification("shutdown");
+    } catch {
+      // Ignore errors during shutdown
+    }
+    try {
+      await this.writer.close();
+    } catch {
+      // Ignore close errors
+    }
+    try {
+      await this.process.stdout.cancel();
+    } catch {
+      // Ignore cancel errors
+    }
+    try {
+      this.process.kill();
+      await this.process.status;
+    } catch {
+      // Process might already be terminated
+    }
+  }
+}

--- a/apps/denomcp/manual-test.ts
+++ b/apps/denomcp/manual-test.ts
@@ -1,0 +1,124 @@
+#!/usr/bin/env -S deno run --allow-read --allow-write --allow-run
+
+// Manual test for the MCP server
+import { getLogger } from "packages/logger/logger.ts";
+
+const logger = getLogger(import.meta);
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+logger.info("Starting MCP server test...");
+
+const process = new Deno.Command(Deno.execPath(), {
+  args: [
+    "run",
+    "--allow-read",
+    "--allow-write",
+    "--allow-run",
+    "apps/denomcp/mod.ts",
+  ],
+  stdin: "piped",
+  stdout: "piped",
+  stderr: "piped",
+}).spawn();
+
+const writer = process.stdin.getWriter();
+
+// Helper to send request and wait for response
+async function sendRequest(request: unknown): Promise<unknown> {
+  await writer.write(encoder.encode(JSON.stringify(request) + "\n"));
+
+  const reader = process.stdout.getReader();
+  const timeout = 5000;
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < timeout) {
+    const { value, done } = await reader.read();
+    if (done) break;
+
+    const text = decoder.decode(value);
+    const lines = text.split("\n");
+
+    for (const line of lines) {
+      if (line.trim()) {
+        try {
+          const msg = JSON.parse(line);
+          if (msg.id === (request as { id: string | number }).id) {
+            reader.releaseLock();
+            return msg;
+          }
+        } catch {
+          // Not JSON, skip
+        }
+      }
+    }
+  }
+
+  reader.releaseLock();
+  throw new Error("Timeout waiting for response");
+}
+
+try {
+  // Wait for server to start
+  await new Promise((resolve) => setTimeout(resolve, 500));
+
+  // 1. Initialize
+  logger.info("\n1. Sending initialize request...");
+  const initResponse = await sendRequest({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {},
+  });
+  logger.info("Initialize response:", JSON.stringify(initResponse, null, 2));
+
+  // 2. Test diagnostics with a file that has errors
+  const testFile = "apps/denomcp/test-error.ts";
+  await Deno.writeTextFile(
+    testFile,
+    `
+    const x: number = "this is a type error";
+    console.log(x);
+  `,
+  );
+
+  logger.info("\n2. Sending diagnostics request...");
+  const diagResponse = await sendRequest({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/call",
+    params: {
+      name: "deno_diagnostics",
+      arguments: {
+        files: [testFile],
+      },
+    },
+  });
+  logger.info("Diagnostics response:", JSON.stringify(diagResponse, null, 2));
+
+  // Cleanup
+  await Deno.remove(testFile);
+
+  // 3. Test with non-existent file
+  logger.info("\n3. Testing non-existent file...");
+  const errorResponse = await sendRequest({
+    jsonrpc: "2.0",
+    id: 3,
+    method: "tools/call",
+    params: {
+      name: "deno/diagnostics",
+      arguments: {
+        files: ["does-not-exist.ts"],
+      },
+    },
+  });
+  logger.info("Error response:", JSON.stringify(errorResponse, null, 2));
+} catch (e) {
+  logger.error("Test failed:", e);
+} finally {
+  await writer.close();
+  process.kill();
+  await process.status;
+}
+
+logger.info("\nTest complete!");

--- a/apps/denomcp/mcp-server.ts
+++ b/apps/denomcp/mcp-server.ts
@@ -1,0 +1,227 @@
+import type {
+  DiagnosticsParams,
+  FileDiagnostic,
+  MCPRequest,
+  MCPResponse,
+  MCPToolResult,
+} from "./types.ts";
+import { LSPClient } from "./lsp-client.ts";
+import { getLogger } from "packages/logger/logger.ts";
+
+const logger = getLogger(import.meta);
+
+export class MCPServer {
+  private lspClient: LSPClient;
+  private decoder = new TextDecoder();
+  private encoder = new TextEncoder();
+
+  constructor() {
+    this.lspClient = new LSPClient();
+  }
+
+  start(): void {
+    // Start reading stdin immediately
+    this.readMessages();
+  }
+
+  private async readMessages(): Promise<void> {
+    const reader = Deno.stdin.readable.getReader();
+    let buffer = "";
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += this.decoder.decode(value);
+
+      // Try to parse JSON messages (newline-delimited)
+      const lines = buffer.split("\n");
+      buffer = lines.pop() || ""; // Keep incomplete line in buffer
+
+      for (const line of lines) {
+        if (line.trim()) {
+          try {
+            const message = JSON.parse(line) as MCPRequest;
+            await this.handleRequest(message);
+          } catch (e) {
+            logger.error("Failed to parse MCP message:", e);
+          }
+        }
+      }
+    }
+  }
+
+  private async handleRequest(request: MCPRequest): Promise<void> {
+    logger.debug(`Handling request: ${request.method}`);
+    let response: MCPResponse;
+
+    try {
+      switch (request.method) {
+        case "initialize": {
+          logger.info("Initializing MCP server");
+          // Handle MCP initialization
+          response = {
+            jsonrpc: "2.0",
+            id: request.id,
+            result: {
+              protocolVersion: "2024-11-05",
+              capabilities: {
+                tools: {
+                  "deno_diagnostics": {
+                    description:
+                      "Get diagnostics for TypeScript/JavaScript files",
+                    inputSchema: {
+                      type: "object",
+                      properties: {
+                        files: {
+                          type: "array",
+                          items: { type: "string" },
+                          description: "Array of file paths to check",
+                        },
+                      },
+                      required: ["files"],
+                    },
+                  },
+                },
+              },
+              serverInfo: {
+                name: "deno-lsp-mcp",
+                version: "1.0.0",
+              },
+            },
+          };
+          break;
+        }
+
+        case "tools/list": {
+          logger.info("Listing available tools");
+          response = {
+            jsonrpc: "2.0",
+            id: request.id,
+            result: {
+              tools: [
+                {
+                  name: "deno_diagnostics",
+                  description:
+                    "Get diagnostics for TypeScript/JavaScript files",
+                  inputSchema: {
+                    type: "object",
+                    properties: {
+                      files: {
+                        type: "array",
+                        items: { type: "string" },
+                        description: "Array of file paths to check",
+                      },
+                    },
+                    required: ["files"],
+                  },
+                },
+              ],
+            },
+          };
+          break;
+        }
+
+        case "tools/call": {
+          const toolCall = request.params as {
+            name: string;
+            arguments: unknown;
+          };
+          if (toolCall.name === "deno_diagnostics") {
+            const result = await this.handleDiagnostics(
+              toolCall.arguments as DiagnosticsParams,
+            );
+            response = {
+              jsonrpc: "2.0",
+              id: request.id,
+              result,
+            };
+          } else {
+            response = {
+              jsonrpc: "2.0",
+              id: request.id,
+              error: {
+                code: -32601,
+                message: `Unknown tool: ${toolCall.name}`,
+              },
+            };
+          }
+          break;
+        }
+
+        default:
+          response = {
+            jsonrpc: "2.0",
+            id: request.id,
+            error: {
+              code: -32601,
+              message: `Method not found: ${request.method}`,
+            },
+          };
+      }
+    } catch (e) {
+      const error = e as Error;
+      response = {
+        jsonrpc: "2.0",
+        id: request.id,
+        error: {
+          code: -32603,
+          message: `Internal error: ${error.message}`,
+        },
+      };
+    }
+
+    await this.sendMessage(response);
+  }
+
+  private async handleDiagnostics(
+    params: DiagnosticsParams,
+  ): Promise<MCPToolResult> {
+    logger.debug(`Getting diagnostics for ${params.files.length} files`);
+    const results: Array<FileDiagnostic> = [];
+
+    for (const file of params.files) {
+      try {
+        // Convert relative paths to absolute
+        const absolutePath = file.startsWith("/")
+          ? file
+          : `${Deno.cwd()}/${file}`;
+
+        logger.debug(`Processing file: ${file} -> ${absolutePath}`);
+        const diagnostics = await this.lspClient.getDiagnostics(absolutePath);
+        logger.info(`Got ${diagnostics.length} diagnostics for ${file}`);
+
+        results.push({
+          file,
+          diagnostics,
+        });
+      } catch (e) {
+        const error = e as Error;
+        logger.error(`Error getting diagnostics for ${file}: ${error.message}`);
+        results.push({
+          file,
+          error: error.message,
+        });
+      }
+    }
+
+    // Return in MCP expected format
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({ results }, null, 2),
+        },
+      ],
+    };
+  }
+
+  private async sendMessage(message: unknown): Promise<void> {
+    const json = JSON.stringify(message) + "\n";
+    await Deno.stdout.write(this.encoder.encode(json));
+  }
+
+  async close(): Promise<void> {
+    await this.lspClient.close();
+  }
+}

--- a/apps/denomcp/mod.ts
+++ b/apps/denomcp/mod.ts
@@ -1,0 +1,29 @@
+#!/usr/bin/env -S deno run --allow-read --allow-write --allow-run --allow-env
+
+import { MCPServer } from "./mcp-server.ts";
+import { getLogger } from "packages/logger/logger.ts";
+
+const logger = getLogger(import.meta);
+
+// Handle graceful shutdown
+let server: MCPServer | null = null;
+
+async function shutdown() {
+  if (server) {
+    await server.close();
+  }
+  Deno.exit(0);
+}
+
+// Register signal handlers.
+Deno.addSignalListener("SIGINT", shutdown);
+Deno.addSignalListener("SIGTERM", shutdown);
+
+// Start server
+try {
+  server = new MCPServer();
+  await server.start();
+} catch (e) {
+  logger.error("Failed to start MCP server:", e);
+  Deno.exit(1);
+}

--- a/apps/denomcp/types.ts
+++ b/apps/denomcp/types.ts
@@ -1,0 +1,100 @@
+// MCP (Model Context Protocol) types
+export interface MCPRequest {
+  jsonrpc: "2.0";
+  id: string | number;
+  method: string;
+  params?: unknown;
+}
+
+export interface MCPResponse {
+  jsonrpc: "2.0";
+  id: string | number;
+  result?: unknown;
+  error?: MCPError;
+}
+
+export interface MCPError {
+  code: number;
+  message: string;
+  data?: unknown;
+}
+
+export interface DiagnosticsParams {
+  files: Array<string>;
+}
+
+export interface DiagnosticsResult {
+  results: Array<FileDiagnostic>;
+}
+
+export interface MCPContent {
+  type: string;
+  text: string;
+}
+
+export interface MCPToolResult {
+  content: Array<MCPContent>;
+}
+
+export interface FileDiagnostic {
+  file: string;
+  diagnostics?: Array<Diagnostic>;
+  error?: string;
+}
+
+export interface Diagnostic {
+  range: Range;
+  severity: DiagnosticSeverity;
+  code?: string | number;
+  source?: string;
+  message: string;
+}
+
+export interface Range {
+  start: Position;
+  end: Position;
+}
+
+export interface Position {
+  line: number;
+  character: number;
+}
+
+export enum DiagnosticSeverity {
+  Error = 1,
+  Warning = 2,
+  Information = 3,
+  Hint = 4,
+}
+
+// LSP (Language Server Protocol) types we need
+export interface LSPMessage {
+  jsonrpc: "2.0";
+  id?: string | number;
+  method?: string;
+  params?: unknown;
+  result?: unknown;
+  error?: unknown;
+}
+
+export interface InitializeParams {
+  processId: number | null;
+  rootUri: string | null;
+  capabilities: object;
+}
+
+export interface TextDocumentItem {
+  uri: string;
+  languageId: string;
+  version: number;
+  text: string;
+}
+
+export interface DidOpenTextDocumentParams {
+  textDocument: TextDocumentItem;
+}
+
+export interface PublishDiagnosticsParams {
+  uri: string;
+  diagnostics: Array<Diagnostic>;
+}

--- a/deno.lock
+++ b/deno.lock
@@ -60,7 +60,7 @@
     "jsr:@std/yaml@^1.0.5": "1.0.6",
     "jsr:@ts-morph/bootstrap@0.24": "0.24.0",
     "jsr:@ts-morph/common@0.24": "0.24.0",
-    "npm:@anthropic-ai/claude-code@^1.0.18": "1.0.18",
+    "npm:@anthropic-ai/claude-code@^1.0.19": "1.0.19",
     "npm:@hexagon/base64@^1.1.27": "1.1.28",
     "npm:@hyperdx/browser@~0.21.2": "0.21.2_@hyperdx+otel-web@0.16.3__@opentelemetry+api@1.9.0",
     "npm:@hyperdx/deno@^0.0.4": "0.0.4_@opentelemetry+api@1.6.0_@opentelemetry+api-logs@0.43.0",
@@ -74,6 +74,7 @@
     "npm:@lexical/utils@0.27.2": "0.27.2",
     "npm:@mdx-js/esbuild@^3.1.0": "3.1.0_esbuild@0.24.2",
     "npm:@mdx-js/mdx@^3.1.0": "3.1.0",
+    "npm:@modelcontextprotocol/sdk@^1.12.1": "1.12.1_express@5.1.0_zod@3.25.48",
     "npm:@neondatabase/serverless@~0.10.4": "0.10.4",
     "npm:@notionhq/client@^2.3.0": "2.3.0",
     "npm:@peculiar/asn1-android@^2.3.10": "2.3.16",
@@ -372,8 +373,8 @@
     }
   },
   "npm": {
-    "@anthropic-ai/claude-code@1.0.18": {
-      "integrity": "sha512-UXg3DkT64IVbtdHyrqUly5/IHGC1J4MXyNP6R4yycePucNK59ViVprMHKkWMdhCeiYMx8DkA6frbuBTYYKavwQ==",
+    "@anthropic-ai/claude-code@1.0.19": {
+      "integrity": "sha512-lejDYytnk5Zh/qhHDplTSNDslpEJOn4V4GN3yVry8ZAdXhc5JGtOpyCoDZPTagtK3yuZ1SpS3R0XFDIPzdJ+eQ==",
       "dependencies": [
         "@img/sharp-darwin-arm64",
         "@img/sharp-darwin-x64",
@@ -1097,6 +1098,22 @@
         "vfile"
       ]
     },
+    "@modelcontextprotocol/sdk@1.12.1_express@5.1.0_zod@3.25.48": {
+      "integrity": "sha512-KG1CZhZfWg+u8pxeM/mByJDScJSrjjxLc8fwQqbsS8xCjBmQfMNEBTotYdNanKekepnfRI85GtgQlctLFpcYPw==",
+      "dependencies": [
+        "ajv",
+        "content-type",
+        "cors",
+        "cross-spawn",
+        "eventsource",
+        "express",
+        "express-rate-limit",
+        "pkce-challenge",
+        "raw-body",
+        "zod",
+        "zod-to-json-schema"
+      ]
+    },
     "@neondatabase/serverless@0.10.4": {
       "integrity": "sha512-2nZuh3VUO9voBauuh+IGYRhGU/MskWHt1IuZvHcJw6GLjDgtqj/KViKo7SIrLdGLdot7vFbiRRw+BgEy3wT9HA==",
       "dependencies": [
@@ -1732,6 +1749,13 @@
         "event-target-shim"
       ]
     },
+    "accepts@2.0.0": {
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dependencies": [
+        "mime-types@3.0.1",
+        "negotiator"
+      ]
+    },
     "acorn-import-attributes@1.9.5_acorn@8.14.1": {
       "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
       "dependencies": [
@@ -1760,6 +1784,15 @@
       "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
       "dependencies": [
         "humanize-ms"
+      ]
+    },
+    "ajv@6.12.6": {
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dependencies": [
+        "fast-deep-equal",
+        "fast-json-stable-stringify",
+        "json-schema-traverse",
+        "uri-js"
       ]
     },
     "ansi-regex@5.0.1": {
@@ -1883,17 +1916,41 @@
     "bignumber.js@9.3.0": {
       "integrity": "sha512-EM7aMFTXbptt/wZdMlBv2t8IViwQL+h6SLHosp8Yf0dqJMTnY6iL32opnAB6kAdL0SZPuvcAzFr31o0c/R3/RA=="
     },
+    "body-parser@2.2.0": {
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "dependencies": [
+        "bytes",
+        "content-type",
+        "debug",
+        "http-errors",
+        "iconv-lite",
+        "on-finished",
+        "qs",
+        "raw-body",
+        "type-is"
+      ]
+    },
     "buffer-crc32@0.2.13": {
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="
     },
     "buffer-equal-constant-time@1.0.1": {
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
+    "bytes@3.1.2": {
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
+    },
     "call-bind-apply-helpers@1.0.2": {
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "dependencies": [
         "es-errors",
         "function-bind"
+      ]
+    },
+    "call-bound@1.0.4": {
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "get-intrinsic"
       ]
     },
     "ccount@2.0.1": {
@@ -1957,13 +2014,43 @@
     "comma-separated-tokens@2.0.3": {
       "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="
     },
+    "content-disposition@1.0.0": {
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "dependencies": [
+        "safe-buffer"
+      ]
+    },
+    "content-type@1.0.5": {
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="
+    },
+    "cookie-signature@1.2.2": {
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="
+    },
+    "cookie@0.7.2": {
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
+    },
     "core-js@3.42.0": {
       "integrity": "sha512-Sz4PP4ZA+Rq4II21qkNqOEDTDrCvcANId3xpIgB34NDkWc3UduWj2dqEtN9yZIq8Dk3HyPI33x9sqqU5C8sr0g=="
+    },
+    "cors@2.8.5": {
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": [
+        "object-assign",
+        "vary"
+      ]
     },
     "cross-inspect@1.0.1": {
       "integrity": "sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==",
       "dependencies": [
         "tslib"
+      ]
+    },
+    "cross-spawn@7.0.6": {
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dependencies": [
+        "path-key",
+        "shebang-command",
+        "which"
       ]
     },
     "css-tree@2.3.1": {
@@ -2018,6 +2105,9 @@
     },
     "delayed-stream@1.0.0": {
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+    },
+    "depd@2.0.0": {
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
     },
     "dequal@2.0.3": {
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
@@ -2084,8 +2174,14 @@
         "safe-buffer"
       ]
     },
+    "ee-first@1.1.1": {
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
     "emoji-regex@8.0.0": {
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "encodeurl@2.0.0": {
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="
     },
     "end-of-stream@1.4.4": {
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
@@ -2168,6 +2264,9 @@
     "escalade@3.2.0": {
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="
     },
+    "escape-html@1.0.3": {
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+    },
     "escodegen@2.1.0": {
       "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
       "dependencies": [
@@ -2232,8 +2331,58 @@
     "esutils@2.0.3": {
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
+    "etag@1.8.1": {
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
+    },
     "event-target-shim@5.0.1": {
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
+    "eventsource-parser@3.0.2": {
+      "integrity": "sha512-6RxOBZ/cYgd8usLwsEl+EC09Au/9BcmCKYF2/xbml6DNczf7nv0MQb+7BA2F+li6//I+28VNlQR37XfQtcAJuA=="
+    },
+    "eventsource@3.0.7": {
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dependencies": [
+        "eventsource-parser"
+      ]
+    },
+    "express-rate-limit@7.5.0_express@5.1.0": {
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "dependencies": [
+        "express"
+      ]
+    },
+    "express@5.1.0": {
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "dependencies": [
+        "accepts",
+        "body-parser",
+        "content-disposition",
+        "content-type",
+        "cookie",
+        "cookie-signature",
+        "debug",
+        "encodeurl",
+        "escape-html",
+        "etag",
+        "finalhandler",
+        "fresh",
+        "http-errors",
+        "merge-descriptors",
+        "mime-types@3.0.1",
+        "on-finished",
+        "once",
+        "parseurl",
+        "proxy-addr",
+        "qs",
+        "range-parser",
+        "router",
+        "send",
+        "serve-static",
+        "statuses@2.0.2",
+        "type-is",
+        "vary"
+      ]
     },
     "extend@3.0.2": {
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
@@ -2253,6 +2402,9 @@
     "fast-fifo@1.3.2": {
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
     },
+    "fast-json-stable-stringify@2.1.0": {
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
     "fast-xml-parser@4.5.3": {
       "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
       "dependencies": [
@@ -2271,6 +2423,17 @@
     "fflate@0.7.4": {
       "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw=="
     },
+    "finalhandler@2.1.0": {
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "dependencies": [
+        "debug",
+        "encodeurl",
+        "escape-html",
+        "on-finished",
+        "parseurl",
+        "statuses@2.0.2"
+      ]
+    },
     "follow-redirects@1.15.9": {
       "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="
     },
@@ -2283,7 +2446,7 @@
         "asynckit",
         "combined-stream",
         "es-set-tostringtag",
-        "mime-types",
+        "mime-types@2.1.35",
         "safe-buffer"
       ]
     },
@@ -2293,7 +2456,7 @@
         "asynckit",
         "combined-stream",
         "es-set-tostringtag",
-        "mime-types"
+        "mime-types@2.1.35"
       ]
     },
     "formdata-node@4.4.1": {
@@ -2302,6 +2465,12 @@
         "node-domexception",
         "web-streams-polyfill"
       ]
+    },
+    "forwarded@0.2.0": {
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
+    },
+    "fresh@2.0.0": {
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="
     },
     "function-bind@1.1.2": {
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
@@ -2492,6 +2661,16 @@
     "html-entities@2.6.0": {
       "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ=="
     },
+    "http-errors@2.0.0": {
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dependencies": [
+        "depd",
+        "inherits",
+        "setprototypeof",
+        "statuses@2.0.1",
+        "toidentifier"
+      ]
+    },
     "http-proxy-agent@5.0.0": {
       "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
       "dependencies": [
@@ -2555,6 +2734,9 @@
         "sprintf-js"
       ]
     },
+    "ipaddr.js@1.9.1": {
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+    },
     "is-alphabetical@2.0.1": {
       "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="
     },
@@ -2586,8 +2768,14 @@
     "is-potential-custom-element-name@1.0.1": {
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
     },
+    "is-promise@4.0.0": {
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
+    },
     "is-stream@2.0.1": {
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
+    },
+    "isexe@2.0.0": {
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "isomorphic.js@0.2.5": {
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw=="
@@ -2629,6 +2817,9 @@
       "dependencies": [
         "bignumber.js"
       ]
+    },
+    "json-schema-traverse@0.4.1": {
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stringify-safe@5.0.1": {
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
@@ -2865,6 +3056,12 @@
     },
     "mdn-data@2.0.30": {
       "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
+    },
+    "media-typer@1.1.0": {
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="
+    },
+    "merge-descriptors@2.0.0": {
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="
     },
     "micromark-core-commonmark@2.0.3": {
       "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
@@ -3125,10 +3322,19 @@
     "mime-db@1.52.0": {
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
+    "mime-db@1.54.0": {
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="
+    },
     "mime-types@2.1.35": {
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dependencies": [
-        "mime-db"
+        "mime-db@1.52.0"
+      ]
+    },
+    "mime-types@3.0.1": {
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "dependencies": [
+        "mime-db@1.54.0"
       ]
     },
     "mime@3.0.0": {
@@ -3145,6 +3351,9 @@
     },
     "ms@2.1.3": {
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "negotiator@1.0.0": {
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="
     },
     "netmask@2.0.2": {
       "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="
@@ -3175,8 +3384,20 @@
         "marked@11.2.0"
       ]
     },
+    "object-assign@4.1.1": {
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+    },
+    "object-inspect@1.13.4": {
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="
+    },
     "obuf@1.1.2": {
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
+    },
+    "on-finished@2.4.1": {
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dependencies": [
+        "ee-first"
+      ]
     },
     "once@1.4.0": {
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
@@ -3241,8 +3462,17 @@
         "entities"
       ]
     },
+    "parseurl@1.3.3": {
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
+    "path-key@3.1.1": {
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+    },
     "path-parse@1.0.7": {
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "path-to-regexp@8.2.0": {
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ=="
     },
     "pend@1.2.0": {
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
@@ -3306,6 +3536,9 @@
       "dependencies": [
         "split2"
       ]
+    },
+    "pkce-challenge@5.0.0": {
+      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ=="
     },
     "postgres-array@2.0.0": {
       "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
@@ -3385,6 +3618,13 @@
         "long@4.0.0"
       ]
     },
+    "proxy-addr@2.0.7": {
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dependencies": [
+        "forwarded",
+        "ipaddr.js"
+      ]
+    },
     "proxy-agent@6.5.0": {
       "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
       "dependencies": [
@@ -3437,8 +3677,26 @@
     "pvutils@1.1.3": {
       "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ=="
     },
+    "qs@6.14.0": {
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "dependencies": [
+        "side-channel"
+      ]
+    },
     "querystringify@2.2.0": {
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+    },
+    "range-parser@1.2.1": {
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+    },
+    "raw-body@3.0.0": {
+      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "dependencies": [
+        "bytes",
+        "http-errors",
+        "iconv-lite",
+        "unpipe"
+      ]
     },
     "react-dom@19.1.0_react@19.1.0": {
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
@@ -3591,6 +3849,16 @@
     "retry@0.13.1": {
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
     },
+    "router@2.2.0": {
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dependencies": [
+        "debug",
+        "depd",
+        "is-promise",
+        "parseurl",
+        "path-to-regexp"
+      ]
+    },
     "rrweb-cssom@0.6.0": {
       "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw=="
     },
@@ -3629,8 +3897,81 @@
     "semver@7.7.2": {
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="
     },
+    "send@1.2.0": {
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "dependencies": [
+        "debug",
+        "encodeurl",
+        "escape-html",
+        "etag",
+        "fresh",
+        "http-errors",
+        "mime-types@3.0.1",
+        "ms",
+        "on-finished",
+        "range-parser",
+        "statuses@2.0.2"
+      ]
+    },
+    "serve-static@2.2.0": {
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "dependencies": [
+        "encodeurl",
+        "escape-html",
+        "parseurl",
+        "send"
+      ]
+    },
+    "setprototypeof@1.2.0": {
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "shebang-command@2.0.0": {
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dependencies": [
+        "shebang-regex"
+      ]
+    },
+    "shebang-regex@3.0.0": {
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+    },
     "shimmer@1.2.1": {
       "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+    },
+    "side-channel-list@1.0.0": {
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dependencies": [
+        "es-errors",
+        "object-inspect"
+      ]
+    },
+    "side-channel-map@1.0.1": {
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dependencies": [
+        "call-bound",
+        "es-errors",
+        "get-intrinsic",
+        "object-inspect"
+      ]
+    },
+    "side-channel-weakmap@1.0.2": {
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dependencies": [
+        "call-bound",
+        "es-errors",
+        "get-intrinsic",
+        "object-inspect",
+        "side-channel-map"
+      ]
+    },
+    "side-channel@1.1.0": {
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dependencies": [
+        "es-errors",
+        "object-inspect",
+        "side-channel-list",
+        "side-channel-map",
+        "side-channel-weakmap"
+      ]
     },
     "smart-buffer@4.2.0": {
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
@@ -3667,6 +4008,12 @@
     },
     "sprintf-js@1.1.3": {
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
+    },
+    "statuses@2.0.1": {
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
+    },
+    "statuses@2.0.2": {
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="
     },
     "stream-events@1.0.5": {
       "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
@@ -3769,6 +4116,9 @@
         "b4a"
       ]
     },
+    "toidentifier@1.0.1": {
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
+    },
     "tough-cookie@4.1.4": {
       "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
       "dependencies": [
@@ -3801,6 +4151,14 @@
     },
     "type-fest@4.20.1": {
       "integrity": "sha512-R6wDsVsoS9xYOpy8vgeBlqpdOyzJ12HNfQhC/aAKWM3YoCV9TtunJzh/QpkMgeDhkoynDcw5f1y+qF9yc/HHyg=="
+    },
+    "type-is@2.0.1": {
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dependencies": [
+        "content-type",
+        "media-typer",
+        "mime-types@3.0.1"
+      ]
     },
     "typed-query-selector@2.12.0": {
       "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg=="
@@ -3871,6 +4229,15 @@
     "universalify@0.2.0": {
       "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="
     },
+    "unpipe@1.0.0": {
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
+    },
+    "uri-js@4.4.1": {
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dependencies": [
+        "punycode"
+      ]
+    },
     "url-parse@1.5.10": {
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "dependencies": [
@@ -3889,6 +4256,9 @@
     },
     "uuid@9.0.1": {
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+    },
+    "vary@1.1.2": {
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     },
     "vfile-message@4.0.2": {
       "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
@@ -3948,6 +4318,12 @@
         "webidl-conversions@3.0.1"
       ]
     },
+    "which@2.0.2": {
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": [
+        "isexe"
+      ]
+    },
     "wrap-ansi@7.0.0": {
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dependencies": [
@@ -4004,6 +4380,12 @@
     },
     "yocto-queue@0.1.0": {
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+    },
+    "zod-to-json-schema@3.24.5_zod@3.25.48": {
+      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "dependencies": [
+        "zod"
+      ]
     },
     "zod@3.25.48": {
       "integrity": "sha512-0X1mz8FtgEIvaxGjdIImYpZEaZMrund9pGXm3M6vM7Reba0e2eI71KPjSCGXBfwKDPwPoywf6waUKc3/tFvX2Q=="
@@ -4121,7 +4503,7 @@
     ],
     "packageJson": {
       "dependencies": [
-        "npm:@anthropic-ai/claude-code@^1.0.18",
+        "npm:@anthropic-ai/claude-code@^1.0.19",
         "npm:@hyperdx/browser@~0.21.2",
         "npm:@hyperdx/deno@^0.0.4",
         "npm:@isograph/compiler@0.0.0-main-1fad6d74",
@@ -4133,6 +4515,7 @@
         "npm:@lexical/utils@0.27.2",
         "npm:@mdx-js/esbuild@^3.1.0",
         "npm:@mdx-js/mdx@^3.1.0",
+        "npm:@modelcontextprotocol/sdk@^1.12.1",
         "npm:@neondatabase/serverless@~0.10.4",
         "npm:@notionhq/client@^2.3.0",
         "npm:@replit/extensions@^1.10.0",

--- a/infra/bin/claude
+++ b/infra/bin/claude
@@ -1,3 +1,3 @@
 #! /bin/bash
 
-deno run -A npm:@anthropic-ai/claude-code
+deno run -A npm:@anthropic-ai/claude-code "$@"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@anthropic-ai/claude-code": "^1.0.18",
+    "@anthropic-ai/claude-code": "^1.0.19",
     "@hyperdx/browser": "^0.21.2",
     "@hyperdx/deno": "^0.0.4",
     "@isograph/compiler": "0.0.0-main-1fad6d74",
@@ -12,6 +12,7 @@
     "@lexical/utils": "0.27.2",
     "@mdx-js/esbuild": "^3.1.0",
     "@mdx-js/mdx": "^3.1.0",
+    "@modelcontextprotocol/sdk": "^1.12.1",
     "@neondatabase/serverless": "^0.10.4",
     "@notionhq/client": "^2.3.0",
     "@replit/extensions": "^1.10.0",


### PR DESCRIPTION

Implement a minimal Model Context Protocol (MCP) server that provides
on-demand TypeScript/JavaScript diagnostics via Deno's language server.

Changes:
- Add apps/denomcp/ with MCP server implementation
- Create LSPClient wrapper for persistent Deno LSP subprocess
- Implement JSON-RPC handling for MCP protocol
- Support batch diagnostics for multiple files
- Add README with usage documentation
- Use logger instead of console for all logging
- Fix all linting issues (type imports, unused vars, case declarations)

Test plan:
1. Run manual test: deno run --allow-all apps/denomcp/manual-test.ts
2. Check server starts: deno run --allow-all apps/denomcp/mod.ts
3. Verify diagnostics work for TypeScript files with errors

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
