### PR TITLE
Add team summary analysis grader for evaluation

### DIFF
--- a/decks/graders/team-summary-analysis-grader.deck.md
+++ b/decks/graders/team-summary-analysis-grader.deck.md
@@ -1,0 +1,35 @@
+# Team Summary Analysis Grader
+
+This grader evaluates team member work summaries to ensure they focus on impact
+rather than activity counts, using plain language and meaningful context.
+
+## Summary Quality Evaluation
+
+![team summary grader contexts](./team-summary-analysis-grader.deck.toml#contexts)
+
+### Main Criteria
+
+- Evaluate whether the summary focuses on meaning over metrics
+- Assess if the language is plain and accessible (not jargony)
+- Consider if the work is connected to company goals when appropriate
+- Check if the summary tells a clear story of what was accomplished
+
+### Scoring Guidelines
+
+- Score 3: Perfect impact-focused summary with clear storytelling [^excellent-summary]
+- Score 2: Good summary with minor improvements possible [^good-summary]
+- Score 1: Adequate but could better emphasize impact over activity
+- Score 0: Neutral - acceptable but neither particularly good nor bad
+- Score -1: Too focused on metrics or lacks clear impact description
+- Score -2: Significantly problematic - too mechanical or jargony [^poor-summary]
+- Score -3: Extremely poor - just lists activities without meaning [^terrible-summary]
+
+[^excellent-summary]: ![sample](./team-summary-analysis-grader.deck.toml#samples.excellent-summary)
+
+[^good-summary]: ![sample](./team-summary-analysis-grader.deck.toml#samples.good-summary)
+
+[^poor-summary]: ![sample](./team-summary-analysis-grader.deck.toml#samples.poor-summary)
+
+[^terrible-summary]: ![sample](./team-summary-analysis-grader.deck.toml#samples.terrible-summary)
+
+> ![grader evaluation framework](../grader-base.deck.md)

--- a/decks/graders/team-summary-analysis-grader.deck.toml
+++ b/decks/graders/team-summary-analysis-grader.deck.toml
@@ -1,0 +1,37 @@
+[contexts.teamMember]
+type = "string"
+question = "What is the team member's name?"
+description = "The name of the team member being evaluated"
+example = "Alice"
+
+[contexts.workSummary]
+type = "string"
+question = "What is the work summary being evaluated?"
+description = "The AI-generated summary of the team member's work to be graded"
+example = "Alice worked on team status tracking. She built the GitHub analysis system which helps the team stay informed about what everyone is working on."
+
+# Sample summaries for different score levels
+[samples.excellent-summary]
+userMessage = "Generate a summary for Alice's work on team status tracking features"
+assistantResponse = "Alice worked on team status tracking. She built the GitHub analysis system which helps the team stay informed about what everyone is working on."
+explanation = "Perfect example - focuses on what was built, explains the benefit in plain terms, connects to team value"
+
+[samples.good-summary]
+userMessage = "Generate a summary for Bob's authentication work"
+assistantResponse = "Bob focused on authentication improvements. He fixed several timeout issues that were affecting users and updated the security flow."
+explanation = "Good summary - clear about what was done and why it matters, could be slightly more specific about impact"
+
+[samples.poor-summary]
+userMessage = "Generate a summary for Carol's infrastructure work" 
+assistantResponse = "Carol has been pioneering our revolutionary approach to next-generation authentication paradigms."
+explanation = "Too jargony - uses buzzwords instead of plain language, doesn't explain what was actually built"
+
+[samples.terrible-summary]
+userMessage = "Generate a summary for Dave's recent work"
+assistantResponse = "Dave submitted 8 PRs this week covering features, bugfixes, and documentation."
+explanation = "Mechanical activity counting - focuses on metrics rather than meaning, doesn't explain what was accomplished"
+
+[samples.vague-summary]
+userMessage = "Generate a summary for Carol's infrastructure work"
+assistantResponse = "Carol worked on infrastructure."
+explanation = "Too vague - doesn't explain what was built or why it matters"

--- a/decks/graders/team-summary-test-samples.jsonl
+++ b/decks/graders/team-summary-test-samples.jsonl
@@ -1,0 +1,5 @@
+{"userMessage": "Generate a summary for Alice's work on team status tracking features", "assistantResponse": "Alice worked on team status tracking. She built the GitHub analysis system which helps the team stay informed about what everyone is working on.", "id": "team-001", "score": 3}
+{"userMessage": "Generate a summary for Bob's authentication work", "assistantResponse": "Bob focused on authentication improvements. He fixed several timeout issues that were affecting users and updated the security flow.", "id": "team-002", "score": 2}
+{"userMessage": "Generate a summary for Carol's infrastructure work", "assistantResponse": "Carol has been pioneering our revolutionary approach to next-generation authentication paradigms.", "id": "team-003", "score": -2}
+{"userMessage": "Generate a summary for Dave's recent work", "assistantResponse": "Dave submitted 8 PRs this week covering features, bugfixes, and documentation.", "id": "team-004", "score": -3}
+{"userMessage": "Generate a summary for Carol's infrastructure work", "assistantResponse": "Carol worked on infrastructure.", "id": "team-005", "score": -1}

--- a/decks/team-summary-analysis.deck.md
+++ b/decks/team-summary-analysis.deck.md
@@ -1,9 +1,10 @@
 # Team Summary Analysis Deck
 
-A collection of cards for analyzing team member contributions and creating
-meaningful summaries that focus on impact rather than activity counts.
+You are an assistant who helps understand team goals and analyze team member
+contributions, creating meaningful summaries that focus on impact rather than
+activity counts.
 
-## Base Card: Team Summary Approach
+## Team Summary Approach
 
 Generate human-readable summaries of what team members worked on by analyzing
 their recent Pull Requests in context of company goals and ongoing projects.
@@ -17,13 +18,7 @@ their recent Pull Requests in context of company goals and ongoing projects.
 - Tell the story of what happened
 - Highlight genuinely significant contributions
 
-### Summary format
-
-```
-[Name] worked on [project/area]. They [implemented/fixed/improved] [specific thing] which [company connection if clear].
-```
-
-## Card: Work Analysis
+## Work Analysis
 
 When analyzing a team member's recent PRs:
 
@@ -52,26 +47,9 @@ Based on company documents, look for work that relates to:
 - **User experience** improvements that make the product better
 - **Team efficiency** improvements that help everyone work better
 
-## Card: Summary Writing
+## Summary Writing
 
 When writing the actual summary:
-
-### Good examples
-
-- "Alice worked on team status tracking. She built the GitHub analysis system
-  which helps the team stay informed about what everyone is working on."
-- "Bob focused on authentication improvements. He fixed several timeout issues
-  that were affecting users and updated the security flow."
-- "Carol optimized the CI pipeline. She reduced build times by 40% which makes
-  deployments faster for the whole team."
-
-### Poor examples
-
-- "Alice submitted 8 PRs this week covering features, bugfixes, and
-  documentation." (too mechanical)
-- "Bob has been pioneering our revolutionary approach to next-generation
-  authentication paradigms." (too jargony)
-- "Carol worked on infrastructure." (too vague)
 
 ### Language guidelines
 
@@ -193,7 +171,7 @@ This deck uses context variables to generate summaries:
 - **Company connection**: `{{companyConnection}}`
 - **Work breakdown**: `{{workCategories}}` across `{{totalPRs}}` PRs
 
-Context file: `team-summary-analysis-context.toml`
+Context file: `team-summary-analysis.deck.toml`
 
 ## Output Format
 

--- a/decks/team-summary-analysis.deck.toml
+++ b/decks/team-summary-analysis.deck.toml
@@ -42,3 +42,9 @@ description = "Breakdown of work by category (features, bugs, etc.)"
 type = "object"
 question = "What are the relevant company goals?"
 description = "Company differentiators and strategic objectives"
+
+[contexts.summaryFormat]
+type = "string"
+question = "What format should the summary follow?"
+description = "Template for writing team member summaries"
+default = "[Name] worked on [project/area]. They [implemented/fixed/improved] [specific thing] which [company connection if clear]."


### PR DESCRIPTION

Create comprehensive grader to evaluate team member work summaries based on
impact-focused criteria established in the team summary analysis deck.

Changes:
- Add decks/graders/team-summary-analysis-grader.deck.md with evaluation framework
- Add decks/graders/team-summary-analysis-grader.deck.toml with contexts and samples
- Add decks/graders/team-summary-test-samples.jsonl with test cases
- Include good/poor examples moved from original deck per PR feedback
- Follow standard grader patterns with -3 to +3 scoring scale
- Use grader-base.deck.md framework for consistency

Features:
- Evaluates summaries on meaning vs metrics focus
- Checks for plain language over jargon
- Assesses clear storytelling and impact description
- Includes sample summaries at different quality levels
- Compatible with bff-eval evaluation system

Test plan:
1. Verify grader files parse correctly with deck builder
2. Run bff test to ensure grader structure is valid
3. Confirm grader follows established patterns in codebase

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/1161).
* __->__ #1161
* #1160