### PR TITLE
Add demo subcommand to aibff calibrate for fastpitch graders

### DIFF
--- a/.github/workflows/publish-aibff-dev.yml
+++ b/.github/workflows/publish-aibff-dev.yml
@@ -271,3 +271,87 @@ jobs:
             artifacts/*/*.zip.sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-npm:
+    name: Publish to npm (dev)
+    needs: create-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # Required for npm provenance
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Get version info
+        id: version
+        run: |
+          # Get the base version from version.ts
+          BASE_VERSION=$(grep 'VERSION = ' apps/aibff/version.ts | cut -d'"' -f2 | sed 's/-dev$//')
+
+          # Get short git hash
+          GIT_HASH=$(git rev-parse --short HEAD)
+
+          # Create dev version
+          DEV_VERSION="${BASE_VERSION}-dev.${GIT_HASH}"
+
+          echo "version=${DEV_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "git_hash=${GIT_HASH}" >> "$GITHUB_OUTPUT"
+
+      - name: Update npm package version
+        run: |
+          cd packages/aibff
+
+          # Update package.json version
+          npm version ${{ steps.version.outputs.version }} --no-git-tag-version
+
+          echo "Updated package.json to version ${{ steps.version.outputs.version }}"
+          cat package.json | grep version
+
+      - name: Download binaries from GitHub Release
+        run: |
+          cd packages/aibff
+          mkdir -p bin
+
+          # Download binaries from the just-created GitHub release
+          RELEASE_TAG="aibff-dev-${{ steps.version.outputs.git_hash }}"
+
+          # Download Linux binary
+          curl -L -o bin/aibff-linux-x86_64 \
+            "https://github.com/${{ github.repository }}/releases/download/${RELEASE_TAG}/aibff-linux-x86_64"
+
+          # Download macOS binary
+          curl -L -o bin/aibff-darwin-aarch64 \
+            "https://github.com/${{ github.repository }}/releases/download/${RELEASE_TAG}/aibff-darwin-aarch64"
+
+          # Download Windows binary
+          curl -L -o bin/aibff-windows-x86_64.exe \
+            "https://github.com/${{ github.repository }}/releases/download/${RELEASE_TAG}/aibff-windows-x86_64.exe"
+
+          # Make Unix binaries executable
+          chmod +x bin/aibff-linux-x86_64
+          chmod +x bin/aibff-darwin-aarch64
+
+          # Verify binaries exist
+          ls -la bin/
+
+      - name: Test npm package
+        run: |
+          cd packages/aibff
+
+          # Test that the postinstall script works
+          npm run postinstall || echo "Postinstall expected to fail without actual download"
+
+      - name: Publish to npm with dev tag
+        run: |
+          cd packages/aibff
+          npm publish --tag dev --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-aibff-release.yml
+++ b/.github/workflows/publish-aibff-release.yml
@@ -257,3 +257,78 @@ jobs:
             artifacts/*/aibff-windows-x86_64.exe
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-npm:
+    name: Publish to npm
+    needs: create-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # Required for npm provenance
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Update npm package version
+        run: |
+          cd packages/aibff
+
+          # Update package.json version
+          npm version ${{ github.event.inputs.version }} --no-git-tag-version
+
+          echo "Updated package.json to version ${{ github.event.inputs.version }}"
+          cat package.json | grep version
+
+      - name: Download binaries from GitHub Release
+        run: |
+          cd packages/aibff
+          mkdir -p bin
+
+          # Download binaries from the just-created GitHub release
+          RELEASE_TAG="aibff-v${{ github.event.inputs.version }}"
+
+          # Download Linux binary
+          curl -L -o bin/aibff-linux-x86_64 \
+            "https://github.com/${{ github.repository }}/releases/download/${RELEASE_TAG}/aibff-linux-x86_64"
+
+          # Download macOS binary
+          curl -L -o bin/aibff-darwin-aarch64 \
+            "https://github.com/${{ github.repository }}/releases/download/${RELEASE_TAG}/aibff-darwin-aarch64"
+
+          # Download Windows binary
+          curl -L -o bin/aibff-windows-x86_64.exe \
+            "https://github.com/${{ github.repository }}/releases/download/${RELEASE_TAG}/aibff-windows-x86_64.exe"
+
+          # Make Unix binaries executable
+          chmod +x bin/aibff-linux-x86_64
+          chmod +x bin/aibff-darwin-aarch64
+
+          # Verify binaries exist
+          ls -la bin/
+
+      - name: Test npm package
+        run: |
+          cd packages/aibff
+
+          # Test that the postinstall script works
+          npm run postinstall || echo "Postinstall expected to fail without actual download"
+
+      - name: Publish to npm
+        run: |
+          cd packages/aibff
+
+          # Publish with appropriate tag
+          if [[ "${{ github.event.inputs.prerelease }}" == "true" ]]; then
+            npm publish --tag beta --provenance --access public
+          else
+            npm publish --tag latest --provenance --access public
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/apps/aibff/commands/calibrate.ts
+++ b/apps/aibff/commands/calibrate.ts
@@ -399,24 +399,40 @@ export const calibrateCommand: Command = {
         c: "concurrency",
       },
       default: {
-        model: "gpt-4",
+        model: "gpt-4o",
         format: "html",
         concurrency: "5",
       },
     });
 
