### PR TITLE
Add .env.local to gitignore and delete during land process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,5 @@ generated-icon.png
 .config/op/
 .config/op/*.sock
 .env
+.env.local
 *.local.*

--- a/infra/bff/friends/land.bff.ts
+++ b/infra/bff/friends/land.bff.ts
@@ -166,6 +166,23 @@ export async function land(): Promise<number> {
     logger.info("No .replit.local.toml file found, skipping merge step.");
   }
 
+  // Delete .env.local file if it exists
+  logger.info("Checking for .env.local file...");
+  const envLocalExists = await exists(".env.local");
+
+  if (envLocalExists) {
+    logger.info("Deleting .env.local file before git commit...");
+    try {
+      await Deno.remove(".env.local");
+      logger.info("Successfully deleted .env.local");
+    } catch (error) {
+      logger.error("Error deleting .env.local:", error);
+      // Continue with the process even if the delete fails
+    }
+  } else {
+    logger.info("No .env.local file found, skipping deletion.");
+  }
+
   // Create git commit with sapling commits and hash
   logger.info("Creating git commit...");
   const fullCommitMsg =


### PR DESCRIPTION

Add security measures to prevent .env.local from being committed to git.

Changes:
- Add .env.local explicitly to .gitignore
- Update land.bff.ts to delete .env.local before git commit
- Ensure secrets remain local and never reach the git repository

This prevents accidental exposure of secrets through version control.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/1125).
* #1130
* #1129
* #1128
* #1127
* #1126
* #1132
* #1131
* __->__ #1125