### PR TITLE
Update aibff build configuration for multi-command architecture

### DIFF
--- a/apps/aibff/__tests__/backward-compatibility.test.ts
+++ b/apps/aibff/__tests__/backward-compatibility.test.ts
@@ -1,0 +1,96 @@
+#!/usr/bin/env -S bff test
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+
+const mainScript = new URL("../main.ts", import.meta.url).pathname;
+const fixturesDir = new URL("./fixtures", import.meta.url).pathname;
+
+/**
+ * Backward compatibility tests to ensure the new command structure
+ * maintains the same behavior as the old eval.ts script
+ */
+
+Deno.test("aibff eval should show help with no arguments", async () => {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: ["run", "--allow-all", mainScript, "eval"],
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const { code, stdout } = await command.output();
+  const output = new TextDecoder().decode(stdout);
+
+  assertEquals(code, 0);
+  assertStringIncludes(output, "Usage: eval.ts");
+  assertStringIncludes(output, "Examples:");
+  assertStringIncludes(output, "Calibration mode");
+});
+
+Deno.test("aibff eval --help should show help", async () => {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: ["run", "--allow-all", mainScript, "eval", "--help"],
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const { code, stdout } = await command.output();
+  const output = new TextDecoder().decode(stdout);
+
+  assertEquals(code, 0);
+  assertStringIncludes(output, "Usage: eval.ts");
+});
+
+Deno.test("aibff eval should fail when OPENROUTER_API_KEY is missing", async () => {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "--allow-all",
+      mainScript,
+      "eval",
+      `${fixturesDir}/test-grader.deck.md`,
+    ],
+    env: {
+      ...Deno.env.toObject(),
+      OPENROUTER_API_KEY: "", // Clear the key
+    },
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const { code, stderr } = await command.output();
+  const error = new TextDecoder().decode(stderr);
+
+  assertEquals(code, 1);
+  assertStringIncludes(error, "OPENROUTER_API_KEY");
+});
+
+Deno.test("aibff eval should display correct info for calibration mode", async () => {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "--allow-all",
+      mainScript,
+      "eval",
+      `${fixturesDir}/test-grader.deck.md`,
+    ],
+    env: {
+      ...Deno.env.toObject(),
+      OPENROUTER_API_KEY: "test-key",
+    },
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const { stderr } = await command.output();
+  const error = new TextDecoder().decode(stderr);
+
+  // Will fail because test-key is not valid, but we can check the info messages
+  assertStringIncludes(error, `${fixturesDir}/test-grader.deck.md`);
+  // The test environment may detect stdin, so we check for either case
+  const hasEmbeddedSamples = error.includes(
+    "Using embedded samples from grader deck",
+  );
+  const hasInputFile = error.includes("Using input file:");
+  assertEquals(hasEmbeddedSamples || hasInputFile, true);
+  assertStringIncludes(error, "anthropic/claude-3.5-sonnet");
+});

