### PR TITLE
Fix aibff version for npm publishing

### DIFF
--- a/apps/aibff/version.ts
+++ b/apps/aibff/version.ts
@@ -1,5 +1,5 @@
 // This file is updated during the release process
-export const VERSION = "unpublished";
+export const VERSION = "0.0.1-dev";
 
 // Build metadata - only updated during CI builds
 export const BUILD_TIME = "";


### PR DESCRIPTION
Update version from 'unpublished' to '0.0.1-dev' to fix npm publish error.
The GitHub workflow expects a valid semantic version to create dev releases.

Changes:
- Update VERSION constant in apps/aibff/version.ts to '0.0.1-dev'

Test plan:
1. Version now matches package.json base version (0.0.1)
2. GitHub workflow will generate valid npm versions like '0.0.1-dev.abc123'

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/1227)
<!-- GitContextEnd -->