### PR TITLE
Simplify aibff version management for local development

### DIFF
--- a/.github/workflows/publish-aibff-dev.yml
+++ b/.github/workflows/publish-aibff-dev.yml
@@ -71,8 +71,13 @@ jobs:
 
       - name: Update version
         run: |
-          # Update version.ts with dev version
+          # Update version.ts with dev version and build metadata
+          BUILD_TIME=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
+          BUILD_COMMIT="${{ steps.version.outputs.git_hash }}"
+
           sed -i.bak "s/VERSION = \".*\"/VERSION = \"${{ steps.version.outputs.version }}\"/" apps/aibff/version.ts
+          sed -i.bak "s/BUILD_TIME = \".*\"/BUILD_TIME = \"$BUILD_TIME\"/" apps/aibff/version.ts
+          sed -i.bak "s/BUILD_COMMIT = \".*\"/BUILD_COMMIT = \"$BUILD_COMMIT\"/" apps/aibff/version.ts
           rm apps/aibff/version.ts.bak
 
           echo "Updated version to ${{ steps.version.outputs.version }}"

--- a/.github/workflows/publish-aibff-release.yml
+++ b/.github/workflows/publish-aibff-release.yml
@@ -60,8 +60,13 @@ jobs:
 
       - name: Update version
         run: |
-          # Update version.ts
+          # Update version.ts with version and build metadata
+          BUILD_TIME=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
+          BUILD_COMMIT=$(git rev-parse --short HEAD)
+
           sed -i.bak 's/VERSION = ".*"/VERSION = "${{ github.event.inputs.version }}"/' apps/aibff/version.ts
+          sed -i.bak "s/BUILD_TIME = \".*\"/BUILD_TIME = \"$BUILD_TIME\"/" apps/aibff/version.ts
+          sed -i.bak "s/BUILD_COMMIT = \".*\"/BUILD_COMMIT = \"$BUILD_COMMIT\"/" apps/aibff/version.ts
           rm apps/aibff/version.ts.bak
 
           echo "Updated version to ${{ github.event.inputs.version }}"

--- a/apps/aibff/bin/build.ts
+++ b/apps/aibff/bin/build.ts
@@ -9,7 +9,6 @@ const logger = getLogger(import.meta);
 const ROOT_DIR = join(import.meta.dirname!, "../../..");
 const MAIN_ENTRY = join(ROOT_DIR, "apps/aibff/main.ts");
 const BUILD_DIR = join(ROOT_DIR, "build/bin");
-const VERSION_FILE = join(ROOT_DIR, "apps/aibff/version.ts");
 
 // Parse command line arguments
 const args = parseArgs(Deno.args, {
@@ -139,32 +138,6 @@ async function getAllRequiredPackages(): Promise<Array<string>> {
   return Array.from(allRequired);
 }
 
-async function updateVersionFile() {
-  const gitCommit = await getGitCommit();
-  const buildTime = new Date().toISOString();
-
-  const versionContent = await Deno.readTextFile(VERSION_FILE);
-  const updatedContent = versionContent
-    .replace(/BUILD_TIME = ".*"/, `BUILD_TIME = "${buildTime}"`)
-    .replace(/BUILD_COMMIT = ".*"/, `BUILD_COMMIT = "${gitCommit}"`);
-
-  await Deno.writeTextFile(VERSION_FILE, updatedContent);
-  logger.debug("Updated version file with build metadata");
-}
-
-async function getGitCommit(): Promise<string> {
-  try {
-    const cmd = new Deno.Command("git", {
-      args: ["rev-parse", "--short", "HEAD"],
-      stdout: "piped",
-    });
-    const { stdout } = await cmd.output();
-    return new TextDecoder().decode(stdout).trim();
-  } catch {
-    return "unknown";
-  }
-}
-
 async function build() {
   const platform = args.platform as string;
   const arch = args.arch as string;
@@ -175,9 +148,6 @@ async function build() {
 
   // Validate node_modules structure first
   await validateNodeModules();
-
-  // Update version file with build metadata
-  await updateVersionFile();
 
   // Ensure build directory exists
   await Deno.mkdir(BUILD_DIR, { recursive: true });

--- a/apps/aibff/version.ts
+++ b/apps/aibff/version.ts
@@ -1,6 +1,6 @@
 // This file is updated during the release process
-export const VERSION = "0.1.0-dev";
+export const VERSION = "unpublished";
 
-// Build metadata - will be replaced during build
-export const BUILD_TIME = "2025-06-23T14:14:30.752Z";
+// Build metadata - only updated during CI builds
+export const BUILD_TIME = "";
 export const BUILD_COMMIT = "";


### PR DESCRIPTION

Change version.ts to use "unpublished" for local builds and prevent constant
timestamp updates during development. Build metadata (time, commit) now only
updates during CI releases.

Changes:
- Update version.ts to show "unpublished" instead of "0.1.0-dev"
- Remove automatic version file updates from build.ts
- Update CI workflows to set build metadata during releases
- Clean up unused git commit and timestamp functions

Test plan:
1. Run local build: `deno run --allow-all apps/aibff/main.ts rebuild`
2. Verify version.ts remains unchanged after build
3. Check binary shows "unpublished": `build/bin/aibff --version`

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
