### PR TITLE
fix: move warmSecrets() to main entry points and improve cache handling

### DIFF
--- a/apps/bfDb/backend/__tests__/DatabaseBackend.test.ts
+++ b/apps/bfDb/backend/__tests__/DatabaseBackend.test.ts
@@ -327,6 +327,8 @@ Deno.test("bfDb - query items", async () => {
 });
 
 Deno.test("bfDb - metadata handling", async () => {
+  const nodesToCleanup: Array<string> = [];
+
   try {
     type TestMetadataNodeProps = {
       name: string;
@@ -347,6 +349,8 @@ Deno.test("bfDb - metadata handling", async () => {
       { name: "Metadata Test" },
     );
     const bfGid = node.metadata.bfGid;
+    const bfOid = node.metadata.bfOid;
+    nodesToCleanup.push(bfGid);
 
     // Verify metadata properties
     assertEquals(node.metadata.className, "TestMetadataNode");
@@ -370,6 +374,9 @@ Deno.test("bfDb - metadata handling", async () => {
       true,
       "lastUpdated should be newer after update",
     );
+
+    // Clean up the created node
+    await bfDeleteItem(bfOid, bfGid);
   } finally {
     // Ensure connection is closed even if test fails
     await bfCloseConnection();
@@ -381,25 +388,38 @@ Deno.test("Database backends compatibility test", async () => {
   logger.info("Testing database backends compatibility");
   const hasDatabaseUrl = Boolean(getConfigurationVariable("DATABASE_URL"));
 
-  if (hasDatabaseUrl) {
-    // Test Neon backend if DATABASE_URL is available
-    logger.info("Testing Neon backend");
-    Deno.env.set("DB_BACKEND_TYPE", "neon");
-    const neonBackend = new DatabaseBackendNeon();
-    await runBackendTests(neonBackend, "Neon");
+  try {
+    if (hasDatabaseUrl) {
+      // Test Neon backend if DATABASE_URL is available
+      logger.info("Testing Neon backend");
+      Deno.env.set("DB_BACKEND_TYPE", "neon");
+      const neonBackend = new DatabaseBackendNeon();
+      await runBackendTests(neonBackend, "Neon");
 
-    // Test PostgreSQL backend if DATABASE_URL is available
-    logger.info("Testing PostgreSQL backend");
-    Deno.env.set("DB_BACKEND_TYPE", "pg");
-    const pgBackend = new DatabaseBackendPg();
-    await runBackendTests(pgBackend, "PostgreSQL");
-  } else {
-    logger.info("Skipping Neon and PostgreSQL tests - DATABASE_URL not set");
+      // Ensure backend is fully closed before moving to next test
+      await bfCloseConnection();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Test PostgreSQL backend if DATABASE_URL is available
+      logger.info("Testing PostgreSQL backend");
+      Deno.env.set("DB_BACKEND_TYPE", "pg");
+      const pgBackend = new DatabaseBackendPg();
+      await runBackendTests(pgBackend, "PostgreSQL");
+
+      // Ensure backend is fully closed before moving to next test
+      await bfCloseConnection();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    } else {
+      logger.info("Skipping Neon and PostgreSQL tests - DATABASE_URL not set");
+    }
+
+    // Always test SQLite backend as it doesn't require external dependencies
+    logger.info("Testing SQLite backend");
+    Deno.env.set("DB_BACKEND_TYPE", "sqlite");
+    const sqliteBackend = new DatabaseBackendSqlite();
+    await runBackendTests(sqliteBackend, "SQLite");
+  } finally {
+    // Final cleanup
+    await bfCloseConnection();
   }
-
-  // Always test SQLite backend as it doesn't require external dependencies
-  logger.info("Testing SQLite backend");
-  Deno.env.set("DB_BACKEND_TYPE", "sqlite");
-  const sqliteBackend = new DatabaseBackendSqlite();
-  await runBackendTests(sqliteBackend, "SQLite");
 });

--- a/apps/collector/collector.ts
+++ b/apps/collector/collector.ts
@@ -12,8 +12,6 @@ import { trackLlmEvent } from "apps/collector/llm-event-tracker.ts";
 
 const logger = getLogger(import.meta);
 
-await warmSecrets();
-
 // Define routes for the collector service
 function registerCollectorRoutes(): Map<string, Handler> {
   const routes = new Map<string, Handler>();
@@ -86,6 +84,7 @@ const port = Number(getConfigurationVariable("COLLECTOR_PORT") ?? 8001);
 
 // Start the server if this is the main module
 if (import.meta.main) {
+  await warmSecrets();
   logger.info(`Starting Collector service on port ${port}...`);
   Deno.serve({ port }, handleCollectorRequest);
 }

--- a/apps/web/web.tsx
+++ b/apps/web/web.tsx
@@ -13,9 +13,6 @@ import { handleRequest } from "apps/web/handlers/mainHandler.ts";
 
 const _logger = getLogger(import.meta);
 
-// Warm the secrets cache before starting auto-refresh
-const warmPromise = warmSecrets();
-
 export type Handler = (
   request: Request,
   routeParams: Record<string, string>,
@@ -26,7 +23,6 @@ const routes = registerAllRoutes();
 
 // Main request handler wrapper
 async function handleRequestWrapper(req: Request): Promise<Response> {
-  await warmPromise;
   return await handleRequest(req, routes, defaultRoute);
 }
 
@@ -35,5 +31,6 @@ const port = Number(getConfigurationVariable("WEB_PORT") ?? 8000);
 
 // Start the server if this is the main module
 if (import.meta.main) {
+  await warmSecrets();
   Deno.serve({ port }, handleRequestWrapper);
 }

--- a/infra/bff/__tests__/ai.test.ts
+++ b/infra/bff/__tests__/ai.test.ts
@@ -1,53 +1,91 @@
 // infra/bff/__tests__/ai.test.ts
 
 import { assertEquals } from "@std/assert";
-import { register } from "../bff.ts";
+import { friendMap, register } from "../bff.ts";
 import { aiCommand } from "../friends/ai.bff.ts";
 
 Deno.test("ai command: should list AI-safe commands", async () => {
-  // Register a test AI-safe command
-  register("test-safe", "Test safe command", () => 0, [], true);
-  // Register a test non-AI-safe command
-  register("test-unsafe", "Test unsafe command", () => 0, [], false);
+  // Save current state of friendMap
+  const originalFriends = new Map(friendMap);
 
-  // Test listing AI-safe commands
-  const result = await aiCommand([]);
-  assertEquals(result, 0);
+  try {
+    // Register a test AI-safe command
+    register("test-safe", "Test safe command", () => 0, [], true);
+    // Register a test non-AI-safe command
+    register("test-unsafe", "Test unsafe command", () => 0, [], false);
+
+    // Test listing AI-safe commands
+    const result = await aiCommand([]);
+    assertEquals(result, 0);
+  } finally {
+    // Restore original state
+    friendMap.clear();
+    for (const [key, value] of originalFriends) {
+      friendMap.set(key, value);
+    }
+  }
 });
 
 Deno.test("ai command: should run AI-safe commands", async () => {
-  // Register a test AI-safe command
-  let wasCalled = false;
-  register(
-    "test-ai-safe",
-    "Test AI-safe command",
-    () => {
-      wasCalled = true;
-      return 0;
-    },
-    [],
-    true,
-  );
+  // Save current state of friendMap
+  const originalFriends = new Map(friendMap);
 
-  // Test running an AI-safe command
-  const result = await aiCommand(["test-ai-safe"]);
-  assertEquals(result, 0);
-  assertEquals(wasCalled, true);
+  try {
+    // Register a test AI-safe command
+    let wasCalled = false;
+    register(
+      "test-ai-safe",
+      "Test AI-safe command",
+      () => {
+        wasCalled = true;
+        return 0;
+      },
+      [],
+      true,
+    );
+
+    // Test running an AI-safe command
+    const result = await aiCommand(["test-ai-safe"]);
+    assertEquals(result, 0);
+    assertEquals(wasCalled, true);
+  } finally {
+    // Restore original state
+    friendMap.clear();
+    for (const [key, value] of originalFriends) {
+      friendMap.set(key, value);
+    }
+    // Wait a bit to ensure any async operations complete
+    await new Promise((resolve) => {
+      const timer = setTimeout(resolve, 100);
+      Deno.unrefTimer(timer);
+    });
+  }
 });
 
 Deno.test("ai command: should reject non-AI-safe commands", async () => {
-  // Register a test non-AI-safe command
-  register(
-    "test-not-safe",
-    "Test non-AI-safe command",
-    () => 0,
-    [],
-    false,
-  );
+  // Save current state of friendMap
+  const originalFriends = new Map(friendMap);
 
-  // Test trying to run a non-AI-safe command
-  const result = await aiCommand(["test-not-safe"]);
-  assertEquals(result, 1); // Should fail
+  try {
+    // Register a test non-AI-safe command
+    register(
+      "test-not-safe",
+      "Test non-AI-safe command",
+      () => 0,
+      [],
+      false,
+    );
+
+    // Test trying to run a non-AI-safe command
+    const result = await aiCommand(["test-not-safe"]);
+    assertEquals(result, 1); // Should fail
+  } finally {
+    // Restore original state
+    friendMap.clear();
+    for (const [key, value] of originalFriends) {
+      friendMap.set(key, value);
+    }
+  }
 });
 
 Deno.test("ai command: should handle unknown commands", async () => {

--- a/infra/bff/friends/build.bff.ts
+++ b/infra/bff/friends/build.bff.ts
@@ -15,8 +15,6 @@ import {
 
 const logger = getLogger(import.meta);
 
-await refreshAllSecrets();
-
 export const ENVIRONMENT_ONLY_KEYS = [
   "CI",
   "COLORTERM",
@@ -400,6 +398,9 @@ async function sh(command: string, cwd?: string): Promise<number> {
 }
 
 export async function build(args: Array<string>): Promise<number> {
+  // Refresh all secrets at the start of the build command
+  await refreshAllSecrets();
+
   const waitForFail = args.includes("--slow-exit");
   const debug = args.includes("--debug");
   const includeBoltFoundry = args.includes("--include-bolt-foundry");

--- a/infra/bff/friends/test.bff.ts
+++ b/infra/bff/friends/test.bff.ts
@@ -17,7 +17,20 @@ export async function testCommand(options: Array<string>): Promise<number> {
     : [...pathsStrings, ...pathsStringsX];
   const testArgs = ["deno", "test", "-A", ...runnablePaths];
 
-  const result = await runShellCommand(testArgs, undefined, {}, true, true);
+  // Set test environment variables to prevent 1Password popups during tests
+  const testEnv = {
+    BF_SECRETS_NEXT_UPDATE: "9999999999999", // Far future timestamp to skip 1Password
+    UNIT_TEST_PUBLIC: "public-value",
+    UNIT_TEST_SECRET: "shh-not-public",
+  };
+
+  const result = await runShellCommand(
+    testArgs,
+    undefined,
+    testEnv,
+    true,
+    true,
+  );
 
   if (result === 0) {
     logger.info("✨ All tests passed!");


### PR DESCRIPTION

- Move warmSecrets() calls from module top-level to main entry points in collector.ts and web.tsx
- Move refreshAllSecrets() call to start of build command instead of module load
- Add BF_SECRETS_NEXT_UPDATE tracking to prevent unnecessary 1Password calls
- Fix quote handling in .env cache files for proper value escaping
- Improve cache validity checks and update time management

This prevents secrets from being loaded during imports and ensures they're only
warmed when services actually start up, improving test performance and reducing
unnecessary 1Password API calls.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/1123).
* #1119
* #1120
* __->__ #1123
* #1122
* #1121