### PR TITLE
Fix team summary analysis deck per PR 1089 feedback

### DIFF
--- a/decks/team-summary-analysis.deck.md
+++ b/decks/team-summary-analysis.deck.md
@@ -1,9 +1,10 @@
 # Team Summary Analysis Deck
 
-A collection of cards for analyzing team member contributions and creating
-meaningful summaries that focus on impact rather than activity counts.
+You are an assistant who helps understand team goals and analyze team member
+contributions, creating meaningful summaries that focus on impact rather than
+activity counts.
 
-## Base Card: Team Summary Approach
+## Team Summary Approach
 
 Generate human-readable summaries of what team members worked on by analyzing
 their recent Pull Requests in context of company goals and ongoing projects.
@@ -17,13 +18,7 @@ their recent Pull Requests in context of company goals and ongoing projects.
 - Tell the story of what happened
 - Highlight genuinely significant contributions
 
-### Summary format
-
-```
-[Name] worked on [project/area]. They [implemented/fixed/improved] [specific thing] which [company connection if clear].
-```
-
-## Card: Work Analysis
+## Work Analysis
 
 When analyzing a team member's recent PRs:
 
@@ -52,26 +47,9 @@ Based on company documents, look for work that relates to:
 - **User experience** improvements that make the product better
 - **Team efficiency** improvements that help everyone work better
 
-## Card: Summary Writing
+## Summary Writing
 
 When writing the actual summary:
-
-### Good examples
-
-- "Alice worked on team status tracking. She built the GitHub analysis system
-  which helps the team stay informed about what everyone is working on."
-- "Bob focused on authentication improvements. He fixed several timeout issues
-  that were affecting users and updated the security flow."
-- "Carol optimized the CI pipeline. She reduced build times by 40% which makes
-  deployments faster for the whole team."
-
-### Poor examples
-
-- "Alice submitted 8 PRs this week covering features, bugfixes, and
-  documentation." (too mechanical)
-- "Bob has been pioneering our revolutionary approach to next-generation
-  authentication paradigms." (too jargony)
-- "Carol worked on infrastructure." (too vague)
 
 ### Language guidelines
 
@@ -193,7 +171,7 @@ This deck uses context variables to generate summaries:
 - **Company connection**: `{{companyConnection}}`
 - **Work breakdown**: `{{workCategories}}` across `{{totalPRs}}` PRs
 
-Context file: `team-summary-analysis-context.toml`
+Context file: `team-summary-analysis.deck.toml`
 
 ## Output Format
 

--- a/decks/team-summary-analysis.deck.toml
+++ b/decks/team-summary-analysis.deck.toml
@@ -42,3 +42,9 @@ description = "Breakdown of work by category (features, bugs, etc.)"
 type = "object"
 question = "What are the relevant company goals?"
 description = "Company differentiators and strategic objectives"
+
+[contexts.summaryFormat]
+type = "string"
+question = "What format should the summary follow?"
+description = "Template for writing team member summaries"
+default = "[Name] worked on [project/area]. They [implemented/fixed/improved] [specific thing] which [company connection if clear]."


### PR DESCRIPTION

Address all review comments from randallb in PR 1089:
- Rename context file from team-summary-analysis-context.toml to .deck.toml
- Remove "Base Card:" prefix from section headers
- Update deck description to start with "You are an assistant who helps..."
- Move summary format template from card content to context as default value
- Remove "Card:" prefixes from section headers (Work Analysis, Summary Writing)
- Remove examples from deck (moved to grader for evaluation)

Changes:
- Rename decks/team-summary-analysis-context.toml → team-summary-analysis.deck.toml
- Update decks/team-summary-analysis.deck.md headers and structure
- Add summaryFormat context variable with default template
- Remove good/poor examples from deck content
- Update context file reference in deck

Test plan:
1. Verify deck can be parsed by build system
2. Confirm context file is properly referenced
3. Check that examples are no longer in main deck content

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/1160).
* #1161
* __->__ #1160