--- a/apps/aibff/__tests__/commands/eval.test.ts
+++ b/apps/aibff/__tests__/commands/eval.test.ts
@@ -1,0 +1,224 @@
+#!/usr/bin/env -S bff test
+
+import { getConfigurationVariable } from "@bolt-foundry/get-configuration-var";
+import { assertEquals, assertStringIncludes } from "@std/assert";
+
+/**
+ * Integration tests for the aibff eval command
+ *
+ * Tests verify that the eval command correctly handles different input modes
+ * and provides appropriate error messages.
+ */
+
+const evalScript = new URL("../../commands/eval.ts", import.meta.url).pathname;
+const fixturesDir = new URL("../fixtures", import.meta.url).pathname;
+
+Deno.test("eval should show help when no arguments provided", async () => {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "--allow-env",
+      "--allow-read",
+      "--allow-net",
+      "--allow-write",
+      evalScript,
+    ],
+  });
+
+  const { code, stdout } = await command.output();
+  const output = new TextDecoder().decode(stdout);
+
+  assertEquals(code, 0);
+  assertStringIncludes(output, "Usage: eval.ts");
+  assertStringIncludes(output, "Examples:");
+  assertStringIncludes(output, "Calibration mode");
+  assertStringIncludes(output, "File input mode");
+  assertStringIncludes(output, "Stdin mode");
+});
+
+Deno.test("eval should show help with --help flag", async () => {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "--allow-env",
+      "--allow-read",
+      "--allow-net",
+      "--allow-write",
+      evalScript,
+      "--help",
+    ],
+  });
+
+  const { code, stdout } = await command.output();
+  const output = new TextDecoder().decode(stdout);
+
+  assertEquals(code, 0);
+  assertStringIncludes(output, "Usage: eval.ts");
+});
+
+Deno.test("eval should fail when OPENROUTER_API_KEY is missing", async () => {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "--allow-env",
+      "--allow-read",
+      "--allow-net",
+      "--allow-write",
+      evalScript,
+      `${fixturesDir}/test-grader.deck.md`,
+      `${fixturesDir}/test-samples.toml`, // Use existing file to bypass stdin
+    ],
+    stdin: "inherit",
+    env: {
+      PATH: getConfigurationVariable("PATH") || "",
+      OPENROUTER_API_KEY: "", // Explicitly set to empty string
+    },
+  });
+
+  const { code, stderr } = await command.output();
+  const error = new TextDecoder().decode(stderr);
+
+  assertEquals(code, 1);
+  assertStringIncludes(
+    error,
+    "OPENROUTER_API_KEY environment variable is required",
+  );
+});
+
+Deno.test("eval should fail when grader file doesn't exist", async () => {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "--allow-env",
+      "--allow-read",
+      "--allow-net",
+      "--allow-write",
+      evalScript,
+      "non-existent-grader.deck.md",
+      "dummy.toml", // Add dummy input to bypass stdin detection
+    ],
+    stdin: "inherit",
+    env: {
+      ...Deno.env.toObject(),
+      OPENROUTER_API_KEY: "test-key",
+    },
+  });
+
+  const { code, stderr } = await command.output();
+  const error = new TextDecoder().decode(stderr);
+
+  assertEquals(code, 1);
+  assertStringIncludes(error, "No such file");
+});
+
+Deno.test("eval should fail when input file doesn't exist", async () => {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "--allow-env",
+      "--allow-read",
+      "--allow-net",
+      evalScript,
+      `${fixturesDir}/test-grader.deck.md`,
+      "non-existent-samples.toml",
+    ],
+    stdin: "inherit",
+    env: {
+      ...Deno.env.toObject(),
+      OPENROUTER_API_KEY: "test-key",
+    },
+  });
+
+  const { code, stderr } = await command.output();
+  const error = new TextDecoder().decode(stderr);
+
+  assertEquals(code, 1);
+  assertStringIncludes(error, "No such file");
+});
+
+Deno.test("eval should display correct info messages for calibration mode", async () => {
+  // In subprocess environment, stdin detection is unreliable
+  // So we'll test with an explicit empty file to simulate no input
+  const emptyFile = await Deno.makeTempFile({ suffix: ".toml" });
+  await Deno.writeTextFile(emptyFile, "");
+
+  try {
+    const command = new Deno.Command(Deno.execPath(), {
+      args: [
+        "run",
+        "--allow-env",
+        "--allow-read",
+        "--allow-net",
+        "--allow-write",
+        evalScript,
+        `${fixturesDir}/test-grader.deck.md`,
+        emptyFile, // Empty file to ensure we don't read from stdin
+      ],
+      env: {
+        ...Deno.env.toObject(),
+        OPENROUTER_API_KEY: "test-key",
+      },
+    });
+
+    const { stderr } = await command.output();
+    const info = new TextDecoder().decode(stderr);
+
+    assertStringIncludes(info, "Running evaluation with grader:");
+    assertStringIncludes(info, "test-grader.deck.md");
+    assertStringIncludes(info, "Using input file:");
+    assertStringIncludes(info, "Model: anthropic/claude-3.5-sonnet");
+  } finally {
+    await Deno.remove(emptyFile);
+  }
+});
+
+Deno.test("eval should display correct info messages for file input mode", async () => {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "--allow-env",
+      "--allow-read",
+      "--allow-net",
+      evalScript,
+      `${fixturesDir}/test-grader.deck.md`,
+      `${fixturesDir}/test-samples.toml`,
+    ],
+    stdin: "inherit",
+    env: {
+      ...Deno.env.toObject(),
+      OPENROUTER_API_KEY: "test-key",
+    },
+  });
+
+  const { stderr } = await command.output();
+  const info = new TextDecoder().decode(stderr);
+
+  assertStringIncludes(info, "Running evaluation with grader:");
+  assertStringIncludes(info, "test-grader.deck.md");
+  assertStringIncludes(info, "Using input file:");
+  assertStringIncludes(info, "test-samples.toml");
+});
+
+Deno.test("eval should accept custom model via ANTHROPIC_MODEL env var", async () => {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "--allow-env",
+      "--allow-read",
+      "--allow-net",
+      "--allow-write",
+      evalScript,
+      `${fixturesDir}/test-grader.deck.md`,
+    ],
+    env: {
+      ...Deno.env.toObject(),
+      OPENROUTER_API_KEY: "test-key",
+      ANTHROPIC_MODEL: "gpt-4-turbo",
+    },
+  });
+
+  const { stderr } = await command.output();
+  const info = new TextDecoder().decode(stderr);
+
+  assertStringIncludes(info, "Model: gpt-4-turbo");
+});

