### PR TITLE
refactor(aibff): replace logger with println for user-facing output

### DIFF
--- a/apps/aibff/bin/build.ts
+++ b/apps/aibff/bin/build.ts
@@ -2,7 +2,7 @@
 
 import { join } from "@std/path";
 import { parseArgs } from "@std/cli";
-import { getLogger } from "packages/logger/logger.ts";
+import { getLogger, startSpinner } from "packages/logger/logger.ts";
 
 const logger = getLogger(import.meta);
 
@@ -50,12 +50,16 @@ async function validateNodeModules() {
   try {
     await Deno.stat(denoDir);
     // If we get here, .deno exists - fail the build
-    logger.error("❌ Detected node_modules/.deno directory!");
-    logger.error("This project uses npm for dependency management.");
-    logger.error("Please run:");
-    logger.error("  rm -rf node_modules");
-    logger.error("  npm install");
-    logger.error("\nThen try building again.");
+    logger.println("❌ Detected node_modules/.deno directory!", {
+      isError: true,
+    });
+    logger.println("This project uses npm for dependency management.", {
+      isError: true,
+    });
+    logger.println("Please run:", { isError: true });
+    logger.println("  rm -rf node_modules", { isError: true });
+    logger.println("  npm install", { isError: true });
+    logger.println("\nThen try building again.", { isError: true });
     Deno.exit(1);
   } catch {
     // Good - .deno doesn't exist, we can proceed
@@ -90,7 +94,7 @@ async function getDirectlyUsedPackages(): Promise<Array<string>> {
     }
   }
 
-  logger.info(`Found ${npmPackages.size} directly used packages`);
+  logger.debug(`Found ${npmPackages.size} directly used packages`);
   return Array.from(npmPackages);
 }
 
@@ -133,7 +137,7 @@ async function getAllRequiredPackages(): Promise<Array<string>> {
     }
   }
 
