### PR TITLE
Default to testing both models in calibrate demo mode

### DIFF
--- a/apps/aibff/commands/calibrate.ts
+++ b/apps/aibff/commands/calibrate.ts
@@ -432,6 +432,17 @@ export const calibrateCommand: Command = {
 
       // Override the deck paths with demo decks
       flags._ = demoDecks;
+
+      // For demo, default to testing both models if user didn't explicitly set --model
+      // Check if --model or -m was in the original args
+      const modelFlagProvided = args.some((arg) =>
+        arg === "--model" || arg === "-m" || arg.startsWith("--model=") ||
+        arg.startsWith("-m=")
+      );
+      if (!modelFlagProvided) {
+        flags.model = "openai/gpt-4o,openai/gpt-4.1";
+        ui.printLn("Testing models: gpt-4o and gpt-4.1");
+      }
     } else if (flags.help || flags._.length === 0) {
       // Show help if requested or no arguments
       ui.printErr(`Usage: aibff calibrate <deck.md> [<deck2.md> ...] [options]


### PR DESCRIPTION
When running calibrate with --demo flag, automatically test both gpt-4o
and gpt-4.1 models unless user explicitly specifies a model via --model
or -m flag.

Changes:
- Check if model flag was provided in original arguments
- Set default model list to "openai/gpt-4o,openai/gpt-4.1" for demo
- Add user feedback showing which models are being tested

Test plan:
1. Run demo without model flag: `aibff calibrate --demo`
2. Verify it tests both models
3. Run with explicit model: `aibff calibrate --demo --model openai/gpt-4o`
4. Verify it only tests specified model

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/1226)
<!-- GitContextEnd -->