### PR TITLE
Replace JavaScript tabs with CSS-only radio button tabs

### DIFF
--- a/apps/aibff/__tests__/utils/toml-to-html.test.ts
+++ b/apps/aibff/__tests__/utils/toml-to-html.test.ts
@@ -46,7 +46,8 @@ Deno.test("generateEvaluationHtml should handle multiple graders", () => {
 
   // Should have tabs for multiple graders
   assertStringIncludes(html, '<div class="tabs">');
-  assertStringIncludes(html, 'onclick="showTab(');
+  assertStringIncludes(html, 'class="tab-radio"');
+  assertStringIncludes(html, 'type="radio"');
 });
 
 Deno.test("generateEvaluationHtml should create expandable details for each row", () => {

--- a/apps/aibff/utils/toml-to-html.ts
+++ b/apps/aibff/utils/toml-to-html.ts
@@ -203,28 +203,32 @@ export function generateEvaluationHtml(
       margin-bottom: 20px;
       border-bottom: 2px solid #e0e0e0;
     }
-    .tab {
+    .tab-radio {
+      display: none;
+    }
+    .tab-label {
       padding: 10px 20px;
       cursor: pointer;
-      border: none;
-      background: none;
       font-size: 16px;
       color: #666;
       transition: all 0.2s;
+      border: none;
+      background: none;
+      display: block;
     }
-    .tab:hover {
+    .tab-label:hover {
       color: #333;
-    }
-    .tab.active {
-      color: #0066cc;
-      border-bottom: 2px solid #0066cc;
-      margin-bottom: -2px;
     }
     .tab-content {
       display: none;
     }
-    .tab-content.active {
+    /* Show content when there's only one tab */
+    .single-tab .tab-content {
       display: block;
+    }
+    .tab-container {
+      display: flex;
+      flex-direction: column;
     }
     .verbose-prompt {
       margin-top: 15px;
@@ -245,6 +249,19 @@ export function generateEvaluationHtml(
       white-space: pre-wrap;
       word-wrap: break-word;
     }
+    
+    /* Dynamic CSS rules for tabs */
+    ${
+    tabEntries.map((entry) => `
+    #tab-radio-${entry.key}:checked ~ .tabs label[for="tab-radio-${entry.key}"] {
+      color: #0066cc;
+      border-bottom: 2px solid #0066cc;
+      margin-bottom: -2px;
+    }
+    #tab-radio-${entry.key}:checked ~ .tab-container #tab-${entry.key} {
+      display: block;
+    }`).join("\n    ")
+  }
   </style>
 </head>
 <body>
@@ -258,12 +275,17 @@ export function generateEvaluationHtml(
     ${
     !singleTab
       ? `
+    ${
+        tabEntries.map((entry, index) => `
+      <input type="radio" class="tab-radio" id="tab-radio-${entry.key}" name="tabs" ${
+          index === 0 ? "checked" : ""
+        }>
+    `).join("")
+      }
     <div class="tabs">
       ${
-        tabEntries.map((entry, index) => `
-        <button class="tab ${
-          index === 0 ? "active" : ""
-        }" onclick="showTab('${entry.key}')">${entry.label}</button>
+        tabEntries.map((entry) => `
+        <label class="tab-label" for="tab-radio-${entry.key}">${entry.label}</label>
       `).join("")
       }
     </div>
@@ -271,8 +293,9 @@ export function generateEvaluationHtml(
       : ""
   }
     
+    <div class="tab-container${singleTab ? " single-tab" : ""}">
     ${
-    tabEntries.map((entry, index) => {
+    tabEntries.map((entry) => {
       // Get the actual data based on nested or flat structure
       let resultData: ModelResults;
       if (isNested) {
@@ -295,9 +318,7 @@ export function generateEvaluationHtml(
         : 0;
 
       return `
-    <div class="tab-content ${
-        singleTab || index === 0 ? "active" : ""
-      }" id="tab-${entry.key}">
+    <div class="tab-content" id="tab-${entry.key}">
       <h2>${entry.label}</h2>
       
       <div class="summary">
@@ -492,29 +513,8 @@ export function generateEvaluationHtml(
   `;
     }).join("")
   }
+    </div>
   </div>
-  
-  ${
-    !singleTab
-      ? `
-  <script>
-    function showTab(graderName) {
-      // Hide all tabs
-      document.querySelectorAll('.tab-content').forEach(tab => {
-        tab.classList.remove('active');
-      });
-      document.querySelectorAll('.tab').forEach(tab => {
-        tab.classList.remove('active');
-      });
-      
-      // Show selected tab
-      document.getElementById('tab-' + graderName).classList.add('active');
-      event.target.classList.add('active');
-    }
-  </script>
-  `
-      : ""
-  }
 </body>
 </html>`;
 }


### PR DESCRIPTION

Improve aibff calibrate results UI by removing JavaScript dependency
and implementing CSS-only tabs using radio buttons and labels.

Changes:
- Replace onclick JavaScript handlers with radio button + label pairs
- Add CSS selectors for :checked state styling of active tabs
- Restructure HTML to place radio buttons before tabs div for sibling selectors
- Generate dynamic CSS rules for each tab's checked state
- Remove all JavaScript showTab function and related code
- Update test to check for radio buttons instead of onclick handlers

Benefits:
- No JavaScript required - works without JS enabled
- Better accessibility with proper radio button semantics
- Faster loading without JavaScript execution dependency
- More reliable tab switching mechanism

Test plan:
1. Run tests: bff test apps/aibff/__tests__/utils/toml-to-html.test.ts
2. Verify tabs show active styling when selected
3. Confirm tab content switches correctly when clicking labels

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/1191).
* #1196
* #1195
* #1194
* #1193
* __->__ #1191