### PR TITLE
Add file argument support to precommit checks

### DIFF
--- a/infra/bff/friends/amend.bff.ts
+++ b/infra/bff/friends/amend.bff.ts
@@ -29,12 +29,28 @@ export async function amend(args: Array<string>): Promise<number> {
     return true;
   });
 
+  // Separate files from other arguments for precommit
+  const files: Array<string> = [];
+  const otherArgs: Array<string> = [];
+
+  for (const arg of filteredArgs) {
+    if (!arg.startsWith("-")) {
+      files.push(arg);
+    } else {
+      otherArgs.push(arg);
+    }
+  }
+
   // Run precommit checks by default (unless skipped)
   if (runPreCheck) {
     logger.info("Running precommit checks...");
     const precommitArgs = ["bff", "precommit"];
     if (verbose) {
       precommitArgs.push("--verbose");
+    }
+    // Add file arguments if provided
+    if (files.length > 0) {
+      precommitArgs.push(...files);
     }
     const precommitResult = await runShellCommand(precommitArgs);
     if (precommitResult !== 0) {
@@ -44,7 +60,7 @@ export async function amend(args: Array<string>): Promise<number> {
     logger.info("✅ Precommit checks passed");
   }
 
-  // Run sl amend with filtered arguments
+  // Run sl amend with all filtered arguments (including files)
   const amendArgs = ["sl", "amend", ...filteredArgs];
   const amendResult = await runShellCommand(amendArgs);
 

--- a/infra/bff/friends/commit.bff.ts
+++ b/infra/bff/friends/commit.bff.ts
@@ -69,12 +69,19 @@ async function stageAllFiles(): Promise<number> {
 /**
  * Run the full precommit checks
  */
-async function runPrecommitChecks(verbose: boolean): Promise<boolean> {
+async function runPrecommitChecks(
+  verbose: boolean,
+  files: Array<string>,
+): Promise<boolean> {
   logger.info("Running precommit checks...");
 
   const precommitArgs = ["bff", "precommit"];
   if (verbose) {
     precommitArgs.push("--verbose");
+  }
+  // Add file arguments if provided
+  if (files.length > 0) {
+    precommitArgs.push(...files);
   }
 
   const precommitResult = await runShellCommand(precommitArgs);
@@ -130,7 +137,7 @@ export async function commit(args: Array<string>): Promise<number> {
 
   // Run precommit checks by default (unless skipped)
   if (runPreCheck) {
-    if (!await runPrecommitChecks(verbose)) {
+    if (!await runPrecommitChecks(verbose, filesToCommit)) {
       return 1;
     }
   }

--- a/infra/bff/friends/format.bff.ts
+++ b/infra/bff/friends/format.bff.ts
@@ -3,8 +3,15 @@
 import { register } from "@bfmono/infra/bff/bff.ts";
 import { runShellCommand } from "@bfmono/infra/bff/shellBase.ts";
 
-export async function formatCommand(_options: Array<string>): Promise<number> {
-  return await runShellCommand(["deno", "fmt"]);
+export async function formatCommand(options: Array<string>): Promise<number> {
+  const args = ["deno", "fmt"];
+
+  // Add any file arguments
+  if (options.length > 0) {
+    args.push(...options);
+  }
+
+  return await runShellCommand(args);
 }
 
 // Register both 'format' and 'f' as aliases for the same command

--- a/infra/bff/friends/lint.bff.ts
+++ b/infra/bff/friends/lint.bff.ts
@@ -11,16 +11,33 @@ export async function lintCommand(options: Array<string>): Promise<number> {
   logger.info("Running Deno lint...");
   const args = ["deno", "lint"];
 
-  if (options.includes("--fix")) {
+  // Separate flags from file arguments
+  const flags: Array<string> = [];
+  const files: Array<string> = [];
+
+  for (const option of options) {
+    if (option.startsWith("--") || option.startsWith("-")) {
+      flags.push(option);
+    } else {
+      files.push(option);
+    }
+  }
+
+  if (flags.includes("--fix")) {
     args.push("--fix");
     logger.info("Auto-fixing linting issues...");
   }
 
-  const githubMode = options.includes("--github") || options.includes("-g");
+  const githubMode = flags.includes("--github") || flags.includes("-g");
   if (githubMode) {
     args.push("--json");
     logger.info("Running in GitHub annotations mode...");
     return await runLintWithGithubAnnotations();
+  }
+
+  // Add file arguments if provided
+  if (files.length > 0) {
+    args.push(...files);
   }
 
   const result = await runShellCommand(args);

--- a/memos/plans/2025-06-25-bfds-to-cfds-rename.md
+++ b/memos/plans/2025-06-25-bfds-to-cfds-rename.md
@@ -1,0 +1,133 @@
+# Implementation Plan: Rename bfDs to cfDs
+
+**Date**: 2025-06-25\
+**Author**: AI Assistant\
+**Status**: Draft\
+**Approach**: Option B - With History Preservation
+
+## Overview
+
+This plan outlines the systematic approach to rename the bfDs (Bolt Foundry
+Design System) to cfDs throughout the codebase. This is phase 1 of a two-phase
+design system naming migration.
+
+## Scope
+
+### What Changes
+
+1. **Directory Structure**
+   - `/apps/bfDs/` → `/apps/cfDs/`
+
+2. **Component Names** (60+ components)
+   - All `BfDs*` prefixed components → `CfDs*`
+   - Examples: `BfDsButton` → `CfDsButton`, `BfDsModal` → `CfDsModal`
+
+3. **Import Paths** (87+ files)
+   - `@bfmono/apps/bfDs/*` → `@bfmono/apps/cfDs/*`
+
+4. **CSS and Styling**
+   - `/static/bfDsStyle.css` → `/static/cfDsStyle.css`
+   - CSS class prefix: `bfds-*` → `cfds-*`
+
+5. **Context and Hooks**
+   - `BfDsContext` → `CfDsContext`
+   - `useBfDs` → `useCfDs`
+
+6. **Documentation** (10+ files)
+   - All references to bfDs in documentation
+
+### What Remains Unchanged
+
+- bfDsLite remains as-is (per requirements)
+
+## Implementation Approach
+
+Using **Option B: Sapling Move with History Preservation**
+
+- All file renames will use `sl mv` to preserve history
+- Allows `sl log --follow` to track changes across rename
+- Ensures complete traceability of code evolution
+
+## Implementation Steps
+
+### Phase 1: Preparation
+
+1. Create comprehensive file list for all changes
+2. Verify no external dependencies reference bfDs
+3. Ensure all tests are passing before starting
+
+### Phase 2: Directory and File Renaming (Using Sapling)
+
+1. **Rename main directory**:
+   ```bash
+   sl mv apps/bfDs apps/cfDs
+   ```
+
+2. **Rename component files** (batch operation):
+   ```bash
+   # Navigate to the renamed directory
+   cd apps/cfDs/components
+   # Rename all BfDs* files to CfDs*
+   for file in BfDs*.tsx; do
+     sl mv "$file" "${file/BfDs/CfDs}"
+   done
+   ```
+
+3. **Rename CSS file**:
+   ```bash
+   sl mv static/bfDsStyle.css static/cfDsStyle.css
+   ```
+
+4. **Commit the renames** before making code changes:
+   ```bash
+   sl commit -m "refactor: Rename bfDs to cfDs - file structure only"
+   ```
+
+### Phase 3: Code Updates
+
+1. Update all component exports and class names
+2. Update import statements across the codebase
+3. Update CSS class prefixes in style files
+4. Update context and hook names
+
+### Phase 4: Documentation Updates
+
+1. Update all documentation references
+2. Update any code examples in documentation
+
+### Phase 5: Verification
+
+1. Run `bff build` to verify compilation
+2. Run `bff test` to ensure all tests pass
+3. Run `bff e2e --build` for end-to-end validation
+4. Manual spot-check of key components
+
+## Risk Mitigation
+
+1. **Breaking Changes**: This is a breaking change for any code using bfDs
+2. **Import Errors**: Systematic approach ensures all imports are updated
+3. **CSS Conflicts**: CSS class renaming prevents style conflicts
+4. **Testing**: Comprehensive test suite validation at each step
+
+## Estimated Effort
+
+- Total files to modify: ~150+ files
+- Complexity: Medium-High (requires careful sequencing)
+- Benefits: Complete history preservation and traceability
+
+## Success Criteria
+
+1. All bfDs references successfully renamed to cfDs
+2. No build errors after rename
+3. All tests passing
+4. No runtime errors in development environment
+5. Documentation accurately reflects new naming
+
+## Future Considerations
+
+This plan sets up for Phase 2 where bfDsLite will be renamed to bfDs, creating a
+cleaner naming hierarchy:
+
+- Current: bfDs (→ cfDs), bfDsLite
+- Phase 1: cfDs, bfDsLite
+- Phase 2: cfDs, bfDs (renamed from bfDsLite)


### PR DESCRIPTION

Enable bff precommit, commit, and amend commands to accept specific file
arguments, allowing targeted checks instead of checking all files.

Changes:
- Update precommit.bff.ts to parse file arguments and pass to check commands
- Update format.bff.ts to accept and use file arguments
- Update lint.bff.ts to separate flags from files and pass files to deno lint
- Update commit.bff.ts to pass file arguments to precommit checks
- Update amend.bff.ts to pass file arguments to precommit checks

Test plan:
1. Run `bff precommit file.ts` - checks only specified file
2. Run `bff commit -m "msg" file.ts` - checks only specified file
3. Run `bff amend file.ts` - checks only specified file
4. Run commands without files - checks all files as before

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
