### PR TITLE
Update .env.local.template to match generated config keys

### DIFF
--- a/.env.local.template
+++ b/.env.local.template
@@ -1,41 +1,35 @@
-# Bolt Foundry Environment Variables Template
-# 
-# To populate this file with secrets from 1Password:
-#   bff inject-secrets
-#
-# This will create .env.local with all secrets from your vault.
-# Deno automatically loads .env.local files on startup.
-#
-# You can also specify individual values here for local development.
-# Any values set here will be used as defaults if not found in 1Password.
-
-# Database Configuration
-DATABASE_URL=
-DATABASE_BACKEND=
-SQLITE_DB_PATH=
-FORCE_DB_BACKEND=
-
-# Authentication
-JWT_SECRET=
-GOOGLE_CLIENT_ID=
-GOOGLE_CLIENT_SECRET=
-
-# API Keys
-OPENAI_API_KEY=
-ANTHROPIC_API_KEY=
+APPS_INTERNALBF_POSTHOG_API_KEY=
+ENABLE_SPECIFIC_LOGGERS=
+GOOGLE_OAUTH_CLIENT_ID=
+LOG_LEVEL=
+LOG_LOGGERS_TO_ENABLE=
 POSTHOG_API_KEY=
-ASSEMBLY_AI_KEY=
-
-# Service URLs
-POSTHOG_API_URL=
-BF_API_URL=
-BF_WEBSITE_URL=
-
-# Feature Flags
-BF_CACHE_TTL_SEC=
-BF_VAULT_ID=
-BF_SECRETS_CACHE_FILE=
-
-# Test Variables (for unit tests)
 UNIT_TEST_PUBLIC=
+ASSEMBLY_AI_KEY=
+BF_CACHE_ENV=
+BF_CACHE_TTL_SEC=
+BF_ENV=
+COLLECTOR_PORT=
+DATABASE_BACKEND=
+DATABASE_URL=
+DATABASE_URL_CONTACTS=
+DB_BACKEND_TYPE=
+EMAIL_FROM=
+EMAIL_HOST=
+EMAIL_PASS=
+EMAIL_PORT=
+EMAIL_USER=
+EXAMPLES_NEXTJS_SAMPLE_POSTHOG_API_KEY=
+GOOGLE_OAUTH_CLIENT_SECRET=
+JWT_SECRET=
+OPENAI_API_KEY=
+OPENAI_BASE_URL=
+OPENAI_ORG_ID=
+OPENAI_PROJECT_ID=
+OPENROUTER_API_KEY=
+THANKSBOT_DISCORD_TO_NOTION_MAP_DATABASE_ID=
+THANKSBOT_NOTION_DATABASE_ID=
+THANKSBOT_NOTION_TOKEN=
 UNIT_TEST_SECRET=
+WAITLIST_API_KEY=
+WEB_PORT=


### PR DESCRIPTION

Fixed deployment issue where inject-secrets was using outdated template
with wrong secret names (e.g., GOOGLE_CLIENT_ID instead of GOOGLE_OAUTH_CLIENT_ID).

Changes:
- Replace manually maintained template with auto-generated list from config keys
- Now includes all 35 secrets (7 public + 28 private) from generated config
- Ensures inject-secrets uses correct secret names for deployment

Test plan:
1. Run `bff inject-secrets` to verify it creates .env.local with 26 secrets
2. Confirm missing 9 secrets are optional configuration values
3. Deploy should now succeed with correct GOOGLE_OAUTH_CLIENT_ID

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
