### PR TITLE
refactor(logger): change println API to have separate println and printErr methods

### DIFF
--- a/apps/aibff/bin/build.ts
+++ b/apps/aibff/bin/build.ts
@@ -50,16 +50,12 @@ async function validateNodeModules() {
   try {
     await Deno.stat(denoDir);
     // If we get here, .deno exists - fail the build
-    logger.println("❌ Detected node_modules/.deno directory!", {
-      isError: true,
-    });
-    logger.println("This project uses npm for dependency management.", {
-      isError: true,
-    });
-    logger.println("Please run:", { isError: true });
-    logger.println("  rm -rf node_modules", { isError: true });
-    logger.println("  npm install", { isError: true });
-    logger.println("\nThen try building again.", { isError: true });
+    logger.printErr("❌ Detected node_modules/.deno directory!");
+    logger.printErr("This project uses npm for dependency management.");
+    logger.printErr("Please run:");
+    logger.printErr("  rm -rf node_modules");
+    logger.printErr("  npm install");
+    logger.printErr("\nThen try building again.");
     Deno.exit(1);
   } catch {
     // Good - .deno doesn't exist, we can proceed
@@ -195,9 +191,8 @@ async function build() {
   // Get the Deno target
   const denoTarget = getDenoTarget(platform, arch);
   if (!denoTarget) {
-    logger.println(
+    logger.printErr(
       `Unsupported platform/arch combination: ${platform}-${arch}`,
-      { isError: true },
     );
     Deno.exit(1);
   }
@@ -266,7 +261,7 @@ async function build() {
       logger.println(`Created symlink: ${latestLink} -> ${outputPath}`);
     }
   } else {
-    logger.println("❌ Build failed!", { isError: true });
+    logger.printErr("❌ Build failed!");
     Deno.exit(1);
   }
 }

--- a/apps/aibff/bin/create-release-notes.ts
+++ b/apps/aibff/bin/create-release-notes.ts
@@ -105,8 +105,6 @@ try {
   // Write to stdout
   await Deno.stdout.write(new TextEncoder().encode(output.join("\n")));
 } catch (error) {
-  logger.println(`Error generating release notes: ${error.message}`, {
-    isError: true,
-  });
+  logger.printErr(`Error generating release notes: ${error.message}`);
   Deno.exit(1);
 }

--- a/apps/aibff/bin/prepare-release.ts
+++ b/apps/aibff/bin/prepare-release.ts
@@ -22,9 +22,8 @@ const newVersion = args.version;
 
 // Validate version format
 if (!/^\d+\.\d+\.\d+(-\w+)?$/.test(newVersion)) {
-  logger.println(
+  logger.printErr(
     "Invalid version format. Use semantic versioning (e.g., 1.0.0 or 1.0.0-beta)",
-    { isError: true },
   );
   Deno.exit(1);
 }

--- a/apps/aibff/commands/rebuild.ts
+++ b/apps/aibff/commands/rebuild.ts
@@ -90,7 +90,7 @@ export const rebuildCommand: Command = {
     stopSpinner();
 
     if (!success) {
-      logger.println("Build failed!", { isError: true });
+      logger.printErr("Build failed!");
       Deno.exit(1);
     }
 

--- a/apps/aibff/main.ts
+++ b/apps/aibff/main.ts
@@ -50,10 +50,8 @@ async function main(): Promise<void> {
   const command = getCommand(commandName);
 
   if (!command) {
-    logger.println(`Unknown command '${commandName}'`, { isError: true });
-    logger.println("Run 'aibff --help' for usage information", {
-      isError: true,
-    });
+    logger.printErr(`Unknown command '${commandName}'`);
+    logger.printErr("Run 'aibff --help' for usage information");
     Deno.exit(1);
   }
 

--- a/packages/logger/__tests__/logger.test.ts
+++ b/packages/logger/__tests__/logger.test.ts
@@ -1,0 +1,31 @@
+import { assertEquals } from "@std/assert";
+import { getLogger } from "../logger.ts";
+
+Deno.test("Logger has println and printErr methods", () => {
+  const logger = getLogger(import.meta);
+  assertEquals(typeof logger.println, "function");
+  assertEquals(typeof logger.printErr, "function");
+});
+
+Deno.test("Logger println and printErr work correctly", () => {
+  const logger = getLogger(import.meta);
+
+  // Test that methods don't throw
+  logger.println("Test message");
+  logger.printErr("Error message");
+  logger.println("Colored message", true);
+  logger.printErr("Colored error", true);
+
+  // If we got here without throwing, the test passes
+  assertEquals(true, true);
+});
+
+Deno.test("Logger still works as a regular logger", () => {
+  const logger = getLogger(import.meta);
+
+  // Test that standard log methods still exist
+  assertEquals(typeof logger.info, "function");
+  assertEquals(typeof logger.error, "function");
+  assertEquals(typeof logger.warn, "function");
+  assertEquals(typeof logger.debug, "function");
+});

--- a/packages/logger/logger.ts
+++ b/packages/logger/logger.ts
@@ -169,29 +169,23 @@ export function getLogger(importMeta: ImportMeta | string): Logger {
 }
 
 export type Logger = log.Logger & {
-  println: (
-    message: string,
-    options?: { isError?: boolean; stripColors?: boolean },
-  ) => void;
+  println: (message: string, stripColors?: boolean) => void;
+  printErr: (message: string, stripColors?: boolean) => void;
 };
 
 function addPrintln(logger: log.Logger): Logger {
   const extendedLogger = logger as Logger;
 
-  extendedLogger.println = (
-    message: string,
-    options?: { isError?: boolean; stripColors?: boolean },
-  ) => {
-    const { isError = false, stripColors = false } = options || {};
+  extendedLogger.println = (message: string, stripColors = false) => {
     const output = stripColors ? stripAnsiCode(message) : message;
+    // deno-lint-ignore no-console
+    console.log(output);
+  };
 
-    if (isError) {
-      // deno-lint-ignore no-console
-      console.error(output);
-    } else {
-      // deno-lint-ignore no-console
-      console.log(output);
-    }
+  extendedLogger.printErr = (message: string, stripColors = false) => {
+    const output = stripColors ? stripAnsiCode(message) : message;
+    // deno-lint-ignore no-console
+    console.error(output);
   };
 
   return extendedLogger;


### PR DESCRIPTION

- Replace println options bag with two distinct methods
- println(message, stripColors?) for standard output
- printErr(message, stripColors?) for error output
- Update all aibff usage to use printErr for error messages
- Update tests to verify both methods work correctly

This provides a cleaner API that makes the intent more explicit
and properly separates stdout and stderr output.
