### PR TITLE
Fix inject-secrets to quote environment variable values

### DIFF
--- a/infra/bff/friends/inject-secrets.bff.ts
+++ b/infra/bff/friends/inject-secrets.bff.ts
@@ -123,7 +123,7 @@ register(
 
       // Generate .env.local file with empty values for users without 1Password access
       logger.info("Generating .env.local file with empty values...");
-      const envLines = keysToInject.map((key) => `${key}=`);
+      const envLines = keysToInject.map((key) => `${key}=""`);
       await Deno.writeTextFile(output, envLines.join("\n") + "\n");
       logger.info(`✅ Created ${output} with empty values`);
       logger.info("Please fill in the values for the secrets you need");
@@ -140,7 +140,7 @@ register(
 
     for (const [key, value] of Object.entries(injected)) {
       if (value && value !== `op://${vault}/${key}/value`) {
-        envLines.push(`${key}=${value}`);
+        envLines.push(`${key}="${value}"`);
         successCount++;
       } else {
         logger.debug(`Secret not found in 1Password: ${key}`);


### PR DESCRIPTION

The inject-secrets command now properly quotes all values in .env.local files.
This ensures that values with special characters are handled correctly.

Changes:
- Quote values when writing to .env.local from 1Password injection
- Quote empty values in fallback case when 1Password is unavailable
- Both cases now use consistent format: KEY="value"

Test plan:
1. Run bff inject-secrets --force with valid 1Password vault
2. Verify values are quoted in .env.local
3. Run with invalid vault to test fallback
4. Verify empty values are quoted as KEY=""

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
