### PR TITLE
Update group-commits command to use bff diff instead of sl diff

### DIFF
--- a/.claude/commands/bff-amend.md
+++ b/.claude/commands/bff-amend.md
@@ -17,6 +17,8 @@ bff amend
 
 - `--no-submit` - Amend without submitting pull request
 - `-m "New message"` - Amend with a new commit message
+- `--verbose`, `-v` - Show full output from pre-commit checks (default: concise)
+- `--skip-precommit` - Skip formatting, linting, and type checking
 
 ## Default Behavior
 

--- a/.claude/commands/bff-commit.md
+++ b/.claude/commands/bff-commit.md
@@ -19,20 +19,33 @@ bff commit -m "Your commit message"
 - `-m "message"` - The commit message (required)
 - `--skip-pre-check` - Skip formatting, linting, and type checking
 - `--no-submit` - Create commit without submitting a pull request
+- `--verbose`, `-v` - Show full output from pre-commit checks (default: concise)
 - `file1 file2` - Commit only specific files
 
 ## Default Behavior
 
 By default, `bff commit` will:
 
-1. Run pre-commit checks:
+1. Run pre-commit checks with concise output:
    - `bff format` - Format code
    - `bff lint` - Run linting rules
    - `bff check` - Type checking
+   - `bff test` - Run tests
+   - Shows only pass/fail status with execution time
 2. Create the commit
 3. Submit a pull request
 
+Use `--verbose` to see full output from all pre-commit checks including detailed
+test results.
+
 ## When to Use Options
+
+### Use `--verbose` when:
+
+- You need to see detailed test output
+- Debugging why a pre-commit check is failing
+- Want to see all linting warnings and errors
+- Need full formatting changes details
 
 ### Use `--skip-pre-check` when:
 
@@ -86,4 +99,5 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 
 ## AI-Safe Alternative
 
-For AI agents, use: `bff precommit` to stage files and run pre-commit checks
+For AI agents, use: `bff precommit` to stage files and run pre-commit checks.
+The precommit command also supports `--verbose` for detailed output.

--- a/.claude/commands/group-commits.md
+++ b/.claude/commands/group-commits.md
@@ -10,7 +10,7 @@ commits.
 
 ## Usage
 
-Run `sl diff` to see all changes, then analyze them to identify:
+Run `bff diff` to see all changes, then analyze them to identify:
 
 - Distinct features or fixes
 - Dependencies between changes

--- a/.claude/commands/group-commits.md
+++ b/.claude/commands/group-commits.md
@@ -1,0 +1,32 @@
+---
+name: group-commits
+description: Analyze uncommitted changes and suggest logical commit groupings
+---
+
+# Group Commits
+
+Analyzes uncommitted changes and suggests how to group them into logical, atomic
+commits.
+
+## Usage
+
+Run `sl diff` to see all changes, then analyze them to identify:
+
+- Distinct features or fixes
+- Dependencies between changes
+- Related functionality that should stay together
+
+## Output
+
+The command will suggest commit groups ordered by dependencies:
+
+1. Infrastructure/utilities (least dependent)
+2. Core features
+3. Integration code
+4. Tests and documentation
+
+Each group should:
+
+- Have a single, clear purpose
+- Build and test independently
+- Include all files needed for that feature

