### PR TITLE
Add format option to aibff render command

### DIFF
--- a/.claude/bft-safety-hook.ts
+++ b/.claude/bft-safety-hook.ts
@@ -1,0 +1,159 @@
+#!/usr/bin/env -S deno run --allow-read --allow-env
+
+import { ui } from "@bfmono/packages/cli-ui/cli-ui.ts";
+
+interface HookInput {
+  session_id: string;
+  transcript_path: string;
+  tool_name: string;
+  tool_input: {
+    command: string;
+    description?: string;
+  };
+}
+
+interface HookOutput {
+  decision?: "approve" | "block";
+  reason?: string;
+  continue?: boolean;
+  stopReason?: string;
+  suppressOutput?: boolean;
+}
+
+const SAFE_BFT_COMMANDS = new Set([
+  "echo",
+  "help",
+  "test",
+  "lint",
+  "deck",
+  "genGqlTypes",
+  "iso",
+  "build",
+  "aibff",
+  "claudify",
+  "code-reviewer",
+  "commit",
+]);
+
+const SAFE_SL_SUBCOMMANDS = new Set([
+  "status",
+  "log",
+  "show",
+  "diff",
+  "help",
+  "annotate",
+  "blame",
+  "parents",
+  "files",
+  "cat",
+  "export",
+  "root",
+  "whereami",
+]);
+
+function parseBftCommand(
+  command: string,
+): { command: string; subcommand?: string; args: Array<string> } {
+  const parts = command.trim().split(/\s+/);
+
+  // Handle "bft unsafe ..." commands
+  if (parts.length >= 3 && parts[0] === "bft" && parts[1] === "unsafe") {
+    return {
+      command: parts[2],
+      subcommand: parts[3],
+      args: parts.slice(3),
+    };
+  }
+
+  // Handle regular "bft ..." commands
+  if (parts.length >= 2 && parts[0] === "bft") {
+    return {
+      command: parts[1],
+      subcommand: parts[2],
+      args: parts.slice(2),
+    };
+  }
+
+  return { command: "", args: [] };
+}
+
+function isBftCommandSafe(command: string, subcommand?: string): boolean {
+  // Always safe commands
+  if (SAFE_BFT_COMMANDS.has(command)) {
+    return true;
+  }
+
+  // Special handling for sl command
+  if (command === "sl" && subcommand) {
+    return SAFE_SL_SUBCOMMANDS.has(subcommand);
+  }
+
+  return false;
+}
+
+async function main() {
+  try {
+    let inputText = "";
+    const decoder = new TextDecoder();
+    const reader = Deno.stdin.readable.getReader();
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      inputText += decoder.decode(value, { stream: true });
+    }
+
+    const hookInput: HookInput = JSON.parse(inputText);
+
+    // Only process Bash tool calls
+    if (hookInput.tool_name !== "Bash") {
+      Deno.exit(0);
+    }
+
+    const command = hookInput.tool_input.command;
+
+    // Only process bft commands
+    if (!command.trim().startsWith("bft ")) {
+      Deno.exit(0);
+    }
+
+    const parsed = parseBftCommand(command);
+
+    // If it's already marked unsafe (bft unsafe ...), let the normal permission system handle it
+    if (command.includes("bft unsafe ")) {
+      Deno.exit(0);
+    }
+
+    // Check if the command is safe
+    const isSafe = isBftCommandSafe(parsed.command, parsed.subcommand);
+
+    if (isSafe) {
+      const output: HookOutput = {
+        decision: "approve",
+        reason: `bft ${parsed.command}${
+          parsed.subcommand ? ` ${parsed.subcommand}` : ""
+        } is marked as AI-safe`,
+      };
+      ui.output(JSON.stringify(output));
+    } else {
+      const output: HookOutput = {
+        decision: "block",
+        reason: `bft ${parsed.command}${
+          parsed.subcommand ? ` ${parsed.subcommand}` : ""
+        } requires manual approval. Use 'bft unsafe ${parsed.command}${
+          parsed.args.length ? ` ${parsed.args.join(" ")}` : ""
+        }' if you want to run it.`,
+      };
+      ui.output(JSON.stringify(output));
+    }
+  } catch (error) {
+    ui.error(
+      `Hook error: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    Deno.exit(1);
+  }
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/.claude/commands/bff/amend.md
+++ b/.claude/commands/bff/amend.md
@@ -1,7 +1,0 @@
----
-name: bff-amend
-description: Amend the current commit and optionally submit a PR
----
-
-please amend the current commit using "bff amend." Don't worry about updating
-the message, unless the change we have conflicts with it.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,8 +5,6 @@
   },
   "permissions": {
     "allow": [
-      "Bash(aibff:*)",
-      "Bash(bff ai:*)",
       "Bash(ls:*)",
       "Bash(cat:*)",
       "Bash(mkdir:*)",
@@ -25,6 +23,19 @@
     ],
     "deny": [
       "Bash(git:*)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/randallb/randallb.com/areas/bolt-foundry-monorepo/.claude/bft-safety-hook.ts"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,13 +94,18 @@ jobs:
       - name: Enter dev-shell & run tests
         run: |
           # Pass DENO_DIR into the Nix environment to ensure cache sharing
-          nix develop . --accept-flake-config --command bash -euc "
+          nix develop .#github-actions --accept-flake-config --command bash -euc "
             export DENO_DIR=\"/home/runner/.cache/deno\"
             echo \"Using Deno cache directory: \${DENO_DIR}\"
+            echo \"Checking for Chromium installation:\"
+            which chromium || echo \"chromium not found in PATH\"
+            which google-chrome || echo \"google-chrome not found in PATH\"
+            which google-chrome-stable || echo \"google-chrome-stable not found in PATH\"
+            ls -la /nix/store/*chromium*/bin/ 2>/dev/null || echo \"No chromium in nix store\"
+            echo \"PATH: \$PATH\"
             deno --version
             deno info
             # Pre-cache dependencies
-            deno cache deno.jsonc || echo \"Failed to cache, continuing anyway\"
             npm install
             deno install
             bff ci --include-bolt-foundry -g

--- a/apps/aibff/gui/__tests__/gui.test.e2e.ts
+++ b/apps/aibff/gui/__tests__/gui.test.e2e.ts
@@ -48,7 +48,6 @@ Deno.test("aibff gui --dev loads successfully with routing and Isograph", async 
   // Setup Puppeteer e2e test
   const context = await setupE2ETest({
     baseUrl: "http://localhost:3006",
-    headless: true, // Run headless in tests
   });
 
   try {
@@ -282,6 +281,227 @@ Deno.test("aibff gui --dev loads successfully with routing and Isograph", async 
       await serverProcess.stderr.cancel();
 
       // Then kill the process
+      serverProcess.kill();
+      await serverProcess.status;
+    } catch {
+      // Process may have already exited
+    }
+  }
+});
+
+Deno.test("debug tool call execution should replace grader deck content", async () => {
+  // Start the aibff gui dev server
+  const serverPort = 3007; // Use different port to avoid conflicts
+  const command = new Deno.Command("aibff", {
+    args: ["gui", "--dev", "--port", String(serverPort), "--no-open"],
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const serverProcess = command.spawn();
+
+  // Wait for server to be ready
+  let serverReady = false;
+  const maxRetries = 50;
+
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      const response = await fetch(`http://localhost:${serverPort}/health`);
+      await response.body?.cancel();
+      if (response.ok) {
+        serverReady = true;
+        break;
+      }
+    } catch {
+      // Server not ready yet
+    }
+    await delay(100);
+  }
+
+  assertEquals(
+    serverReady,
+    true,
+    "Dev server failed to start within timeout",
+  );
+
+  // Setup Puppeteer e2e test
+  const context = await setupE2ETest({
+    baseUrl: `http://localhost:${serverPort}`,
+  });
+
+  try {
+    // Navigate to the GUI
+    await context.page.goto(context.baseUrl, {
+      waitUntil: "networkidle2",
+    });
+
+    // Wait for initial load - look for React root or any content
+    await context.page.waitForFunction(
+      () => {
+        // Check if React app has loaded by looking for the root element or any meaningful content
+        const root = document.getElementById("root");
+        if (root && root.children.length > 0) {
+          return true;
+        }
+        // Also check for any elements that might contain our text
+        const elements = Array.from(document.querySelectorAll("*"));
+        return elements.some((el) =>
+          el.textContent?.includes("New Conversation") ||
+          el.textContent?.includes("Loading") ||
+          el.textContent?.includes("Assistant")
+        );
+      },
+      { timeout: 10000 },
+    );
+
+    await delay(500);
+
+    // Wait for the Grader Deck tab to be available and click it
+    await context.page.waitForFunction(
+      () => {
+        const buttons = Array.from(document.querySelectorAll("button"));
+        return buttons.some((button) =>
+          button.textContent?.includes("Grader Deck")
+        );
+      },
+      { timeout: 15000 },
+    );
+
+    // Click on Grader Deck tab to see initial content
+    const graderTabClicked = await context.page.evaluate(() => {
+      const buttons = Array.from(document.querySelectorAll("button"));
+      const graderTab = buttons.find((button) =>
+        button.textContent?.includes("Grader Deck")
+      );
+
+      if (graderTab) {
+        graderTab.click();
+        return true;
+      }
+
+      return false;
+    });
+
+    assert(graderTabClicked, "Should be able to click Grader Deck tab");
+    await delay(200);
+
+    // Set up console log capture BEFORE sending the message
+    const consoleLogs: Array<string> = [];
+    context.page.on("console", (msg) => {
+      consoleLogs.push(msg.text());
+    });
+
+    // Get initial grader deck content
+    const initialGraderContent = await context.page.evaluate(() => {
+      const textareas = Array.from(document.querySelectorAll("textarea"));
+      const graderTextarea = textareas.find((textarea) =>
+        textarea.closest("div")?.textContent?.includes("Grader Deck") ||
+        textarea.placeholder?.includes("grader") ||
+        textarea.value?.includes("grader") ||
+        textarea.getAttribute("data-tab") === "grader"
+      );
+      return graderTextarea?.value || "";
+    });
+    logger.info("Initial grader deck content:", initialGraderContent);
+
+    // Find and click the chat textarea
+    const chatTextarea = await context.page.$(
+      'textarea[placeholder="Type a message..."]',
+    );
+    assert(chatTextarea, "Should find chat textarea");
+
+    // Type the debug command to test streaming tool calls
+    const debugCommand = '⚡️debug⚡️ replaceGraderDeck "lol we did it"';
+    await chatTextarea.focus();
+    await chatTextarea.type(debugCommand);
+
+    // Find and click send button
+    const sendButtonClicked = await context.page.evaluate(() => {
+      const buttons = Array.from(document.querySelectorAll("button"));
+      const sendButton = buttons.find((button) =>
+        button.textContent === "Send"
+      );
+      if (sendButton) {
+        sendButton.click();
+        return true;
+      }
+      return false;
+    });
+    assert(sendButtonClicked, "Should find and click Send button");
+
+    // Wait for the streaming to complete and tool calls to be executed
+    await delay(10000); // Give more time for the API call and processing
+
+    // Take screenshot for debugging
+    await context.takeScreenshot("debug-tool-call-after-send");
+
+    // Check console logs for tool call processing
+    const toolCallLogs = consoleLogs.filter((log) =>
+      log.includes("tool") || log.includes("Tool") ||
+      log.includes("replaceGraderDeck") || log.includes("executeToolCall")
+    );
+    logger.info("All console logs related to tool calls:", toolCallLogs);
+
+    // Look for specific completion messages
+    const hasStreamFinished = consoleLogs.some((log) =>
+      log.includes("Stream finished")
+    );
+    const hasToolCallsExecuted = consoleLogs.some((log) =>
+      log.includes("All tool calls processed")
+    );
+    const hasExecuteToolCall = consoleLogs.some((log) =>
+      log.includes("executeToolCall called with")
+    );
+
+    logger.info("Tool call execution status:", {
+      hasStreamFinished,
+      hasToolCallsExecuted,
+      hasExecuteToolCall,
+      totalLogs: consoleLogs.length,
+      toolCallLogsCount: toolCallLogs.length,
+    });
+
+    // Go back to Grader Deck tab to check if content changed
+    await context.page.evaluate(() => {
+      const elements = Array.from(document.querySelectorAll("*"));
+      const graderTab = elements.find((el) =>
+        el.textContent?.trim() === "Grader Deck"
+      );
+      if (graderTab && graderTab instanceof HTMLElement) {
+        graderTab.click();
+      }
+    });
+    await delay(200);
+
+    // Get updated grader deck content
+    const updatedGraderContent = await context.page.evaluate(() => {
+      const textareas = Array.from(document.querySelectorAll("textarea"));
+      const graderTextarea = textareas.find((textarea) =>
+        textarea.closest("div")?.textContent?.includes("Grader Deck") ||
+        textarea.placeholder?.includes("grader") ||
+        textarea.value?.includes("grader") ||
+        textarea.getAttribute("data-tab") === "grader"
+      );
+      return graderTextarea?.value || "";
+    });
+    logger.info("Updated grader deck content:", updatedGraderContent);
+
+    // This should pass once we fix the streaming tool call execution
+    assertEquals(
+      updatedGraderContent.trim(),
+      "lol we did it",
+      "Grader deck content should be updated by debug tool call",
+    );
+  } catch (error) {
+    await context.takeScreenshot("debug-tool-call-error");
+    logger.error("Debug tool call test failed:", error);
+    throw error;
+  } finally {
+    await teardownE2ETest(context);
+
+    try {
+      await serverProcess.stdout.cancel();
+      await serverProcess.stderr.cancel();
       serverProcess.kill();
       await serverProcess.status;
     } catch {

--- a/deno.lock
+++ b/deno.lock
@@ -69,7 +69,7 @@
     "jsr:@std/yaml@^1.0.5": "1.0.8",
     "jsr:@ts-morph/bootstrap@0.24": "0.24.0",
     "jsr:@ts-morph/common@0.24": "0.24.0",
-    "npm:@anthropic-ai/claude-code@^1.0.25": "1.0.31",
+    "npm:@anthropic-ai/claude-code@^1.0.25": "1.0.38",
     "npm:@babel/preset-react@^7.27.1": "7.27.1_@babel+core@7.27.4",
     "npm:@deno/vite-plugin@^1.0.4": "1.0.5_vite@6.3.5__@types+node@22.15.33__picomatch@4.0.2_@types+node@22.15.33",
     "npm:@hexagon/base64@^1.1.27": "1.1.28",
@@ -416,8 +416,8 @@
         "@jridgewell/trace-mapping"
       ]
     },
