### PR TITLE
refactor(logger): replace chalk with @std/fmt/colors and add println method

### DIFF
--- a/.github/workflows/publish-aibff-release.yml
+++ b/.github/workflows/publish-aibff-release.yml
@@ -211,10 +211,3 @@ jobs:
             artifacts/*/*.sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create Git Tag
-        run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git tag -a aibff-v${{ github.event.inputs.version }} -m "Release aibff v${{ github.event.inputs.version }}"
-          git push origin aibff-v${{ github.event.inputs.version }}

--- a/.github/workflows/publish-aibff-release.yml
+++ b/.github/workflows/publish-aibff-release.yml
@@ -18,7 +18,7 @@ jobs:
     name: Build and Release aibff
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # Required for creating releases and tags
+      contents: write # Required for creating releases and tags
 
     steps:
       - name: Install Nix
@@ -99,20 +99,28 @@ jobs:
         run: |
           cd build/bin
 
-          # Create archives for each platform
-          for binary in aibff-linux-x86_64 aibff-windows-x86_64.exe aibff-darwin-aarch64; do
-            # Remove .exe extension for archive name if present
-            archive_name="${binary%.exe}"
+          # Make Unix binaries executable before archiving
+          chmod +x aibff-linux-x86_64
+          chmod +x aibff-darwin-aarch64
 
-            echo "Creating archive for $binary..."
-            tar -czf "${archive_name}.tar.gz" "$binary"
+          # Create archives with simplified names
+          echo "Creating Linux archive..."
+          tar -czf aibff-linux-x86_64.tar.gz --transform 's/aibff-linux-x86_64/aibff/' aibff-linux-x86_64
+          sha256sum aibff-linux-x86_64.tar.gz > aibff-linux-x86_64.tar.gz.sha256
 
-            # Generate checksum
-            sha256sum "${archive_name}.tar.gz" > "${archive_name}.tar.gz.sha256"
-          done
+          echo "Creating Windows archive..."
+          # Use zip for Windows (more common on Windows)
+          cp aibff-windows-x86_64.exe aibff.exe
+          zip aibff-windows-x86_64.zip aibff.exe
+          rm aibff.exe
+          sha256sum aibff-windows-x86_64.zip > aibff-windows-x86_64.zip.sha256
+
+          echo "Creating macOS archive..."
+          tar -czf aibff-darwin-aarch64.tar.gz --transform 's/aibff-darwin-aarch64/aibff/' aibff-darwin-aarch64
+          sha256sum aibff-darwin-aarch64.tar.gz > aibff-darwin-aarch64.tar.gz.sha256
 
           # List created archives
-          ls -la *.tar.gz*
+          ls -la *.tar.gz* *.zip*
 
       - name: Upload Linux artifact
         uses: actions/upload-artifact@v4
@@ -127,8 +135,8 @@ jobs:
         with:
           name: aibff-windows-x86_64
           path: |
-            build/bin/aibff-windows-x86_64.tar.gz
-            build/bin/aibff-windows-x86_64.tar.gz.sha256
+            build/bin/aibff-windows-x86_64.zip
+            build/bin/aibff-windows-x86_64.zip.sha256
 
       - name: Upload macOS artifact
         uses: actions/upload-artifact@v4
@@ -143,7 +151,7 @@ jobs:
     needs: build-and-release
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # Required for creating releases and tags
+      contents: write # Required for creating releases and tags
 
     steps:
       - name: Checkout repository
@@ -168,15 +176,13 @@ jobs:
           \`\`\`bash
           # Linux x64
           curl -L https://github.com/${{ github.repository }}/releases/download/aibff-v${{ github.event.inputs.version }}/aibff-linux-x86_64.tar.gz | tar xz
-          chmod +x aibff-linux-x86_64
 
           # macOS ARM64
           curl -L https://github.com/${{ github.repository }}/releases/download/aibff-v${{ github.event.inputs.version }}/aibff-darwin-aarch64.tar.gz | tar xz
-          chmod +x aibff-darwin-aarch64
 
-          # Windows x64
-          curl -L https://github.com/${{ github.repository }}/releases/download/aibff-v${{ github.event.inputs.version }}/aibff-windows-x86_64.tar.gz -o aibff-windows-x86_64.tar.gz
-          tar -xzf aibff-windows-x86_64.tar.gz
+          # Windows x64 (PowerShell)
+          Invoke-WebRequest https://github.com/${{ github.repository }}/releases/download/aibff-v${{ github.event.inputs.version }}/aibff-windows-x86_64.zip -OutFile aibff-windows-x86_64.zip
+          Expand-Archive aibff-windows-x86_64.zip -DestinationPath .
           \`\`\`
 
           ## Usage
@@ -208,6 +214,8 @@ jobs:
           prerelease: ${{ github.event.inputs.prerelease }}
           files: |
             artifacts/*/*.tar.gz