--- a/.claude/commands/split-commits.md
+++ b/.claude/commands/split-commits.md
@@ -1,0 +1,189 @@
+---
+name: split-commits
+description: Intelligently split commits into logical, atomic units based on features and dependencies
+---
+
+# Split Commits Intelligently
+
+Splits a single commit containing multiple changes into smaller, logical commits
+ordered by dependencies.
+
+## Overview
+
+This command helps you break apart commits that contain multiple unrelated
+changes or features. It analyzes dependencies between changes and creates atomic
+commits that:
+
+- Group related functionality together
+- Order commits from least to most dependent
+- Ensure each commit can build and test independently
+
+## Process
+
+### 1. Analyze Current Changes
+
+First, examine all uncommitted changes:
+
+```bash
+sl diff
+```
+
+Review the changes and identify:
+
+- Distinct features or bug fixes
+- Dependencies between changes
+- Shared functionality that should stay together
+
+### 2. Group Changes Logically
+
+Group changes by **feature/functionality**, not by file type:
+
+✅ **Good groupings:**
+
+- All changes for "Add user authentication" (model, API, UI)
+- All changes for "Fix database connection bug" (config, retry logic, tests)
+- All changes for "Refactor logging system" (interface, implementations, tests)
+
+❌ **Bad groupings:**
+
+- All TypeScript files in one commit
+- All test files in another commit
+- All documentation in a third commit
+
+### 3. Determine Dependency Order
+
+Order commits from least to most dependent:
+
+1. **Infrastructure/utilities** - Helper functions, types, configs
+2. **Core functionality** - Main feature implementation
+3. **Integration** - Code that uses the new functionality
+4. **Tests** - Tests for the new features
+5. **Documentation** - Updates to docs reflecting the changes
+
+### 4. Execute the Split
+
+Use Sapling's non-interactive split workflow:
+
+```bash
+# 1. Uncommit the current commit (keeps changes in working directory)
+sl uncommit
+
+# 2. Create first commit with least dependent changes
+sl add src/utils/newHelper.ts src/types/newTypes.ts
+sl commit -m "Add helper functions and types for feature X"
+
+# 3. Create second commit with core functionality
+sl add src/core/featureX.ts src/api/featureXEndpoint.ts
+sl commit -m "Implement feature X core functionality"
+
+# 4. Create third commit with integration
+sl add src/components/FeatureXComponent.tsx
+sl commit -m "Add UI component for feature X"
+
+# 5. Commit remaining changes
+sl commit -m "Add tests and documentation for feature X"
+```
+
+## Guidelines
+
+### Atomic Commits
+
+Each commit should:
+
+- Have a single, clear purpose
+- Include all changes needed for that purpose
+- Build and test successfully on its own
+- Not break existing functionality
+
+### Dependency Analysis
+
+Before splitting, ask yourself:
+
+- Which changes depend on others?
+- What's the minimal set of changes needed for each feature?
+- Can each commit be deployed independently?
+
+### Testing Each Commit
+
+After creating each commit, verify it works:
+
+```bash
+# After each commit
+bff test
+bff check
+```
+
+## Examples
+
+### Example 1: Mixed Feature and Bug Fix
+
+**Original commit contains:**
+
+- Bug fix for database connections
+- New user profile feature
+- Logging improvements
+
+**Split into:**
+
+1. `Fix database connection timeout handling`
+2. `Improve logging output format`
+3. `Add user profile management feature`
+
+### Example 2: Large Feature with Dependencies
+
+**Original commit contains:**
+
+- New GraphQL types
+- GraphQL resolver implementation
+- React components using the GraphQL
+- Tests for everything
+
+**Split into:**
+
+1. `Add GraphQL types for order management`
+2. `Implement order management resolvers`
+3. `Add order management UI components`
+4. `Add tests for order management feature`
+
+## Limitations
+
+### Hunk-Level Splitting
+
+When a single file contains multiple unrelated changes, you'll need human
+intervention:
+
+- `sl split` - Interactive hunk selection (requires human)
+- `sl commit --interactive` - Interactive staging (requires human)
+
+**Workaround for mixed files:**
+
+1. Manually separate changes into different files temporarily
+2. Create commits
+3. Recombine if needed
+
+### Best Practice
+
+Avoid needing to split by:
+
+- Making smaller, focused changes
+- Committing more frequently
+- Using `sl commit file1 file2` to commit specific files
+
+## Command Summary
+
+```bash
+# View current changes
+sl diff
+
+# Uncommit current commit
+sl uncommit
+
+# Stage specific files
+sl add file1 file2
+
+# Create focused commit
+sl commit -m "Descriptive message"
+
+# Verify each commit
+bff test && bff check
+```