-  logger.info(
+  logger.debug(
     `Resolved ${directPackages.length} direct packages to ${allRequired.size} total required packages`,
   );
   return Array.from(allRequired);
@@ -149,7 +153,7 @@ async function updateVersionFile() {
     .replace(/BUILD_COMMIT = ".*"/, `BUILD_COMMIT = "${gitCommit}"`);
 
   await Deno.writeTextFile(VERSION_FILE, updatedContent);
-  logger.info("Updated version file with build metadata");
+  logger.debug("Updated version file with build metadata");
 }
 
 async function getGitCommit(): Promise<string> {
@@ -170,8 +174,8 @@ async function build() {
   const arch = args.arch as string;
   const outputPath = getOutputPath(platform, arch);
 
-  logger.info(`Building aibff for ${platform}-${arch}...`);
-  logger.info(`Output: ${outputPath}`);
+  logger.println(`Building aibff for ${platform}-${arch}...`);
+  logger.println(`Output: ${outputPath}`);
 
   // Validate node_modules structure first
   await validateNodeModules();
@@ -183,13 +187,18 @@ async function build() {
   await Deno.mkdir(BUILD_DIR, { recursive: true });
 
   // Get required npm packages
-  logger.info("Collecting required npm packages...");
+  logger.println("Collecting required npm packages...");
+  const stopPackageSpinner = startSpinner();
   const npmPackages = await getAllRequiredPackages();
+  stopPackageSpinner();
 
   // Get the Deno target
   const denoTarget = getDenoTarget(platform, arch);
   if (!denoTarget) {
-    logger.error(`Unsupported platform/arch combination: ${platform}-${arch}`);
+    logger.println(
+      `Unsupported platform/arch combination: ${platform}-${arch}`,
+      { isError: true },
+    );
     Deno.exit(1);
   }
 
@@ -221,12 +230,13 @@ async function build() {
   // Add the entry point
   compileArgs.push(MAIN_ENTRY);
 
-  logger.info("Running deno compile...");
-  logger.info(
+  logger.println("Running deno compile...");
+  logger.println(
     `Compile command will include ${npmPackages.length} npm packages`,
   );
   logger.debug(`Output will be: ${outputPath}`);
 
+  const stopCompileSpinner = startSpinner();
   const cmd = new Deno.Command("deno", {
     args: compileArgs,
     stdout: "inherit",
@@ -234,14 +244,15 @@ async function build() {
   });
 
   const { success } = await cmd.output();
+  stopCompileSpinner();
 
   if (success) {
-    logger.info("✅ Build successful!");
+    logger.println("✅ Build successful!");
 
     // Check output size
     const stat = await Deno.stat(outputPath);
-    logger.info(`Output size: ${(stat.size / 1024 / 1024).toFixed(2)} MB`);
-    logger.info(`Binary location: ${outputPath}`);
+    logger.println(`Output size: ${(stat.size / 1024 / 1024).toFixed(2)} MB`);
+    logger.println(`Binary location: ${outputPath}`);
 
     // Create a symlink to the latest build for convenience
     const latestLink = join(BUILD_DIR, "aibff");
@@ -252,10 +263,10 @@ async function build() {
     }
     if (platform === Deno.build.os && arch === Deno.build.arch) {
       await Deno.symlink(outputPath, latestLink);
-      logger.info(`Created symlink: ${latestLink} -> ${outputPath}`);
+      logger.println(`Created symlink: ${latestLink} -> ${outputPath}`);
     }
   } else {
-    logger.error("❌ Build failed!");
+    logger.println("❌ Build failed!", { isError: true });
     Deno.exit(1);
   }
 }

--- a/apps/aibff/bin/create-release-notes.ts
+++ b/apps/aibff/bin/create-release-notes.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S deno run --allow-read --allow-run
 
 import { parseArgs } from "@std/cli";
-import { getLogger } from "packages/logger/logger.ts";
+import { getLogger, startSpinner } from "packages/logger/logger.ts";
 
 const logger = getLogger(import.meta);
 
@@ -14,10 +14,12 @@ const args = parseArgs(Deno.args, {
 });
 
 if (args.help || !args.from) {
-  logger.info(
+  logger.println(
     "Usage: create-release-notes.ts --from <tag/commit> [--to <tag/commit>]",
   );
-  logger.info("Example: create-release-notes.ts --from aibff-v0.1.0 --to HEAD");
+  logger.println(
+    "Example: create-release-notes.ts --from aibff-v0.1.0 --to HEAD",
+  );
   Deno.exit(args.help ? 0 : 1);
 }
 
@@ -67,10 +69,12 @@ function categorizeCommits(commits: Array<string>): {
 }
 
 try {
-  logger.info(`Generating release notes from ${args.from} to ${args.to}...`);
+  logger.println(`Generating release notes from ${args.from} to ${args.to}...`);
 
+  const stopSpinner = startSpinner();
   const commits = await getGitLog(args.from, args.to);
   const { features, fixes, other } = await categorizeCommits(commits);
+  stopSpinner();
 
   // Using stdout directly for release notes output
   const output: Array<string> = [];
@@ -101,6 +105,8 @@ try {
   // Write to stdout
   await Deno.stdout.write(new TextEncoder().encode(output.join("\n")));
 } catch (error) {
-  logger.error(`Error generating release notes: ${error.message}`);
+  logger.println(`Error generating release notes: ${error.message}`, {
+    isError: true,
+  });
   Deno.exit(1);
 }

--- a/apps/aibff/bin/prepare-release.ts
+++ b/apps/aibff/bin/prepare-release.ts
@@ -12,8 +12,8 @@ const args = parseArgs(Deno.args, {
 });
 
 if (args.help || !args.version) {
-  logger.info("Usage: prepare-release.ts --version <version>");
-  logger.info("Example: prepare-release.ts --version 1.0.0");
+  logger.println("Usage: prepare-release.ts --version <version>");
+  logger.println("Example: prepare-release.ts --version 1.0.0");
   Deno.exit(args.help ? 0 : 1);
 }
 
@@ -22,14 +22,15 @@ const newVersion = args.version;
 
 // Validate version format
 if (!/^\d+\.\d+\.\d+(-\w+)?$/.test(newVersion)) {
-  logger.error(
+  logger.println(
     "Invalid version format. Use semantic versioning (e.g., 1.0.0 or 1.0.0-beta)",
+    { isError: true },
   );
   Deno.exit(1);
 }
 
 // Update version.ts
-logger.info(`Updating version to ${newVersion}...`);
+logger.println(`Updating version to ${newVersion}...`);
 
 const versionContent = await Deno.readTextFile(VERSION_FILE);
 const updatedContent = versionContent.replace(
@@ -39,9 +40,9 @@ const updatedContent = versionContent.replace(
 
 await Deno.writeTextFile(VERSION_FILE, updatedContent);
 
-logger.info("✅ Version updated successfully!");
-logger.info("\nNext steps:");
-logger.info("1. Commit the version change");
-logger.info("2. Push to repository");
-logger.info("3. Run the GitHub Actions workflow 'Publish aibff Release'");
-logger.info(`4. Use version: ${newVersion}`);
+logger.println("✅ Version updated successfully!");
+logger.println("\nNext steps:");
+logger.println("1. Commit the version change");
+logger.println("2. Push to repository");
+logger.println("3. Run the GitHub Actions workflow 'Publish aibff Release'");
+logger.println(`4. Use version: ${newVersion}`);

--- a/apps/aibff/commands/rebuild.ts
+++ b/apps/aibff/commands/rebuild.ts
@@ -1,5 +1,5 @@
 import type { Command } from "./types.ts";
-import { getLogger } from "packages/logger/logger.ts";
+import { getLogger, startSpinner } from "packages/logger/logger.ts";
 import { join } from "@std/path";
 import { parseArgs } from "@std/cli";
 
@@ -22,24 +22,24 @@ export const rebuildCommand: Command = {
     });
 
     if (parsedArgs.help) {
-      logger.info("Usage: aibff rebuild [options]");
-      logger.info("\nOptions:");
-      logger.info(
+      logger.println("Usage: aibff rebuild [options]");
+      logger.println("\nOptions:");
+      logger.println(
         "  --platform <os>     Target platform (darwin, linux, windows)",
       );
-      logger.info(
+      logger.println(
         "  --arch <arch>       Target architecture (x86_64, aarch64)",
       );
-      logger.info("  --debug, -d         Show debug output");
-      logger.info("  --help, -h          Show this help message");
-      logger.info("\nExamples:");
-      logger.info(
+      logger.println("  --debug, -d         Show debug output");
+      logger.println("  --help, -h          Show this help message");
+      logger.println("\nExamples:");
+      logger.println(
         "  aibff rebuild                               # Rebuild for current platform",
       );
-      logger.info(
+      logger.println(
         "  aibff rebuild --platform linux --arch x86_64 # Build for Linux x64",
       );
-      logger.info(
+      logger.println(
         "  aibff rebuild --debug                        # Rebuild with debug output",
       );
       return;
@@ -48,7 +48,7 @@ export const rebuildCommand: Command = {
     const platform = parsedArgs.platform as string;
     const arch = parsedArgs.arch as string;
 
-    logger.info(`Rebuilding aibff binary for ${platform}-${arch}...`);
+    logger.println(`Rebuilding aibff binary for ${platform}-${arch}...`);
 
     // Path to the build script
     const buildScriptPath = join(
@@ -76,7 +76,9 @@ export const rebuildCommand: Command = {
       buildArgs.push("--debug");
     }
 
-    // Run the build script
+    // Run the build script with spinner
+    const stopSpinner = startSpinner();
+
     const buildCommand = new Deno.Command("deno", {
       args: buildArgs,
       stdout: "inherit",
@@ -85,12 +87,13 @@ export const rebuildCommand: Command = {
     });
 
     const { success } = await buildCommand.output();
+    stopSpinner();
 
     if (!success) {
-      logger.error("Build failed!");
+      logger.println("Build failed!", { isError: true });
       Deno.exit(1);
     }
 
-    logger.info("✅ Rebuild complete!");
+    logger.println("✅ Rebuild complete!");
   },
 };

--- a/apps/aibff/main.ts
+++ b/apps/aibff/main.ts
@@ -7,24 +7,24 @@ import { BUILD_COMMIT, BUILD_TIME, VERSION } from "./version.ts";
 const logger = getLogger(import.meta);
 
 function showHelp(): void {
-  logger.info("Usage: aibff <command> [args...]");
-  logger.info("\nAvailable commands:");
+  logger.println("Usage: aibff <command> [args...]");
+  logger.println("\nAvailable commands:");
 
   const commands = getAllCommands();
   for (const command of commands) {
-    logger.info(`  ${command.name.padEnd(12)} ${command.description}`);
+    logger.println(`  ${command.name.padEnd(12)} ${command.description}`);
   }
 
-  logger.info("\nOptions:");
-  logger.info("  --version    Show version information");
-  logger.info("  --help       Show this help message");
+  logger.println("\nOptions:");
+  logger.println("  --version    Show version information");
+  logger.println("  --help       Show this help message");
 }
 
 function showVersion(): void {
-  logger.info(`aibff ${VERSION}`);
+  logger.println(`aibff ${VERSION}`);
   if (BUILD_TIME !== "development") {
-    logger.info(`Built: ${BUILD_TIME}`);
-    logger.info(`Commit: ${BUILD_COMMIT}`);
+    logger.println(`Built: ${BUILD_TIME}`);
+    logger.println(`Commit: ${BUILD_COMMIT}`);
   }
 }
 
@@ -50,8 +50,10 @@ async function main(): Promise<void> {
   const command = getCommand(commandName);
 
   if (!command) {
-    logger.error(`Unknown command '${commandName}'`);
-    logger.error("Run 'aibff --help' for usage information");
+    logger.println(`Unknown command '${commandName}'`, { isError: true });
+    logger.println("Run 'aibff --help' for usage information", {
+      isError: true,
+    });
     Deno.exit(1);
   }
 

--- a/apps/boltFoundry/__tests__/e2e/joinWaitlist.test.e2e.ts
+++ b/apps/boltFoundry/__tests__/e2e/joinWaitlist.test.e2e.ts
@@ -1,6 +1,7 @@
 #! /usr/bin/env -S bff e2e
 
 import {
+  type E2ETestContext,
   navigateTo,
   setupE2ETest,
   teardownE2ETest,
@@ -22,52 +23,169 @@ const logger = getLogger(import.meta);
 // Flaky b/c it depends on an external service (waitlist API)
 Deno.test("User can join the waitlist successfully", async () => {
   const context = await setupE2ETest();
+  const maxRetries = 3;
+  let lastError: Error | null = null;
 
+  // Retry logic for handling external API failures
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      logger.info(
+        `Attempting waitlist test (attempt ${attempt}/${maxRetries})`,
+      );
+      await runWaitlistTest(context);
+      await teardownE2ETest(context);
+      return; // Success, exit test
+    } catch (error) {
+      lastError = error as Error;
+      logger.warn(`Waitlist test attempt ${attempt} failed`, error);
+
+      if (attempt < maxRetries) {
+        // Wait before retry with exponential backoff
+        const retryDelay = 1000 * Math.pow(2, attempt - 1);
+        logger.info(`Retrying in ${retryDelay}ms...`);
+        await new Promise((resolve) => setTimeout(resolve, retryDelay));
+      }
+    }
+  }
+
+  // All retries failed
+  await teardownE2ETest(context);
+  throw new Error(
+    `Waitlist test failed after ${maxRetries} attempts: ${lastError?.message}`,
+  );
+});
+
+async function runWaitlistTest(context: E2ETestContext) {
   try {
     // 1️⃣  Navigate to the home page
     await navigateTo(context, "/");
     await context.takeScreenshot("waitlist‑home‑initial");
 
-    // 2️⃣  Wait for and scroll to the waitlist form
+    // 2️⃣  Wait for and scroll to the waitlist form with retry logic
     const formSelector = '[data-testid="waitlist-form"]';
-    await context.page.waitForSelector(formSelector, { timeout: 10_000 });
+
+    // Increase timeout and add state check
+    await context.page.waitForSelector(formSelector, {
+      timeout: 30_000,
+      state: "visible",
+    });
+
+    // Wait for form to be fully interactive
+    await context.page.waitForFunction(
+      (selector) => {
+        const form = document.querySelector(selector);
+        const nameInput = document.querySelector("#bfDsFormInput-name");
+        const emailInput = document.querySelector("#bfDsFormInput-email");
+        const submitButton = document.querySelector(
+          "[data-bf-testid='waitlist-submit']",
+        );
+        return form && nameInput && emailInput && submitButton &&
+          !submitButton.disabled;
+      },
+      { timeout: 20_000 },
+      formSelector,
+    );
+
     await context.page.evaluate((selector) => {
       const element = document.querySelector(selector);
       element?.scrollIntoView({ behavior: "smooth", block: "center" });
     }, formSelector);
+
+    // Add a small delay after scrolling to ensure form is stable
+    await new Promise((resolve) => setTimeout(resolve, 500));
     await context.takeScreenshot("waitlist‑form‑visible");
 
     // 3️⃣  Fill the form fields with test data (use dry run email format)
-    await context.page.type("#bfDsFormInput-name", "Test User");
-    await context.page.type("#bfDsFormInput-email", "test.dryrun@example.com");
-    await context.page.type("#bfDsFormInput-company", "Bolt Foundry");
+    // Clear fields first and type with delay to ensure proper input
+    const nameInput = "#bfDsFormInput-name";
+    const emailInput = "#bfDsFormInput-email";
+    const companyInput = "#bfDsFormInput-company";
+
+    await context.page.click(nameInput);
+    await context.page.evaluate(
+      (selector) => document.querySelector(selector).value = "",
+      nameInput,
+    );
+    await context.page.type(nameInput, "Test User", { delay: 50 });
+
+    await context.page.click(emailInput);
+    await context.page.evaluate(
+      (selector) => document.querySelector(selector).value = "",
+      emailInput,
+    );
+    await context.page.type(emailInput, "test.dryrun@example.com", {
+      delay: 50,
+    });
+
+    await context.page.click(companyInput);
+    await context.page.evaluate(
+      (selector) => document.querySelector(selector).value = "",
+      companyInput,
+    );
+    await context.page.type(companyInput, "Bolt Foundry", { delay: 50 });
+
     await context.takeScreenshot("waitlist‑form‑filled");
 
     // 4️⃣  Submit the form via the submit button
     const submitSelector = "[data-bf-testid='waitlist-submit']";
+
+    // Ensure submit button is enabled before clicking
+    await context.page.waitForFunction(
+      (selector) => {
+        const btn = document.querySelector(selector);
+        return btn && !btn.disabled;
+      },
+      { timeout: 10_000 },
+      submitSelector,
+    );
+
     await context.page.click(submitSelector);
 
     // 5️⃣  Wait for the success message (form should be replaced)
     // The form should disappear and be replaced with a thank you message
     await context.page.waitForSelector(formSelector, {
       hidden: true,
-      timeout: 10_000,
+      timeout: 30_000,
     });
 
-    // Look for the success message text
+    // Look for the success message text with increased timeout
     await context.page.waitForFunction(
       () =>
         document.body.textContent?.includes("Thanks for joining the waitlist!"),
-      { timeout: 10_000 },
+      { timeout: 30_000 },
     );
 
     await context.takeScreenshot("waitlist‑success");
     logger.info("Join waitlist flow completed successfully");
   } catch (error) {
+    // Enhanced error debugging
     await context.takeScreenshot("waitlist‑error");
-    logger.error("Join waitlist e2e test failed", error);
+
+    // Log current page content for debugging
+    const pageContent = await context.page.evaluate(() => {
+      return {
+        url: globalThis.location.href,
+        title: document.title,
+        bodyText: document.body.innerText.substring(0, 500),
+        formVisible: !!document.querySelector('[data-testid="waitlist-form"]'),
+        submitButtonState: (() => {
+          const btn = document.querySelector(
+            "[data-bf-testid='waitlist-submit']",
+          );
+          return btn ? { disabled: btn.disabled, text: btn.textContent } : null;
+        })(),
+        errorMessages: Array.from(
+          document.querySelectorAll('.error, [class*="error"]'),
+        ).map((el) => el.textContent),
+      };
+    });
+
+    logger.error("Join waitlist e2e test failed", {
+      error: error.message,
+      pageState: pageContent,
+      timestamp: new Date().toISOString(),
+    });
+
     throw error;
-  } finally {
-    await teardownE2ETest(context);
   }
-});
+}

--- a/deno.lock
+++ b/deno.lock
@@ -5,7 +5,9 @@
     "jsr:@bolt-foundry/get-configuration-var@0.0.0-dev.0": "0.0.0-dev.0",
     "jsr:@david/code-block-writer@^13.0.2": "13.0.3",
     "jsr:@deno/cache-dir@~0.10.3": "0.10.3",
+    "jsr:@deno/cache-dir@~0.22.3": "0.22.3",
     "jsr:@deno/dnt@~0.41.3": "0.41.3",
+    "jsr:@deno/graph@0.86": "0.86.9",
     "jsr:@deno/graph@~0.73.1": "0.73.1",
     "jsr:@denosaurs/plug@1.0.3": "1.0.3",
     "jsr:@luca/esbuild-deno-loader@~0.11.1": "0.11.1",
@@ -20,6 +22,7 @@
     "jsr:@std/async@^1.0.12": "1.0.12",
     "jsr:@std/bytes@0.223": "0.223.0",
     "jsr:@std/bytes@^1.0.2": "1.0.5",
+    "jsr:@std/bytes@^1.0.5": "1.0.5",
     "jsr:@std/cli@^1.0.17": "1.0.17",
     "jsr:@std/cli@^1.0.20": "1.0.20",
     "jsr:@std/collections@^1.0.11": "1.0.11",
@@ -30,18 +33,22 @@
     "jsr:@std/fmt@0.213.1": "0.213.1",
     "jsr:@std/fmt@0.223": "0.223.0",
     "jsr:@std/fmt@1": "1.0.7",
+    "jsr:@std/fmt@^1.0.3": "1.0.8",
     "jsr:@std/fmt@^1.0.7": "1.0.7",
+    "jsr:@std/fmt@^1.0.8": "1.0.8",
     "jsr:@std/front-matter@^1.0.5": "1.0.9",
     "jsr:@std/fs@0.213.1": "0.213.1",
     "jsr:@std/fs@0.223": "0.223.0",
     "jsr:@std/fs@1": "1.0.17",
     "jsr:@std/fs@^1.0.10": "1.0.17",
     "jsr:@std/fs@^1.0.16": "1.0.17",
+    "jsr:@std/fs@^1.0.6": "1.0.17",
     "jsr:@std/fs@~0.229.3": "0.229.3",
     "jsr:@std/html@^1.0.3": "1.0.3",
     "jsr:@std/http@^1.0.12": "1.0.15",
     "jsr:@std/internal@^1.0.6": "1.0.6",
     "jsr:@std/io@0.223": "0.223.0",
+    "jsr:@std/io@0.225": "0.225.2",
     "jsr:@std/media-types@^1.1.0": "1.1.0",
     "jsr:@std/net@^1.0.4": "1.0.4",
     "jsr:@std/path@0.213.1": "0.213.1",
@@ -139,18 +146,28 @@
     "@deno/cache-dir@0.10.3": {
       "integrity": "eb022f84ecc49c91d9d98131c6e6b118ff63a29e343624d058646b9d50404776",
       "dependencies": [
-        "jsr:@deno/graph",
+        "jsr:@deno/graph@~0.73.1",
         "jsr:@std/fmt@0.223",
         "jsr:@std/fs@0.223",
-        "jsr:@std/io",
+        "jsr:@std/io@0.223",
         "jsr:@std/path@0.223"
+      ]
+    },
+    "@deno/cache-dir@0.22.3": {
+      "integrity": "20e1b87d99ca2af13f7e1484861cefadcb28b1eebc773bc5a18f26f0edd988ae",
+      "dependencies": [
+        "jsr:@deno/graph@0.86",
+        "jsr:@std/fmt@^1.0.3",
+        "jsr:@std/fs@^1.0.6",
+        "jsr:@std/io@0.225",
+        "jsr:@std/path@^1.0.8"
       ]
     },
     "@deno/dnt@0.41.3": {
       "integrity": "b2ef2c8a5111eef86cb5bfcae103d6a2938e8e649e2461634a7befb7fc59d6d2",
       "dependencies": [
         "jsr:@david/code-block-writer",
-        "jsr:@deno/cache-dir",
+        "jsr:@deno/cache-dir@~0.10.3",
         "jsr:@std/fmt@1",
         "jsr:@std/fs@1",
         "jsr:@std/path@1",
@@ -159,6 +176,9 @@
     },
     "@deno/graph@0.73.1": {
       "integrity": "cd69639d2709d479037d5ce191a422eabe8d71bb68b0098344f6b07411c84d41"
+    },
+    "@deno/graph@0.86.9": {
+      "integrity": "c4f353a695bcc5246c099602977dabc6534eacea9999a35a8cb24e807192e6a1"
     },
     "@denosaurs/plug@1.0.3": {
       "integrity": "b010544e386bea0ff3a1d05e0c88f704ea28cbd4d753439c2f1ee021a85d4640",
@@ -249,6 +269,9 @@
     "@std/fmt@1.0.7": {
       "integrity": "2a727c043d8df62cd0b819b3fb709b64dd622e42c3b1bb817ea7e6cc606360fb"
     },
+    "@std/fmt@1.0.8": {
+      "integrity": "71e1fc498787e4434d213647a6e43e794af4fd393ef8f52062246e06f7e372b7"
+    },
     "@std/front-matter@1.0.9": {
       "integrity": "ee6201d06674cbef137dda2252f62477450b48249e7d8d9ab57a30f85ff6f051",
       "dependencies": [
@@ -302,6 +325,12 @@
       "dependencies": [
         "jsr:@std/assert@0.223",
         "jsr:@std/bytes@0.223"
+      ]
+    },
+    "@std/io@0.225.2": {
+      "integrity": "3c740cd4ee4c082e6cfc86458f47e2ab7cb353dc6234d5e9b1f91a2de5f4d6c7",
+      "dependencies": [
+        "jsr:@std/bytes@^1.0.5"
       ]
     },
     "@std/media-types@1.1.0": {
@@ -4079,6 +4108,7 @@
   "workspace": {
     "dependencies": [
       "jsr:@b-fuze/deno-dom@~0.1.49",
+      "jsr:@deno/cache-dir@~0.22.3",
       "jsr:@deno/dnt@~0.41.3",
       "jsr:@luca/esbuild-deno-loader@~0.11.1",
       "jsr:@openai/openai@^4.78.1",
@@ -4087,6 +4117,7 @@
       "jsr:@std/assert@^1.0.11",
       "jsr:@std/cli@^1.0.20",
       "jsr:@std/encoding@^1.0.10",
+      "jsr:@std/fmt@^1.0.8",
       "jsr:@std/front-matter@^1.0.5",
       "jsr:@std/fs@^1.0.10",
       "jsr:@std/http@^1.0.12",
@@ -4122,7 +4153,6 @@
         "npm:@types/react-dom@19",
         "npm:@types/react@19",
         "npm:assemblyai@^4.9.0",
-        "npm:chalk@^5.4.1",
         "npm:discord.js@^14.18.0",
         "npm:esbuild@~0.24.2",
         "npm:graphql-relay@~0.10.2",

--- a/infra/appBuild/plugins/denoFileResolver.ts
+++ b/infra/appBuild/plugins/denoFileResolver.ts
@@ -24,8 +24,17 @@ export const denoFileResolver: esbuild.Plugin = {
           throw new Error(`File not found in cache: ${args.path}`);
         }
 
-        // Convert Uint8Array to string
-        const contents = new TextDecoder().decode(cached.content);
+        // Convert content to string if it's a Uint8Array
+        let contents: string;
+        if (cached.kind === "module") {
+          if (typeof cached.content === "string") {
+            contents = cached.content;
+          } else {
+            contents = new TextDecoder().decode(cached.content);
+          }
+        } else {
+          throw new Error(`Unexpected cache kind: ${cached.kind}`);
+        }
         logger.debug(`Loaded from cache: ${args.path}`);
 
         return {


### PR DESCRIPTION

- Replace logger.info() with logger.println() for all user-facing output
- Replace logger.error() with logger.println(msg, { isError: true }) for errors
- Add spinner support for long-running operations (build, compile, etc.)
- Keep logger.debug() and logger.warn() for internal logging
- Follow the pattern established in eval.ts which already uses direct console output
- Fix denoFileResolver to handle both string and Uint8Array content types

This makes the CLI output cleaner and more suitable for piping/scripting
by removing timestamps and log level prefixes from user-facing messages.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/1108).
* #1110
* #1109
* __->__ #1108