-    // Show help if requested or no arguments
-    if (flags.help || flags._.length === 0) {
+    // Check if this is the demo subcommand
+    if (flags._.length > 0 && flags._[0] === "demo") {
+      // Run the fastpitch demo
+      const demoDecks = [
+        "apps/aibff/decks/fastpitch/sports-relevance-grader.deck.md",
+        "apps/aibff/decks/fastpitch/sports-relevance-grader-v2.deck.md",
+      ];
+
+      ui.printLn("Running fastpitch grader demo...");
+      ui.printLn(`Using graders: ${demoDecks.join(", ")}`);
+
+      // Override the deck paths with demo decks
+      flags._ = demoDecks;
+    } else if (flags.help || flags._.length === 0) {
+      // Show help if requested or no arguments
       ui.printErr(`Usage: aibff calibrate <deck.md> [<deck2.md> ...] [options]
+       aibff calibrate demo [options]
 
 Options:
-  -m, --model <models>      Comma-separated list of models (default: gpt-4)
+  -m, --model <models>      Comma-separated list of models (default: gpt-4o)
   -c, --concurrency <n>     Number of concurrent requests (default: 5)
   -f, --format <format>     Output format: toml or html (default: html)
   -o, --output <dir>        Output directory (default: current directory)
   -h, --help                Show this help message
 
 Examples:
+  aibff calibrate demo                     # Run fastpitch grader demo
+  aibff calibrate demo --model gpt-3.5-turbo
   aibff calibrate deck.md
   aibff calibrate deck.md deck2.md --model gpt-4,gpt-3.5-turbo
   aibff calibrate deck.md -c 10 -f html

--- a/apps/aibff/commands/index.ts
+++ b/apps/aibff/commands/index.ts
@@ -1,6 +1,5 @@
 import type { Command } from "./types.ts";
-// import { calibrateCommand } from "./calibrate.ts";
-import { calibrateCommand } from "./calibrate_render_style.ts";
+import { calibrateCommand } from "./calibrate.ts";
 import { rebuildCommand } from "./rebuild.ts";
 import { replCommand } from "./repl.ts";
 import { renderCommand } from "./render.ts";

--- a/apps/aibff/commands/index.ts
+++ b/apps/aibff/commands/index.ts
@@ -4,6 +4,7 @@ import { calibrateCommand } from "./calibrate_render_style.ts";
 import { rebuildCommand } from "./rebuild.ts";
 import { replCommand } from "./repl.ts";
 import { renderCommand } from "./render.ts";
+import { web } from "./web.ts";
 
 export type CommandRegistry = Map<string, Command>;
 
@@ -20,6 +21,9 @@ registry.set("repl", replCommand);
 
 // Register the render command
 registry.set("render", renderCommand);
+
+// Register the web command
+registry.set("web", web);
 
 export function getCommand(name: string): Command | undefined {
   return registry.get(name);

--- a/apps/aibff/commands/web.ts
+++ b/apps/aibff/commands/web.ts
@@ -1,0 +1,47 @@
+import { parseArgs } from "@std/cli";
+import { getLogger } from "../../../packages/logger/logger.ts";
+import type { Command } from "./types.ts";
+
+const logger = getLogger(import.meta);
+
+export const web: Command = {
+  name: "web",
+  description: "Start the aibff web UI server",
+  async run(args: Array<string>) {
+    const flags = parseArgs(args, {
+      boolean: ["help"],
+      string: ["port"],
+      default: {
+        port: "9999",
+      },
+    });
+
+    if (flags.help) {
+      logger.println(`Usage: aibff web [OPTIONS]
+
+Start the aibff web UI server
+
+Options:
+  --port <PORT>    Port to run the server on (default: 9999)
+  --help           Show this help message`);
+      return;
+    }
+
+    const port = parseInt(flags.port as string);
+    if (isNaN(port)) {
+      logger.printErr(`Invalid port: ${flags.port}`);
+      Deno.exit(1);
+    }
+
+    logger.info(`Starting aibff web server on port ${port}...`);
+
+    try {
+      // Import and start the web server
+      const { startWebServer } = await import("../web/server.ts");
+      await startWebServer(port);
+    } catch (error) {
+      logger.printErr(`Failed to start web server: ${error}`);
+      Deno.exit(1);
+    }
+  },
+};

--- a/apps/aibff/web/server.ts
+++ b/apps/aibff/web/server.ts
@@ -1,0 +1,85 @@
+import { getLogger } from "../../../packages/logger/logger.ts";
+import { BUILD_COMMIT, BUILD_TIME, VERSION } from "../version.ts";
+
+const logger = getLogger(import.meta);
+
+export async function startWebServer(port: number): Promise<void> {
+  const handler = (request: Request): Response => {
+    const url = new URL(request.url);
+    const path = url.pathname;
+
+    // Serve static files
+    if (path.startsWith("/static/")) {
+      return serveStaticFile(path);
+    }
+
+    // Main page route
+    if (path === "/" || path === "") {
+      return serveMainPage(port);
+    }
+
+    // 404 for unknown routes
+    return new Response("Not Found", { status: 404 });
+  };
+
+  logger.info(`Web server listening on http://localhost:${port}`);
+  await Deno.serve({ port }, handler);
+}
+
+function serveMainPage(port: number): Response {
+  // For now, serve a simple HTML page
+  // Later this will server-render React
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>aibff UI</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 2rem;
+      background: #0a0a0a;
+      color: #fafafa;
+    }
+    h1 {
+      font-size: 2.5rem;
+      margin-bottom: 1rem;
+    }
+    .version {
+      font-family: monospace;
+      background: #1a1a1a;
+      padding: 1rem;
+      border-radius: 0.5rem;
+      margin: 1rem 0;
+    }
+  </style>
+</head>
+<body>
+  <h1>aibff UI</h1>
+  <div class="version">
+    <p><strong>Version:</strong> ${VERSION}</p>
+    ${BUILD_TIME ? `<p><strong>Built:</strong> ${BUILD_TIME}</p>` : ""}
+    ${BUILD_COMMIT ? `<p><strong>Commit:</strong> ${BUILD_COMMIT}</p>` : ""}
+    <p><strong>Status:</strong> Running on port ${port}</p>
+  </div>
+  <p>React UI coming soon...</p>
+</body>
+</html>`;
+
+  return new Response(html, {
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+    },
+  });
+}
+
+function serveStaticFile(_path: string): Response {
+  // Placeholder for static file serving
+  // Will be implemented when we add the build system
+  return new Response("Static file serving not yet implemented", {
+    status: 501,
+  });
+}

--- a/infra/bff/friends/test.bff.ts
+++ b/infra/bff/friends/test.bff.ts
@@ -15,7 +15,7 @@ export async function testCommand(options: Array<string>): Promise<number> {
   const runnablePaths = options.length > 0
     ? options
     : [...pathsStrings, ...pathsStringsX];
-  const testArgs = ["deno", "test", "-A", ...runnablePaths];
+  const testArgs = ["deno", "test", "-A", "--trace-leaks", ...runnablePaths];
 
   const result = await runShellCommand(testArgs, undefined, {}, true, true);
 

--- a/packages/aibff/install.js
+++ b/packages/aibff/install.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import process from "node:process";
 const fs = require('fs');
 const path = require('path');
 const https = require('https');


### PR DESCRIPTION

Add a demo mode that runs both sports-relevance-grader versions with a single command.
Also update default model from gpt-4 to gpt-4o and rename file for clarity.

Changes:
- Add 'aibff calibrate demo' subcommand that runs both fastpitch graders
- Change default model from gpt-4 to gpt-4o in calibrate command
- Rename calibrate_render_style.ts to calibrate.ts for better naming
- Update import in commands/index.ts to reflect rename

Test plan:
1. Run 'aibff calibrate --help' to verify help text shows demo option
2. Run 'aibff calibrate demo' to test fastpitch grader demo
3. Run 'bff ai check' to verify no type errors

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