--- a/apps/aibff/version.ts
+++ b/apps/aibff/version.ts
@@ -2,5 +2,5 @@
 export const VERSION = "0.1.0-dev";
 
 // Build metadata - will be replaced during build
-export const BUILD_TIME = "2025-06-13T22:19:31.152Z";
+export const BUILD_TIME = "2025-06-16T13:45:22.590Z";
 export const BUILD_COMMIT = "";

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -23,6 +23,7 @@
     "@std/front-matter": "jsr:@std/front-matter@^1.0.5",
     "@std/fs": "jsr:@std/fs@^1.0.18",
     "@std/http": "jsr:@std/http@^1.0.12",
+    "@std/io": "jsr:@std/io@^0.225.2",
     "@std/path": "jsr:@std/path@^1.1.0",
     "@std/streams": "jsr:@std/streams@^1.0.10",
     "@std/testing": "jsr:@std/testing@^1.0.9",

--- a/deno.lock
+++ b/deno.lock
@@ -51,6 +51,7 @@
     "jsr:@std/internal@^1.0.6": "1.0.6",
     "jsr:@std/io@0.223": "0.223.0",
     "jsr:@std/io@0.225": "0.225.2",
+    "jsr:@std/io@~0.225.2": "0.225.2",
     "jsr:@std/media-types@^1.1.0": "1.1.0",
     "jsr:@std/net@^1.0.4": "1.0.4",
     "jsr:@std/path@0.213.1": "0.213.1",
@@ -71,7 +72,7 @@
     "jsr:@std/yaml@^1.0.5": "1.0.6",
     "jsr:@ts-morph/bootstrap@0.24": "0.24.0",
     "jsr:@ts-morph/common@0.24": "0.24.0",
-    "npm:@anthropic-ai/claude-code@latest": "1.0.22",
+    "npm:@anthropic-ai/claude-code@^1.0.24": "1.0.24",
     "npm:@hexagon/base64@^1.1.27": "1.1.28",
     "npm:@isograph/compiler@0.0.0-main-1fad6d74": "0.0.0-main-1fad6d74",
     "npm:@isograph/react@0.0.0-main-1fad6d74": "0.0.0-main-1fad6d74_react@19.1.0",
