### PR TITLE
Remove A-F grading system from evaluation output

### DIFF
--- a/apps/aibff/commands/eval.ts
+++ b/apps/aibff/commands/eval.ts
@@ -19,14 +19,6 @@ function getConfigVar(key: string): string | undefined {
   return Deno.env.get(key);
 }
 
-function scoreToGrade(score: number): string {
-  if (score >= 3) return "A";
-  if (score >= 1) return "B";
-  if (score >= -1) return "C";
-  if (score >= -2) return "D";
-  return "F";
-}
-
 function determineSource(inputFile?: string, actualInputFile?: string): string {
   if (!inputFile && !actualInputFile) return "deck";
   if (actualInputFile && actualInputFile.includes("/tmp/")) return "stdin";
@@ -102,19 +94,6 @@ async function runEvaluation(graderFile: string, inputFile?: string) {
       const passed = scores.filter((s) => s > 0).length;
       const failed = scores.filter((s) => s <= 0).length;
 
-      // Count grades
-      const gradeCounts: Record<string, number> = {
-        A: 0,
-        B: 0,
-        C: 0,
-        D: 0,
-        F: 0,
-      };
-      results.forEach((r) => {
-        const grade = scoreToGrade(r.score);
-        gradeCounts[grade]++;
-      });
-
       // Build TOML output structure
       const tomlOutput = {
         meta: {
@@ -128,11 +107,8 @@ async function runEvaluation(graderFile: string, inputFile?: string) {
           average_score: Number(avgScore.toFixed(2)),
           passed,
           failed,
-          grades: gradeCounts,
         },
         samples: results.map((result, idx) => {
-          const grade = scoreToGrade(result.score);
-
           // Parse feedback from notes if available
           const feedback: Record<string, string> = {};
           if (result.output.notes) {
@@ -143,7 +119,6 @@ async function runEvaluation(graderFile: string, inputFile?: string) {
             id: result.sample.id || `sample-${idx + 1}`,
             source: determineSource(inputFile, actualInputFile),
             score: result.score,
-            grade,
             specs_passed: [], // TODO: Extract from grader output
             specs_failed: [], // TODO: Extract from grader output
             input: {

--- a/apps/aibff/memos/plans/eval-output-format.toml
+++ b/apps/aibff/memos/plans/eval-output-format.toml
@@ -11,13 +11,11 @@ context_provided = { temperature = 0.7, model = "gpt-4" }
 average_score = 2.5
 passed = 2
 failed = 1
-grades = { A = 1, B = 1, F = 1 }
 
 [[samples]]
 id = "sample-1"
 source = "stdin"  # or "deck", "file:samples.toml"
 score = 4
-grade = "A"
 specs_passed = ["concise", "accurate", "helpful"]
 specs_failed = []
 
@@ -32,7 +30,6 @@ specs_failed = []
 id = "sample-2" 
 source = "deck"
 score = 3
-grade = "B"
 specs_passed = ["accurate", "helpful"]
 specs_failed = ["concise"]
 
@@ -48,7 +45,6 @@ specs_failed = ["concise"]
 id = "sample-3"
 source = "file:bad-samples.jsonl"
 score = -2
-grade = "F"
 specs_passed = []
 specs_failed = ["accurate", "helpful", "safe"]
 


### PR DESCRIPTION

Simplify the evaluation system by removing letter grade conversions and
focusing on numeric scores (-3 to 3) for clearer, more precise feedback.

Changes:
- Remove scoreToGrade function from both eval implementations
- Remove grade counting and distribution tracking
- Remove grade field from individual sample outputs
- Update eval-output-format.toml example to reflect new structure

Test plan:
1. Run tests: bff test apps/aibff/__tests__/eval.test.ts
2. Type check passes: deno check apps/aibff/eval.ts apps/aibff/commands/eval.ts
3. Verify evaluation output only shows numeric scores

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