-            artifacts/*/*.sha256
+            artifacts/*/*.tar.gz.sha256
+            artifacts/*/*.zip
+            artifacts/*/*.zip.sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,33 +2,120 @@
 
 We're building structured prompt engineering. Instead of text strings,
 developers compose AI from decks of cards with examples and specs that make it
-reliable.
+99% reliable.
 
 ## The Deck System
 
 Our deck system brings structured engineering to LLM applications:
 
+- **Graders**: Markdown-based evaluation frameworks that define and score AI
+  behaviors
 - **Decks**: Composable collections of cards that define specific AI behaviors
 - **Cards**: Hierarchical specifications organized by category (persona,
   behavior, etc.)
 - **Specs**: Clear, testable requirements that define precise AI capabilities
-- **Context**: Structured information that guides AI understanding and responses
 - **Samples**: Rated examples (-3 to +3) showing good and bad behaviors
 
-## What are assistant cards?
+## Getting Started with aibff
 
-Assistant cards turn AI instructions into testable specifications:
+aibff (AI BFF) is our command-line tool for evaluating and grading AI behaviors
+using the deck system. It helps you:
 
-- **Persona cards**: Define who the AI should be (traits, voice, constraints)
-- **Behavior cards**: Define what the AI should do (goals, steps, formats)
-- **Examples**: Show good and bad behaviors with -3 to +3 ratings
-- **Specifications**: Break down requirements into clear, testable units
+- Run evaluations against your deck specifications
+- Calibrate graders to ensure accuracy
+- Compare outputs across different LLMs
+
+### Installation
+
+Download the latest release for your platform:
+
+- **[Download aibff releases →](https://github.com/content-foundry/content-foundry/releases?q=aibff&expanded=true)**
+
+Extract and run:
+
+```bash
+# Linux/macOS
+curl -L https://github.com/content-foundry/content-foundry/releases/download/aibff-vX.X.X/aibff-linux-x86_64.tar.gz | tar xz
+./aibff --help
+
+# Windows (PowerShell)
+# Download the .zip file and extract aibff.exe
+```
+
+### Quick Example
+
+```bash
+# Run an evaluation
+export OPENROUTER_API_KEY=your-api-key
+./aibff eval grader.deck.md samples.jsonl
+```
+
+## What are graders?
+
+Graders are markdown-based evaluation frameworks that turn AI instructions into
+testable specifications:
+
+- **Evaluation criteria**: Define what behaviors to assess
+- **Scoring guidelines**: Clear rubrics from -3 to +3
+- **Sample embeddings**: Reference TOML files with scored examples
+- **Composable structure**: Mix and match grader components
+
+## Your First Grader
+
+Create a markdown-based grader that evaluates AI responses:
+
+```markdown
+# Customer Support Grader
+
+Evaluate customer support responses for empathy and helpfulness.
+
+## Evaluation Criteria
+
+- Response shows empathy and understanding
+- Provides actionable solutions
+- Maintains professional tone
+
+## Scoring Guidelines
+
+- Score 3: Perfect empathy with clear solution
+- Score 2: Good response with minor improvements possible
+- Score 1: Acceptable but lacks warmth or clarity
+- Score -1: Somewhat dismissive or unclear
+- Score -2: Unprofessional or unhelpful
+- Score -3: Rude or completely fails to address issue
+
+![samples](./support-grader.deck.toml#samples)
+```
+
+Then reference scored examples in your TOML file:
+
+```toml
+[samples.perfect-empathy]
+input = "My package never arrived"
+response = "I understand how frustrating that must be. Let me track your order right away."
+score = 3
+
+[samples.dismissive]
+input = "My package never arrived"
+response = "Check your tracking number."
+score = -3
+```
+
+The scoring system (-3 to +3) helps achieve reliable outputs:
+
+- **+3**: Excellent example of desired behavior
+- **+2**: Good example
+- **+1**: Acceptable
+- **-1**: Mildly undesirable
+- **-2**: Bad example
+- **-3**: Completely wrong behavior
 
 ## Learn more
 
 - **[Company vision](docs/guides/company-vision.md)**: Making LLMs 99% reliable
-  through structured assistant cards
-- **[Product plan](/404.md)**: How we're building the card system
+  through structured prompt engineering
+- **[Deck system guide](memos/guides/deck-system.md)**: How graders and cards
+  work together
 - **[Inference philosophy](docs/guides/improving-inference-philosophy.md)**: Why
   inference-time control matters
 - **[Team story](memos/guides/team-story.md)**: Who we are and why we're doing

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -8,6 +8,7 @@
     "@bolt-foundry/get-configuration-var": "./packages/get-configuration-var/get-configuration-var.ts",
 
     "@b-fuze/deno-dom": "jsr:@b-fuze/deno-dom@^0.1.49",
+    "@deno/cache-dir": "jsr:@deno/cache-dir@^0.22.3",
     "@deno/dnt": "jsr:@deno/dnt@^0.41.3",
     "@iso": "./apps/boltFoundry/__generated__/__isograph/iso.ts",
     "@iso/": "./apps/boltFoundry/__generated__/__isograph/",
@@ -18,6 +19,7 @@
     "@std/assert": "jsr:@std/assert@^1.0.11",
     "@std/cli": "jsr:@std/cli@^1.0.20",
     "@std/encoding": "jsr:@std/encoding@^1.0.10",
+    "@std/fmt": "jsr:@std/fmt@^1.0.8",
     "@std/front-matter": "jsr:@std/front-matter@^1.0.5",
     "@std/fs": "jsr:@std/fs@^1.0.10",
     "@std/http": "jsr:@std/http@^1.0.12",

--- a/infra/appBuild/plugins/denoFileResolver.ts
+++ b/infra/appBuild/plugins/denoFileResolver.ts
@@ -1,24 +1,91 @@
 import type * as esbuild from "esbuild";
 import { getLogger } from "packages/logger/logger.ts";
+import { createCache } from "@deno/cache-dir";
 
 const logger = getLogger(import.meta);
+
+// Create cache instance
+const cache = createCache();
 
 export const denoFileResolver: esbuild.Plugin = {
   name: "deno-file-resolver",
   setup(build) {
+    logger.info("Setting up deno-file-resolver plugin");
+
+    // Add loader for HTTPS URLs - read from Deno's cache
+    build.onLoad({ filter: /.*/, namespace: "https" }, async (args) => {
+      logger.info(`Loading HTTPS resource from cache: ${args.path}`);
+
+      try {
+        // Use @deno/cache-dir to load from cache
+        const cached = await cache.load(args.path);
+
+        if (!cached || cached.kind === "redirect") {
+          throw new Error(`File not found in cache: ${args.path}`);
+        }
+
+        // Convert Uint8Array to string
+        const contents = new TextDecoder().decode(cached.content);
+        logger.debug(`Loaded from cache: ${args.path}`);
+
+        return {
+          contents,
+          loader: args.path.endsWith(".ts") || args.path.endsWith(".tsx")
+            ? "ts"
+            : "js",
+        };
+      } catch (error) {
+        logger.error(`Failed to load ${args.path} from cache: ${error}`);
+        throw error;
+      }
+    });
+
     build.onResolve(
-      { filter: /^(?:@bolt-foundry.*|\S+\.(?:ts|js|tsx|jsx|md|mdx|ipynb))$/ },
+      {
+        filter:
+          /^(?:@bolt-foundry.*|@std\/.*|\S+\.(?:ts|js|tsx|jsx|md|mdx|ipynb))$/,
+      },
       async (args) => {
         if (args.kind === "entry-point") return;
 
-        const resolved = import.meta.resolve(args.path).split("file://")[1];
-        const fileExists = await Deno.lstat(resolved).then(() => true).catch(
-          () => false,
-        );
-        logger.debug(resolved);
-        if (fileExists) {
-          return { path: resolved };
+        logger.debug(`Resolving: ${args.path}`);
+        const resolved = import.meta.resolve(args.path);
+        logger.debug(`Resolved to: ${resolved}`);
+
+        // Handle JSR imports
+        if (resolved.startsWith("jsr:")) {
+          // Simple conversion: jsr:/@std/fmt@^1.0.8/colors -> https://jsr.io/@std/fmt/1.0.8/colors.ts
+          const jsrPath = resolved.slice(4); // Remove "jsr:"
+
+          // Replace @version with /version and add .ts extension
+          const httpsUrl = jsrPath
+            .replace(/^\//, "") // Remove leading slash if present
+            .replace(/@(\^?~?[\d.]+)/, "/$1") // Replace @version with /version
+            .replace(/\^|~/, ""); // Remove semver prefixes
+
+          const finalUrl = `https://jsr.io/${httpsUrl}.ts`;
+          logger.info(`Resolved JSR import: ${args.path} -> ${finalUrl}`);
+          return { path: finalUrl, external: false };
         }
+
+        // Handle HTTPS URLs (including JSR)
+        if (resolved.startsWith("https://")) {
+          logger.info(`Resolved HTTPS import: ${args.path} -> ${resolved}`);
+          return { path: resolved, namespace: "https", external: false };
+        }
+
+        // Handle file:// URLs
+        if (resolved.startsWith("file://")) {
+          const filePath = resolved.slice(7); // Remove "file://"
+          const fileExists = await Deno.lstat(filePath).then(() => true).catch(
+            () => false,
+          );
+          logger.debug(filePath);
+          if (fileExists) {
+            return { path: filePath };
+          }
+        }
+
         return null;
       },
     );

--- a/infra/bff/friends/eval.bff.ts
+++ b/infra/bff/friends/eval.bff.ts
@@ -4,7 +4,7 @@ import { register } from "infra/bff/bff.ts";
 import { getLogger } from "packages/logger/logger.ts";
 import { runEval } from "packages/bolt-foundry/evals/eval.ts";
 import type { JSONValue } from "packages/bolt-foundry/builders/builders.ts";
-import startSpinner from "lib/terminalSpinner.ts";
+import { startSpinner } from "packages/logger/logger.ts";
 import { parse as parseToml } from "@std/toml";
 
 const logger = getLogger(import.meta);

--- a/infra/bff/friends/remote.bff.ts
+++ b/infra/bff/friends/remote.bff.ts
@@ -3,7 +3,7 @@
 import { getConfigurationVariable } from "@bolt-foundry/get-configuration-var";
 import { register } from "infra/bff/bff.ts";
 import { getLogger } from "packages/logger/logger.ts";
-import startSpinner from "lib/terminalSpinner.ts";
+import { startSpinner } from "packages/logger/logger.ts";
 
 const logger = getLogger(import.meta);
 

--- a/infra/bff/shellBase.ts
+++ b/infra/bff/shellBase.ts
@@ -5,7 +5,7 @@
 import { getLogger } from "packages/logger/logger.ts";
 import { getConfigurationVariable } from "@bolt-foundry/get-configuration-var";
 import { register } from "infra/bff/bff.ts";
-import startSpinner from "lib/terminalSpinner.ts";
+import { startSpinner } from "packages/logger/logger.ts";
 
 const logger = getLogger(import.meta);
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@types/react": "^19.0",
     "@types/react-dom": "^19.0",
     "assemblyai": "^4.9.0",
-    "chalk": "^5.4.1",
     "discord.js": "^14.18.0",
     "esbuild": "^0.24.2",
     "graphql": "^16.10.0",

--- a/packages/logger/terminalSpinner.ts
+++ b/packages/logger/terminalSpinner.ts
@@ -1,0 +1,30 @@
+// backend only, idk how to represent that yet? #BOOTCAMPTASK l1
+const moonFrames = ["🌑", "🌒", "🌓", "🌔", "🌕", "🌖", "🌗", "🌘", "🌑"];
+function spinner(isATTY: boolean, frames = moonFrames) {
+  let i = 0;
+  const frameDuration = 80;
+  return setInterval(async () => {
+    const frame = frames[i++ % frames.length];
+    const duration = (i * frameDuration) / 1000;
+    const formattedDuration = duration.toFixed(1);
+    if (isATTY) {
+      try {
+        await Deno.stdout.write(
+          new TextEncoder().encode(
+            `\r${frame} Elapsed: ${formattedDuration}s - `,
+          ),
+        );
+      } catch (_) {
+        // ignore
+      }
+    }
+  }, frameDuration);
+}
+
+export default function startSpinner(): () => void {
+  const isATTY = Deno.stdout.isTerminal();
+  const spinnerInterval = spinner(isATTY);
+  return () => {
+    clearInterval(spinnerInterval);
+  };
+}


### PR DESCRIPTION

- Replace chalk npm dependency with @std/fmt/colors from JSR
- Add println method to Logger interface for external output
- Move terminalSpinner from lib/ to logger package
- Update esbuild configuration to handle JSR imports using @deno/cache-dir
- Export startSpinner from logger.ts for unified imports

This refactoring removes the npm chalk dependency in favor of Deno's native
color support and consolidates terminal output functionality within the
logger package.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/1106).
* #1110
* #1109
* #1108
* #1107
* __->__ #1106
* #1105
* #1104
* #1103