--- a/apps/aibff/__tests__/commands/index.test.ts
+++ b/apps/aibff/__tests__/commands/index.test.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env -S bff test
+
+import { assertEquals, assertExists } from "@std/assert";
+import { getAllCommands, getCommand } from "../../commands/index.ts";
+
+Deno.test("getCommand should return eval command", () => {
+  const evalCommand = getCommand("eval");
+  assertExists(evalCommand);
+  assertEquals(evalCommand.name, "eval");
+  assertEquals(
+    evalCommand.description,
+    "Evaluate a grader deck against sample prompts",
+  );
+});
+
+Deno.test("getCommand should return undefined for unknown command", () => {
+  const unknownCommand = getCommand("unknown");
+  assertEquals(unknownCommand, undefined);
+});
+
+Deno.test("getAllCommands should return all registered commands", () => {
+  const commands = getAllCommands();
+  assertEquals(commands.length >= 1, true);
+  assertEquals(commands.some((command) => command.name === "eval"), true);
+});
+
+Deno.test("getAllCommands should return sorted list by name", () => {
+  const commands = getAllCommands();
+  const sortedNames = commands.map((c) => c.name).sort();
+  const actualNames = commands.map((c) => c.name);
+  assertEquals(actualNames, sortedNames);
+});

--- a/apps/aibff/__tests__/commands/types.test.ts
+++ b/apps/aibff/__tests__/commands/types.test.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env -S bff test
+
+import { assertEquals } from "@std/assert";
+import type { Command } from "../../commands/types.ts";
+
+Deno.test("Command interface should have required properties", () => {
+  const mockCommand: Command = {
+    name: "test",
+    description: "Test command",
+    run: async () => {},
+  };
+
+  assertEquals(mockCommand.name, "test");
+  assertEquals(mockCommand.description, "Test command");
+  assertEquals(typeof mockCommand.run, "function");
+});
+
+Deno.test("Command run function should accept args array", async () => {
+  let receivedArgs: Array<string> = [];
+
+  const mockCommand: Command = {
+    name: "test",
+    description: "Test command",
+    run: (args: Array<string>) => {
+      receivedArgs = args;
+      return Promise.resolve();
+    },
+  };
+
+  await mockCommand.run(["arg1", "arg2"]);
+  assertEquals(receivedArgs, ["arg1", "arg2"]);
+});

--- a/apps/aibff/__tests__/main.test.ts
+++ b/apps/aibff/__tests__/main.test.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env -S bff test
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+
+const mainScript = new URL("../main.ts", import.meta.url).pathname;
+
+Deno.test("aibff should show help when no command provided", async () => {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: ["run", "--allow-all", mainScript],
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const { code, stdout } = await command.output();
+  const output = new TextDecoder().decode(stdout);
+
+  assertEquals(code, 0);
+  assertStringIncludes(output, "Usage: aibff <command>");
+  assertStringIncludes(output, "Available commands:");
+  assertStringIncludes(output, "eval");
+  assertStringIncludes(output, "Evaluate a grader deck against sample prompts");
+});
+
+Deno.test("aibff should handle unknown command", async () => {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: ["run", "--allow-all", mainScript, "unknown"],
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const { code, stderr } = await command.output();
+  const error = new TextDecoder().decode(stderr);
+
+  assertEquals(code, 1);
+  assertStringIncludes(error, "Unknown command 'unknown'");
+});
+
+Deno.test("aibff should delegate to eval command", async () => {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: ["run", "--allow-all", mainScript, "eval", "--help"],
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const { code, stdout } = await command.output();
+  const output = new TextDecoder().decode(stdout);
+
+  assertEquals(code, 0);
+  // The eval command shows help when called with --help
+  assertStringIncludes(output, "Usage: eval.ts");
+});