-    "@anthropic-ai/claude-code@1.0.31": {
-      "integrity": "sha512-prn3DEIBm5ALgCjp0sCcXwNbfBR5w98bEOXQbWViow/3BwkTgW784V8i0S/kfIWDVorz0o4cqR5D0fB4hbjNIg==",
+    "@anthropic-ai/claude-code@1.0.38": {
+      "integrity": "sha512-hPZbJCt7O8T872wbCXGiwF210DzMBo/k3EVKB6EZQB10b73ZQIEflAWGTC2ZvBcMp79qAR4F6c82V0+Cc6o0sg==",
       "optionalDependencies": [
         "@img/sharp-darwin-arm64",
         "@img/sharp-darwin-x64",

--- a/infra/bff/friends/ci.bff.ts
+++ b/infra/bff/friends/ci.bff.ts
@@ -316,7 +316,7 @@ async function runE2ETestStep(useGithub: boolean): Promise<number> {
     e2eArgs,
     {},
     true,
-    useGithub,
+    false, // Always show e2e output for debugging
   );
   return code;
 }

--- a/infra/bft/tasks/lint.bft.ts
+++ b/infra/bft/tasks/lint.bft.ts
@@ -1,0 +1,48 @@
+import { runShellCommand } from "@bfmono/infra/bff/shellBase.ts";
+import { getLogger } from "@bfmono/packages/logger/logger.ts";
+import { runLintWithGithubAnnotations } from "@bfmono/infra/bff/friends/githubAnnotations.ts";
+import type { TaskDefinition } from "@bfmono/infra/bft/bft.ts";
+
+const logger = getLogger(import.meta);
+
+export async function lintCommand(options: Array<string>): Promise<number> {
+  logger.info("Running Deno lint...");
+
+  const args = ["deno", "lint"];
+
+  // Check for GitHub annotations mode
+  const githubMode = options.includes("--github") || options.includes("-g");
+  if (githubMode) {
+    logger.info("Running in GitHub annotations mode...");
+    return await runLintWithGithubAnnotations();
+  }
+
+  // Auto-fix by default unless --no-fix is specified
+  const noFix = options.includes("--no-fix");
+  if (!noFix) {
+    args.push("--fix");
+    logger.info("Auto-fixing linting issues...");
+  }
+
+  // Add all other arguments (excluding our custom flags)
+  const filteredOptions = options.filter((opt) =>
+    opt !== "--github" && opt !== "-g" && opt !== "--no-fix"
+  );
+  args.push(...filteredOptions);
+
+  const result = await runShellCommand(args);
+
+  if (result === 0) {
+    logger.info("✨ Linting passed!");
+  } else {
+    logger.error("❌ Linting failed");
+  }
+
+  return result;
+}
+
+export const bftDefinition = {
+  description: "Run Deno lint (auto-fix by default)",
+  fn: lintCommand,
+  aiSafe: true,
+} satisfies TaskDefinition;


### PR DESCRIPTION

Enhance the render command to support both OpenAI and markdown output formats.
The --format flag allows users to choose between JSON structure (openai) and
plain markdown content output for different use cases.

Changes:
- Add --format flag with 'openai' and 'markdown' options to render command
- Add --help flag support to show usage information
- Extract system message content for markdown format output
- Add comprehensive tests for both format options and help flag
- Add error handling for invalid format values

Test plan:
1. Run `aibff render deck.md --format openai` - outputs JSON
2. Run `aibff render deck.md --format markdown` - outputs plain markdown
3. Run `aibff render deck.md --help` - shows usage information
4. Run `aibff render deck.md --format invalid` - shows error message
5. Run existing tests: `bff test apps/aibff/__tests__/commands/render.test.ts`

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/1301).
* #1308
* #1307
* #1306
* #1305
* #1304
* #1303
* #1302
* __->__ #1301
* #1300
* #1290
* #1289