@@ -422,8 +423,8 @@
     }
   },
   "npm": {
-    "@anthropic-ai/claude-code@1.0.22": {
-      "integrity": "sha512-vqfDHq4KNtUzUiwdsls8+2aTrC1Rn96iH+yOyCrBjHjJwojzU6pt3MOAMkJHMeErKeGqve+I7HM6mFw0OgZgqw==",
+    "@anthropic-ai/claude-code@1.0.24": {
+      "integrity": "sha512-4S6ly2297ngNlto7IFZeEicS9u0yRDhocOzndWFovGBb+iUoEPKdZa/rhVk/tcyCADL6S+mMkiGQOlqFDrN3JQ==",
       "optionalDependencies": [
         "@img/sharp-darwin-arm64",
         "@img/sharp-darwin-x64",
@@ -4139,6 +4140,7 @@
       "jsr:@std/front-matter@^1.0.5",
       "jsr:@std/fs@^1.0.18",
       "jsr:@std/http@^1.0.12",
+      "jsr:@std/io@~0.225.2",
       "jsr:@std/path@^1.1.0",
       "jsr:@std/streams@^1.0.10",
       "jsr:@std/testing@^1.0.9",
@@ -4148,7 +4150,7 @@
     ],
     "packageJson": {
       "dependencies": [
-        "npm:@anthropic-ai/claude-code@latest",
+        "npm:@anthropic-ai/claude-code@^1.0.24",
         "npm:@isograph/compiler@0.0.0-main-1fad6d74",
         "npm:@isograph/react@0.0.0-main-1fad6d74",
         "npm:@lexical/mark@0.27.2",

--- a/infra/bin/aibff
+++ b/infra/bin/aibff
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+# aibff wrapper script
+# Run aibff either from source or from compiled binary
+#
+# Usage:
+#   aibff [--build|--binary] [command] [args...]
+#
+# Options:
+#   --build    Build the aibff binary
+#   --binary   Run the compiled binary instead of source
+#
+# Examples:
+#   aibff --help              # Run from source, show help
+#   aibff repl                # Run repl command from source
+#   aibff --binary repl       # Run repl command from compiled binary
+#   aibff --build             # Build the binary
+
+set -euo pipefail
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Default to running from source
+USE_BINARY=false
+BUILD_BINARY=false
+
+# Parse wrapper-specific flags
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --binary)
+            USE_BINARY=true
+            shift
+            ;;
+        --build)
+            BUILD_BINARY=true
+            shift
+            ;;
+        *)
+            break # Stop parsing when we hit a non-wrapper flag
+            ;;
+    esac
+done
+
+# Handle --build flag
+if $BUILD_BINARY; then
+    echo "Building aibff binary..."
+    BUILD_SCRIPT="$ROOT_DIR/apps/aibff/bin/build.ts"
+    
+    if [[ ! -f "$BUILD_SCRIPT" ]]; then
+        echo "Error: Build script not found at $BUILD_SCRIPT" >&2
+        exit 1
+    fi
+    
+    # Run the build script with any remaining arguments
+    exec deno run \
+        --allow-read \
+        --allow-run \
+        --allow-write \
+        --allow-env \
+        "$BUILD_SCRIPT" \
+        "$@"
+fi
+
+if $USE_BINARY; then
+    # Run compiled binary
+    BINARY_PATH="$ROOT_DIR/build/bin/aibff"
+    
+    # Check if binary exists
+    if [[ ! -f "$BINARY_PATH" ]]; then
+        echo "Error: Compiled binary not found at $BINARY_PATH" >&2
+        echo "Run 'deno run --allow-all apps/aibff/bin/build.ts' to build it first." >&2
+        exit 1
+    fi
+    
+    # Execute the binary with remaining arguments
+    exec "$BINARY_PATH" "$@"
+else
+    # Run from source using deno
+    MAIN_PATH="$ROOT_DIR/apps/aibff/main.ts"
+    
+    # Check if main.ts exists
+    if [[ ! -f "$MAIN_PATH" ]]; then
+        echo "Error: aibff main.ts not found at $MAIN_PATH" >&2
+        exit 1
+    fi
+    
+    # Execute with deno, providing all necessary permissions
+    exec deno run \
+        --allow-env \
+        --allow-read \
+        --allow-write \
+        --allow-net \
+        --allow-run \
+        "$MAIN_PATH" \
+        "$@"
+fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "workspace",
+  "name": "bolt-foundry-monorepo",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -29,7 +29,6 @@
         "@types/react": "^19.0",
         "@types/react-dom": "^19.0",
         "assemblyai": "^4.9.0",
-        "chalk": "^5.4.1",
         "discord.js": "^14.18.0",
         "esbuild": "^0.24.2",
         "graphql": "^16.10.0",
@@ -2562,18 +2561,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/character-entities": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@anthropic-ai/claude-code": "latest",
+    "@anthropic-ai/claude-code": "^1.0.24",
     "@isograph/compiler": "0.0.0-main-1fad6d74",
     "@isograph/react": "0.0.0-main-1fad6d74",
     "@lexical/mark": "0.27.2",


### PR DESCRIPTION

Update the group-commits custom command to use the bff wrapper command
instead of direct sapling commands, following the project's best practices
of preferring bff commands over direct sapling usage.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/1149).
* #1153
* #1152
* #1145
* #1151
* #1150
* __->__ #1149
* #1146
* #1144
* #1143
* #1142
* #1141