### PR TITLE
Restrict hero image extraction to content before first header

### DIFF
--- a/apps/bfDb/nodeTypes/BlogPost.ts
+++ b/apps/bfDb/nodeTypes/BlogPost.ts
@@ -118,8 +118,18 @@ export class BlogPost extends GraphQLNode {
 
   /**
    * Extract first image URL from markdown content for hero display.
+   * Only extracts images that appear before the first header.
    */
   get heroImage(): string | undefined {
+    // Find the position of the first header
+    const headerMatch = this._content.match(/^#+\s/m);
+    const headerPosition = headerMatch
+      ? this._content.indexOf(headerMatch[0])
+      : this._content.length;
+
+    // Only process content before the first header
+    const contentBeforeHeader = this._content.substring(0, headerPosition);
+
     let extractedImage: string | undefined;
 
     const renderer = new Renderer();
@@ -130,8 +140,8 @@ export class BlogPost extends GraphQLNode {
       return ""; // We don't need HTML output, just extraction
     };
 
-    // Process the content to trigger image extraction
-    marked(this._content, { renderer });
+    // Process only the content before the header to trigger image extraction
+    marked(contentBeforeHeader, { renderer });
 
     return extractedImage;
   }


### PR DESCRIPTION
Update BlogPost.heroImage() to only extract images that appear before
the first header in markdown content, preventing images from within
article content from being used as hero images.

Changes:
- Add header position detection using regex pattern /^#+\s/m
- Process only content substring before first header
- Update JSDoc comment to clarify new behavior

Test plan:
1. Verify hero images are only extracted from content before headers
2. Ensure fallback works when no headers exist in content

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/1230)
<!-- GitContextEnd -->