### PR TITLE
Update aibff GitHub release workflow

### DIFF
--- a/.github/workflows/publish-aibff-release.yml
+++ b/.github/workflows/publish-aibff-release.yml
@@ -27,6 +27,10 @@ jobs:
             platform: darwin
             arch: aarch64
             artifact-name: aibff-darwin-aarch64
+          - os: windows-latest
+            platform: windows
+            arch: x86_64
+            artifact-name: aibff-windows-x86_64
 
     runs-on: ${{ matrix.os }}
 
@@ -79,7 +83,7 @@ jobs:
 
       - name: Build aibff binary
         run: |
-          nix develop --impure --command bff aibff:build --platform ${{ matrix.platform }} --arch ${{ matrix.arch }}
+          nix develop --impure --command deno run --allow-all apps/aibff/main.ts rebuild --platform ${{ matrix.platform }} --arch ${{ matrix.arch }}
 
       - name: Test binary
         run: |
@@ -148,6 +152,10 @@ jobs:
           # macOS ARM64
           curl -L https://github.com/${{ github.repository }}/releases/download/aibff-v${{ github.event.inputs.version }}/aibff-darwin-aarch64.tar.gz | tar xz
           chmod +x aibff-darwin-aarch64
+
+          # Windows x64
+          curl -L https://github.com/${{ github.repository }}/releases/download/aibff-v${{ github.event.inputs.version }}/aibff-windows-x86_64.tar.gz -o aibff-windows-x86_64.tar.gz
+          tar -xzf aibff-windows-x86_64.tar.gz
           \`\`\`
 
           ## Usage


### PR DESCRIPTION

- Fix outdated build command to use 'aibff rebuild' instead of 'bff aibff:build'
- Add Windows x64 to the build matrix for cross-platform releases
- Update installation instructions to include Windows

Changes:
- Replace 'bff aibff:build' with 'deno run --allow-all apps/aibff/main.ts rebuild'
- Add Windows build configuration to matrix
- Add Windows installation instructions to release notes

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