--- a/apps/aibff/bin/build.ts
+++ b/apps/aibff/bin/build.ts
@@ -7,16 +7,16 @@ const logger = getLogger(import.meta);
 
 const ROOT_DIR = join(import.meta.dirname!, "../../..");
 const DENO_LOCK_PATH = join(ROOT_DIR, "deno.lock");
-const EVAL_ENTRY = join(ROOT_DIR, "apps/aibff/eval.ts");
-const BUILD_DIR = join(ROOT_DIR, "build");
-const OUTPUT_PATH = join(BUILD_DIR, "eval");
+const MAIN_ENTRY = join(ROOT_DIR, "apps/aibff/main.ts");
+const BUILD_DIR = join(ROOT_DIR, "build/bin");
+const OUTPUT_PATH = join(BUILD_DIR, "aibff");
 
 async function extractNpmDependencies(): Promise<Array<string>> {
   const lockFile = JSON.parse(await Deno.readTextFile(DENO_LOCK_PATH));
 
   // Get initial packages from deno info
   const denoInfoCmd = new Deno.Command("deno", {
-    args: ["info", "--json", EVAL_ENTRY],
+    args: ["info", "--json", MAIN_ENTRY],
     stdout: "piped",
   });
 
@@ -90,7 +90,7 @@ async function extractNpmDependencies(): Promise<Array<string>> {
 }
 
 async function build() {
-  logger.info("Building aibff eval command...");
+  logger.info("Building aibff command...");
 
   // Ensure build directory exists
   await Deno.mkdir(BUILD_DIR, { recursive: true });
@@ -138,7 +138,7 @@ async function build() {
   }
 
   // Add the entry point
-  compileArgs.push(EVAL_ENTRY);
+  compileArgs.push(MAIN_ENTRY);
 
   logger.info("Running deno compile...");
   logger.debug(`Output will be: ${OUTPUT_PATH}`);

--- a/apps/aibff/commands/eval.ts
+++ b/apps/aibff/commands/eval.ts
@@ -1,0 +1,220 @@
+#!/usr/bin/env -S deno run --allow-env --allow-read --allow-net --allow-write
+
+import { runEval } from "packages/bolt-foundry/evals/eval.ts";
+import { stringify as stringifyToml } from "@std/toml";
+import type { Command } from "./types.ts";
+
+function printText(message: string, isError = false) {
+  if (isError) {
+    // deno-lint-ignore no-console
+    console.error(message);
+  } else {
+    // deno-lint-ignore no-console
+    console.log(message);
+  }
+}
+
+function getConfigVar(key: string): string | undefined {
+  // deno-lint-ignore bolt-foundry/no-env-direct-access
+  return Deno.env.get(key);
+}
+
+function scoreToGrade(score: number): string {
+  if (score >= 3) return "A";
+  if (score >= 1) return "B";
+  if (score >= -1) return "C";
+  if (score >= -2) return "D";
+  return "F";
+}
+
+function determineSource(inputFile?: string, actualInputFile?: string): string {
+  if (!inputFile && !actualInputFile) return "deck";
+  if (actualInputFile && actualInputFile.includes("/tmp/")) return "stdin";
+  return `file:${inputFile}`;
+}
+
+async function runEvaluation(graderFile: string, inputFile?: string) {
+  try {
+    // Get model from environment or use default
+    const model = getConfigVar("ANTHROPIC_MODEL") ||
+      "anthropic/claude-3.5-sonnet";
+
+    // Check for API key
+    if (!getConfigVar("OPENROUTER_API_KEY")) {
+      printText(
+        "Error: OPENROUTER_API_KEY environment variable is required",
+        true,
+      );
+      Deno.exit(1);
+    }
+
+    // Check if we have stdin input and no input file
+    let actualInputFile = inputFile;
+    let tempFile: string | undefined;
+
+    if (!inputFile) {
+      // Check if stdin is piped
+      let hasStdinInput = false;
+      try {
+        hasStdinInput = !Deno.stdin.isTerminal();
+      } catch {
+        // Ignore errors, assume no stdin
+      }
+
+      if (hasStdinInput) {
+        // Create a temporary file for stdin input
+        tempFile = await Deno.makeTempFile({ suffix: ".jsonl" });
+        const decoder = new TextDecoder();
+        const lines: Array<string> = [];
+
+        for await (const chunk of Deno.stdin.readable) {
+          const text = decoder.decode(chunk);
+          lines.push(text.trim());
+        }
+
+        await Deno.writeTextFile(tempFile, lines.join("\n"));
+        actualInputFile = tempFile;
+      }
+    }
+
+    printText(`Running evaluation with grader: ${graderFile}`, true);
+    if (actualInputFile) {
+      printText(`Using input file: ${actualInputFile}`, true);
+    } else {
+      printText("Using embedded samples from grader deck", true);
+    }
+    printText(`Model: ${model}`, true);
+    printText("", true);
+
+    try {
+      const results = await runEval({
+        graderFile,
+        inputFile: actualInputFile,
+        model,
+      });
+
+      // Calculate summary statistics
+      const totalSamples = results.length;
+      const scores = results.map((r) => r.score as number);
+      const avgScore = totalSamples > 0
+        ? scores.reduce((a, b) => a + b, 0) / totalSamples
+        : 0;
+      const passed = scores.filter((s) => s > 0).length;
+      const failed = scores.filter((s) => s <= 0).length;
+
+      // Count grades
+      const gradeCounts: Record<string, number> = {
+        A: 0,
+        B: 0,
+        C: 0,
+        D: 0,
+        F: 0,
+      };
+      results.forEach((r) => {
+        const grade = scoreToGrade(r.score);
+        gradeCounts[grade]++;
+      });
+
+      // Build TOML output structure
+      const tomlOutput = {
+        meta: {
+          version: "0.1.0",
+          deck: graderFile,
+          timestamp: new Date().toISOString(),
+          total_samples: totalSamples,
+          context_provided: { model },
+        },
+        summary: {
+          average_score: Number(avgScore.toFixed(2)),
+          passed,
+          failed,
+          grades: gradeCounts,
+        },
+        samples: results.map((result, idx) => {
+          const grade = scoreToGrade(result.score);
+
+          // Parse feedback from notes if available
+          const feedback: Record<string, string> = {};
+          if (result.output.notes) {
+            feedback.overall = result.output.notes;
+          }
+
+          return {
+            id: result.sample.id || `sample-${idx + 1}`,
+            source: determineSource(inputFile, actualInputFile),
+            score: result.score,
+            grade,
+            specs_passed: [], // TODO: Extract from grader output
+            specs_failed: [], // TODO: Extract from grader output
+            input: {
+              userMessage: result.sample.userMessage,
+              assistantResponse: result.sample.assistantResponse,
+            },
+            feedback,
+          };
+        }),
+      };
+
+      // Output TOML format
+      printText(stringifyToml(tomlOutput));
+
+      // Print summary to stderr
+      printText("", true);
+      printText("Summary:", true);
+      printText(`Total samples: ${totalSamples}`, true);
+      printText(`Average score: ${avgScore.toFixed(2)}`, true);
+      printText(`Passed: ${passed}`, true);
+      printText(`Failed: ${failed}`, true);
+    } finally {
+      // Clean up temp file if we created one
+      if (tempFile) {
+        await Deno.remove(tempFile).catch(() => {});
+      }
+    }
+  } catch (error) {
+    printText(
+      `Error: ${error instanceof Error ? error.message : String(error)}`,
+      true,
+    );
+    Deno.exit(1);
+  }
+}
+
+export const evalCommand: Command = {
+  name: "eval",
+  description: "Evaluate a grader deck against sample prompts",
+  run: async (args: Array<string>) => {
+    // Simple argument parsing
+    if (args.length === 0 || args.includes("--help") || args.includes("-h")) {
+      printText(`Usage: eval.ts <grader.deck.md> [samples.jsonl|samples.toml]
+
+Examples:
+  # Calibration mode (uses deck's internal samples)
+  deno run --allow-env --allow-read --allow-net --allow-write eval.ts grader.deck.md
+  
+  # File input mode
+  deno run --allow-env --allow-read --allow-net --allow-write eval.ts grader.deck.md samples.toml
+  deno run --allow-env --allow-read --allow-net --allow-write eval.ts grader.deck.md samples.jsonl
+  
+  # Stdin mode
+  echo '{"userMessage": "test", "assistantResponse": "response"}' | deno run --allow-env --allow-read --allow-net --allow-write eval.ts grader.deck.md
+
+Environment:
+  OPENROUTER_API_KEY    Required for LLM access
+  ANTHROPIC_MODEL      Model to use (default: anthropic/claude-3.5-sonnet)
+`);
+      Deno.exit(0);
+    }
+
+    const graderFile = args[0];
+    const inputFile = args[1]; // Optional
+
+    // Normal file mode or calibration mode
+    await runEvaluation(graderFile, inputFile);
+  },
+};
+
+// Support direct execution for backward compatibility
+if (import.meta.main) {
+  await evalCommand.run(Deno.args);
+}

--- a/apps/aibff/commands/index.ts
+++ b/apps/aibff/commands/index.ts
@@ -1,0 +1,19 @@
+import type { Command } from "./types.ts";
+import { evalCommand } from "./eval.ts";
+
+export type CommandRegistry = Map<string, Command>;
+
+const registry: CommandRegistry = new Map();
+
+// Register the eval command
+registry.set("eval", evalCommand);
+
+export function getCommand(name: string): Command | undefined {
+  return registry.get(name);
+}
+
+export function getAllCommands(): Array<Command> {
+  return Array.from(registry.values()).sort((a, b) =>
+    a.name.localeCompare(b.name)
+  );
+}

--- a/apps/aibff/commands/types.ts
+++ b/apps/aibff/commands/types.ts
@@ -1,0 +1,5 @@
+export interface Command {
+  name: string;
+  description: string;
+  run: (args: Array<string>) => Promise<void>;
+}

--- a/apps/aibff/main.ts
+++ b/apps/aibff/main.ts
@@ -1,0 +1,41 @@
+#!/usr/bin/env deno
+
+import { getAllCommands, getCommand } from "./commands/index.ts";
+import { getLogger } from "packages/logger/logger.ts";
+
+const logger = getLogger(import.meta);
+
+function showHelp(): void {
+  logger.info("Usage: aibff <command> [args...]");
+  logger.info("\nAvailable commands:");
+
+  const commands = getAllCommands();
+  for (const command of commands) {
+    logger.info(`  ${command.name.padEnd(12)} ${command.description}`);
+  }
+}
+
+async function main(): Promise<void> {
+  const args = Deno.args;
+
+  if (args.length === 0) {
+    showHelp();
+    Deno.exit(0);
+  }
+
+  const commandName = args[0];
+  const command = getCommand(commandName);
+
+  if (!command) {
+    logger.error(`Unknown command '${commandName}'`);
+    Deno.exit(1);
+  }
+
+  // Pass remaining arguments to the command
+  const commandArgs = args.slice(1);
+  await command.run(commandArgs);
+}
+
+if (import.meta.main) {
+  main();
+}


### PR DESCRIPTION

Update build.ts to support the new command-based structure:
- Build from main.ts instead of eval.ts as the entry point
- Output binary to build/bin/aibff instead of build/eval
- This aligns with the command router pattern implemented

The change enables aibff to work as a multi-command CLI tool while
maintaining backward compatibility with the eval functionality.

Test plan:
1. Run build: ./apps/aibff/bin/build.ts
2. Verify output at build/bin/aibff
3. Test help: build/bin/aibff (should show available commands)
4. Test eval: build/bin/aibff eval --help

🤖 Generated with Claude Code (https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/1094).
* #1095
* __->__ #1094