### PR TITLE
Add BfDsList and BfDsListItem components

### DIFF
--- a/apps/bfDs/components/BfDsForm.tsx
+++ b/apps/bfDs/components/BfDsForm.tsx
@@ -1,0 +1,197 @@
+import * as React from "react";
+import { getLogger } from "@bfmono/packages/logger/logger.ts";
+
+const { useState, createContext, useContext } = React;
+const logger = getLogger(import.meta);
+
+type FormError = {
+  message: string;
+  field: string;
+  type: "error" | "warn" | "info";
+};
+
+type BfDsFormErrorRecord<T> = {
+  [key in keyof T]: FormError;
+};
+
+type BfDsFormCallbacks<T> = {
+  onSubmit?: (value: T) => void;
+  onChange?: (value: T) => void;
+  onError?: (errors: BfDsFormErrorRecord<T>) => void;
+};
+
+export type BfDsFormValue<T = Record<string, string | number | boolean>> = {
+  errors?: BfDsFormErrorRecord<T>;
+  data?: T;
+} & BfDsFormCallbacks<T>;
+
+// deno-lint-ignore no-explicit-any
+const BfDsFormContext = createContext<BfDsFormValue<any> | null>(null);
+
+type BfDsFormProps<T = Record<string, string | number | boolean | null>> =
+  & React.PropsWithChildren<BfDsFormCallbacks<T>>
+  & {
+    initialData: T;
+    className?: string;
+    testId?: string;
+  };
+
+export function BfDsForm<T>({
+  initialData,
+  className,
+  children,
+  testId,
+  ...bfDsFormCallbacks
+}: BfDsFormProps<T>) {
+  const [data, setData] = useState<T>(initialData);
+  const [errors, setErrors] = useState<BfDsFormErrorRecord<T>>(
+    {} as BfDsFormErrorRecord<T>,
+  );
+
+  function onChange(value: T) {
+    setData(value);
+    bfDsFormCallbacks.onChange?.(value);
+  }
+
+  function onError(errors: BfDsFormErrorRecord<T>) {
+    setErrors(errors);
+    bfDsFormCallbacks.onError?.(errors);
+  }
+
+  function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    logger.debug("form callbacks", bfDsFormCallbacks);
+    e.preventDefault();
+    bfDsFormCallbacks.onSubmit?.(data);
+  }
+
+  const formClasses = [
+    "bfds-form",
+    className,
+  ].filter(Boolean).join(" ");
+
+  return (
+    <BfDsFormContext.Provider
+      value={{ data, errors, onChange, onError, onSubmit }}
+    >
+      <form
+        data-testid={testId}
+        onSubmit={onSubmit}
+        className={formClasses}
+      >
+        {children}
+      </form>
+    </BfDsFormContext.Provider>
+  );
+}
+
+export function useBfDsFormContext<T>() {
+  return useContext(BfDsFormContext) as BfDsFormValue<T> | null;
+}
+
+export type BfDsFormElementProps<
+  TAdditionalFormElementProps = Record<string, unknown>,
+> = TAdditionalFormElementProps & {
+  name: string;
+  label?: string;
+};
+
+BfDsForm.Example = function BfDsFormExample() {
+  // Import components dynamically to avoid circular dependencies
+  const BfDsInput = React.lazy(() =>
+    import("./BfDsInput.tsx").then((m) => ({ default: m.BfDsInput }))
+  );
+  const BfDsTextArea = React.lazy(() =>
+    import("./BfDsTextArea.tsx").then((m) => ({ default: m.BfDsTextArea }))
+  );
+  const BfDsFormSubmitButton = React.lazy(() =>
+    import("./BfDsFormSubmitButton.tsx").then((m) => ({
+      default: m.BfDsFormSubmitButton,
+    }))
+  );
+
+  type ExampleFormData = {
+    name: string;
+    email: string;
+    message: string;
+  };
+
+  const exampleInitialFormData: ExampleFormData = {
+    name: "John Doe",
+    email: "john@example.com",
+    message: "Hello world!",
+  };
+
+  function exampleOnSubmit(value: ExampleFormData) {
+    logger.info("Form submitted:", value);
+    alert(`Form submitted with: ${JSON.stringify(value, null, 2)}`);
+  }
+
+  function exampleOnChange(value: ExampleFormData) {
+    logger.debug("Form changed:", value);
+  }
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "24px",
+        padding: "24px",
+        backgroundColor: "var(--bfds-background)",
+        color: "var(--bfds-text)",
+        fontFamily: "system-ui, -apple-system, sans-serif",
+        maxWidth: "600px",
+      }}
+    >
+      <h2>BfDsForm Examples</h2>
+
+      <div>
+        <h3>Complete Form with Context Integration</h3>
+        <React.Suspense fallback={<div>Loading form components...</div>}>
+          <BfDsForm<ExampleFormData>
+            onSubmit={exampleOnSubmit}
+            onChange={exampleOnChange}
+            initialData={exampleInitialFormData}
+          >
+            <div
+              style={{ display: "flex", flexDirection: "column", gap: "16px" }}
+            >
+              <BfDsInput
+                name="name"
+                label="Your Name"
+                placeholder="Enter your name"
+                required
+                helpText="This input gets its value from form context"
+              />
+              <BfDsInput
+                name="email"
+                label="Email Address"
+                type="email"
+                placeholder="email@example.com"
+                required
+              />
+              <BfDsTextArea
+                name="message"
+                label="Message"
+                placeholder="Enter your message..."
+                rows={4}
+                helpText="This textarea also uses form context"
+              />
+              <BfDsFormSubmitButton text="Submit Form" />
+            </div>
+          </BfDsForm>
+        </React.Suspense>
+      </div>
+
+      <div>
+        <h3>Form Context Benefits</h3>
+        <ul style={{ margin: "16px 0", paddingLeft: "24px" }}>
+          <li>Components automatically sync with form state</li>
+          <li>No need to pass value/onChange to each field</li>
+          <li>Form-level validation and error handling</li>
+          <li>Centralized form submission logic</li>
+        </ul>
+      </div>
+    </div>
+  );
+};

--- a/apps/bfDs/components/BfDsForm.tsx
+++ b/apps/bfDs/components/BfDsForm.tsx
@@ -25,8 +25,7 @@ export type BfDsFormValue<T = Record<string, string | number | boolean>> = {
   data?: T;
 } & BfDsFormCallbacks<T>;
 
-// deno-lint-ignore no-explicit-any
-const BfDsFormContext = createContext<BfDsFormValue<any> | null>(null);
+const BfDsFormContext = createContext<BfDsFormValue<unknown> | null>(null);
 
 type BfDsFormProps<T = Record<string, string | number | boolean | null>> =
   & React.PropsWithChildren<BfDsFormCallbacks<T>>
@@ -71,7 +70,9 @@ export function BfDsForm<T>({
 
   return (
     <BfDsFormContext.Provider
-      value={{ data, errors, onChange, onError, onSubmit }}
+      value={{ data, errors, onChange, onError, onSubmit } as BfDsFormValue<
+        unknown
+      >}
     >
       <form
         data-testid={testId}

--- a/apps/bfDs/components/BfDsFormSubmitButton.tsx
+++ b/apps/bfDs/components/BfDsFormSubmitButton.tsx
@@ -1,0 +1,167 @@
+import type * as React from "react";
+import { BfDsButton, type BfDsButtonProps } from "./BfDsButton.tsx";
+
+export type BfDsFormSubmitButtonProps =
+  & Omit<BfDsButtonProps, "type" | "onClick">
+  & {
+    text?: string;
+    onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  };
+
+export function BfDsFormSubmitButton({
+  text = "Submit",
+  onClick,
+  children,
+  ...props
+}: BfDsFormSubmitButtonProps) {
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    // Call custom onClick first if provided
+    onClick?.(e);
+
+    // Let the form handle submission if we're in form context
+    // The form's onSubmit will be called automatically by the form element
+  };
+
+  return (
+    <BfDsButton
+      {...props}
+      type="submit"
+      onClick={handleClick}
+    >
+      {children || text}
+    </BfDsButton>
+  );
+}
+
+BfDsFormSubmitButton.Example = function BfDsFormSubmitButtonExample() {
+  const handleStandaloneClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    alert("Standalone submit button clicked!");
+  };
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "24px",
+        padding: "24px",
+        backgroundColor: "var(--bfds-background)",
+        color: "var(--bfds-text)",
+        fontFamily: "system-ui, -apple-system, sans-serif",
+        maxWidth: "600px",
+      }}
+    >
+      <h2>BfDsFormSubmitButton Examples</h2>
+
+      <div>
+        <h3>Standalone Mode</h3>
+        <div style={{ display: "flex", gap: "12px", flexWrap: "wrap" }}>
+          <BfDsFormSubmitButton
+            text="Submit Form"
+            onClick={handleStandaloneClick}
+          />
+          <BfDsFormSubmitButton
+            text="Save"
+            variant="secondary"
+            onClick={handleStandaloneClick}
+          />
+          <BfDsFormSubmitButton
+            variant="outline"
+            onClick={handleStandaloneClick}
+          >
+            Custom Content
+          </BfDsFormSubmitButton>
+        </div>
+      </div>
+
+      <div>
+        <h3>Different Variants</h3>
+        <div style={{ display: "flex", gap: "12px", flexWrap: "wrap" }}>
+          <BfDsFormSubmitButton
+            text="Primary Submit"
+            variant="primary"
+            onClick={handleStandaloneClick}
+          />
+          <BfDsFormSubmitButton
+            text="Secondary Submit"
+            variant="secondary"
+            onClick={handleStandaloneClick}
+          />
+          <BfDsFormSubmitButton
+            text="Outline Submit"
+            variant="outline"
+            onClick={handleStandaloneClick}
+          />
+          <BfDsFormSubmitButton
+            text="Ghost Submit"
+            variant="ghost"
+            onClick={handleStandaloneClick}
+          />
+        </div>
+      </div>
+
+      <div>
+        <h3>Different Sizes</h3>
+        <div
+          style={{
+            display: "flex",
+            gap: "12px",
+            alignItems: "center",
+            flexWrap: "wrap",
+          }}
+        >
+          <BfDsFormSubmitButton
+            text="Small"
+            size="small"
+            onClick={handleStandaloneClick}
+          />
+          <BfDsFormSubmitButton
+            text="Medium"
+            size="medium"
+            onClick={handleStandaloneClick}
+          />
+          <BfDsFormSubmitButton
+            text="Large"
+            size="large"
+            onClick={handleStandaloneClick}
+          />
+        </div>
+      </div>
+
+      <div>
+        <h3>With Icons</h3>
+        <div style={{ display: "flex", gap: "12px", flexWrap: "wrap" }}>
+          <BfDsFormSubmitButton
+            text="Save"
+            icon="checkmark"
+            onClick={handleStandaloneClick}
+          />
+          <BfDsFormSubmitButton
+            text="Send"
+            icon="arrowRight"
+            iconPosition="right"
+            onClick={handleStandaloneClick}
+          />
+        </div>
+      </div>
+
+      <div>
+        <h3>States</h3>
+        <div style={{ display: "flex", gap: "12px", flexWrap: "wrap" }}>
+          <BfDsFormSubmitButton
+            text="Disabled"
+            disabled
+            onClick={handleStandaloneClick}
+          />
+        </div>
+      </div>
+
+      <p>
+        <strong>Note:</strong>{" "}
+        Form context integration will be demonstrated in the BfDsForm examples
+        once complete.
+      </p>
+    </div>
+  );
+};

--- a/apps/bfDs/components/BfDsInput.tsx
+++ b/apps/bfDs/components/BfDsInput.tsx
@@ -1,0 +1,247 @@
+import * as React from "react";
+import { useBfDsFormContext } from "./BfDsForm.tsx";
+
+export type BfDsInputState = "default" | "error" | "success" | "disabled";
+
+export type BfDsInputProps = {
+  // Form context props
+  name?: string;
+
+  // Standalone props
+  value?: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+
+  // Common props
+  label?: string;
+  placeholder?: string;
+  required?: boolean;
+  state?: BfDsInputState;
+  errorMessage?: string;
+  successMessage?: string;
+  helpText?: string;
+  className?: string;
+} & Omit<React.InputHTMLAttributes<HTMLInputElement>, "value" | "onChange">;
+
+export function BfDsInput({
+  name,
+  value: standaloneProp,
+  onChange: standaloneOnChange,
+  label,
+  placeholder,
+  required = false,
+  state = "default",
+  errorMessage,
+  successMessage,
+  helpText,
+  className,
+  disabled,
+  id,
+  ...props
+}: BfDsInputProps) {
+  const formContext = useBfDsFormContext();
+  const inputId = id || React.useId();
+  const helpTextId = `${inputId}-help`;
+  const errorId = `${inputId}-error`;
+  const successId = `${inputId}-success`;
+
+  // Determine if we're in form context or standalone mode
+  const isInFormContext = formContext !== null && name !== undefined;
+
+  // Get value and onChange from form context or standalone props
+  const value = isInFormContext && formContext?.data && name
+    ? (formContext.data[name as keyof typeof formContext.data] as string) ?? ""
+    : standaloneProp ?? "";
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (isInFormContext && formContext?.onChange && formContext?.data && name) {
+      formContext.onChange({ ...formContext.data, [name]: e.target.value });
+    } else if (standaloneOnChange) {
+      standaloneOnChange(e);
+    }
+  };
+
+  // Get error state from form context if available
+  const formError = isInFormContext && formContext?.errors && name
+    ? formContext.errors[name as keyof typeof formContext.errors]
+    : undefined;
+  const actualErrorMessage =
+    (formError as unknown as { message?: string })?.message ||
+    errorMessage;
+  const actualState = disabled ? "disabled" : (formError ? "error" : state);
+
+  const classes = [
+    "bfds-input",
+    `bfds-input--${actualState}`,
+    className,
+  ].filter(Boolean).join(" ");
+
+  const containerClasses = [
+    "bfds-input-container",
+    `bfds-input-container--${actualState}`,
+  ].filter(Boolean).join(" ");
+
+  return (
+    <div className={containerClasses}>
+      {label && (
+        <label htmlFor={inputId} className="bfds-input-label">
+          {label}
+          {required && <span className="bfds-input-required">*</span>}
+        </label>
+      )}
+      <input
+        {...props}
+        id={inputId}
+        name={name}
+        className={classes}
+        placeholder={placeholder}
+        disabled={disabled || actualState === "disabled"}
+        required={required}
+        value={value}
+        onChange={handleChange}
+        aria-describedby={[
+          helpText ? helpTextId : null,
+          actualErrorMessage ? errorId : null,
+          successMessage ? successId : null,
+        ].filter(Boolean).join(" ") || undefined}
+        aria-invalid={actualState === "error"}
+      />
+      {helpText && (
+        <div id={helpTextId} className="bfds-input-help">
+          {helpText}
+        </div>
+      )}
+      {actualState === "error" && actualErrorMessage && (
+        <div id={errorId} className="bfds-input-error" role="alert">
+          {actualErrorMessage}
+        </div>
+      )}
+      {actualState === "success" && successMessage && (
+        <div id={successId} className="bfds-input-success">
+          {successMessage}
+        </div>
+      )}
+    </div>
+  );
+}
+
+BfDsInput.Example = function BfDsInputExample() {
+  const [value1, setValue1] = React.useState("");
+  const [value2, setValue2] = React.useState("test@example.com");
+  const [value3, setValue3] = React.useState("Valid input");
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "24px",
+        padding: "24px",
+        backgroundColor: "var(--bfds-background)",
+        color: "var(--bfds-text)",
+        fontFamily: "system-ui, -apple-system, sans-serif",
+        maxWidth: "600px",
+      }}
+    >
+      <h2>BfDsInput Examples</h2>
+
+      <div>
+        <h3>Standalone Mode</h3>
+        <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+          <BfDsInput
+            label="Your Name"
+            placeholder="Enter your name"
+            value={value1}
+            onChange={(e) => setValue1(e.target.value)}
+            helpText="This is a standalone input field"
+          />
+          <BfDsInput
+            label="Email Address"
+            placeholder="email@example.com"
+            required
+            type="email"
+            value={value2}
+            onChange={(e) => setValue2(e.target.value)}
+          />
+        </div>
+      </div>
+
+      <div>
+        <h3>Input States</h3>
+        <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+          <BfDsInput
+            label="Error State"
+            placeholder="Enter something"
+            state="error"
+            errorMessage="This field is required"
+            value=""
+            onChange={() => {}}
+          />
+          <BfDsInput
+            label="Success State"
+            placeholder="Valid input"
+            state="success"
+            value={value3}
+            onChange={(e) => setValue3(e.target.value)}
+            successMessage="Looks good!"
+          />
+          <BfDsInput
+            label="Disabled State"
+            placeholder="Cannot edit this"
+            state="disabled"
+            value="Disabled value"
+            onChange={() => {}}
+          />
+        </div>
+      </div>
+
+      <div>
+        <h3>Input Types</h3>
+        <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+          <BfDsInput
+            label="Password"
+            type="password"
+            placeholder="Enter password"
+            value=""
+            onChange={() => {}}
+          />
+          <BfDsInput
+            label="Number"
+            type="number"
+            placeholder="Enter a number"
+            value=""
+            onChange={() => {}}
+          />
+          <BfDsInput
+            label="Date"
+            type="date"
+            value=""
+            onChange={() => {}}
+          />
+        </div>
+      </div>
+
+      <div>
+        <h3>Without Labels</h3>
+        <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+          <BfDsInput
+            placeholder="Just a placeholder"
+            value=""
+            onChange={() => {}}
+          />
+          <BfDsInput
+            placeholder="With help text"
+            helpText="This input has no label but includes help text"
+            value=""
+            onChange={() => {}}
+          />
+        </div>
+      </div>
+
+      <p>
+        <strong>Note:</strong>{" "}
+        Form context integration will be demonstrated in the BfDsForm examples
+        once complete.
+      </p>
+    </div>
+  );
+};

--- a/apps/bfDs/components/BfDsList.tsx
+++ b/apps/bfDs/components/BfDsList.tsx
@@ -1,0 +1,83 @@
+import * as React from "react";
+
+type BfDsListProps = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+export function BfDsList({ children, className }: BfDsListProps) {
+  const listClasses = [
+    "bfds-list",
+    className,
+  ].filter(Boolean).join(" ");
+
+  return (
+    <ul className={listClasses}>
+      {children}
+    </ul>
+  );
+}
+
+BfDsList.Example = function BfDsListExample() {
+  const BfDsListItem = React.lazy(() =>
+    import("./BfDsListItem.tsx").then((m) => ({ default: m.BfDsListItem }))
+  );
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "32px",
+        padding: "24px",
+        backgroundColor: "var(--bfds-background)",
+        color: "var(--bfds-text)",
+        fontFamily: "system-ui, -apple-system, sans-serif",
+        maxWidth: "600px",
+      }}
+    >
+      <h2>BfDsList Examples</h2>
+
+      <div>
+        <h3>Simple List</h3>
+        <React.Suspense fallback={<div>Loading...</div>}>
+          <BfDsList>
+            <BfDsListItem>Home</BfDsListItem>
+            <BfDsListItem>About</BfDsListItem>
+            <BfDsListItem>Services</BfDsListItem>
+            <BfDsListItem>Contact</BfDsListItem>
+          </BfDsList>
+        </React.Suspense>
+      </div>
+
+      <div>
+        <h3>Navigation List</h3>
+        <React.Suspense fallback={<div>Loading...</div>}>
+          <BfDsList>
+            <BfDsListItem active>Dashboard</BfDsListItem>
+            <BfDsListItem>Projects</BfDsListItem>
+            <BfDsListItem>Team</BfDsListItem>
+            <BfDsListItem disabled>Settings</BfDsListItem>
+          </BfDsList>
+        </React.Suspense>
+      </div>
+
+      <div>
+        <h3>Clickable List</h3>
+        <React.Suspense fallback={<div>Loading...</div>}>
+          <BfDsList>
+            <BfDsListItem onClick={() => alert("Clicked Item 1")}>
+              Clickable Item 1
+            </BfDsListItem>
+            <BfDsListItem onClick={() => alert("Clicked Item 2")}>
+              Clickable Item 2
+            </BfDsListItem>
+            <BfDsListItem onClick={() => alert("Clicked Item 3")}>
+              Clickable Item 3
+            </BfDsListItem>
+          </BfDsList>
+        </React.Suspense>
+      </div>
+    </div>
+  );
+};

--- a/apps/bfDs/components/BfDsListItem.tsx
+++ b/apps/bfDs/components/BfDsListItem.tsx
@@ -1,0 +1,105 @@
+import * as React from "react";
+
+export type BfDsListItemProps = {
+  children: React.ReactNode;
+  active?: boolean;
+  disabled?: boolean;
+  onClick?: () => void;
+  className?: string;
+};
+
+export function BfDsListItem({
+  children,
+  active = false,
+  disabled = false,
+  onClick,
+  className,
+}: BfDsListItemProps) {
+  const itemClasses = [
+    "bfds-list-item",
+    active && "bfds-list-item--active",
+    disabled && "bfds-list-item--disabled",
+    onClick && !disabled && "bfds-list-item--clickable",
+    className,
+  ].filter(Boolean).join(" ");
+
+  const handleClick = () => {
+    if (!disabled && onClick) {
+      onClick();
+    }
+  };
+
+  const element = onClick && !disabled ? "button" : "li";
+  const buttonProps = element === "button"
+    ? {
+      type: "button" as const,
+      onClick: handleClick,
+    }
+    : {};
+
+  return React.createElement(
+    element,
+    {
+      className: itemClasses,
+      ...buttonProps,
+    },
+    children,
+  );
+}
+
+BfDsListItem.Example = function BfDsListItemExample() {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "32px",
+        padding: "24px",
+        backgroundColor: "var(--bfds-background)",
+        color: "var(--bfds-text)",
+        fontFamily: "system-ui, -apple-system, sans-serif",
+        maxWidth: "600px",
+      }}
+    >
+      <h2>BfDsListItem Examples</h2>
+
+      <div>
+        <h3>Item States</h3>
+        <ul className="bfds-list">
+          <BfDsListItem>Normal Item</BfDsListItem>
+          <BfDsListItem active>Active Item</BfDsListItem>
+          <BfDsListItem disabled>Disabled Item</BfDsListItem>
+        </ul>
+      </div>
+
+      <div>
+        <h3>Clickable Items</h3>
+        <ul className="bfds-list">
+          <BfDsListItem onClick={() => alert("Clicked Item 1")}>
+            Clickable Item 1
+          </BfDsListItem>
+          <BfDsListItem onClick={() => alert("Clicked Item 2")}>
+            Clickable Item 2
+          </BfDsListItem>
+          <BfDsListItem onClick={() => alert("Clicked Item 3")} disabled>
+            Disabled Clickable Item
+          </BfDsListItem>
+        </ul>
+      </div>
+
+      <div>
+        <h3>Mixed Usage</h3>
+        <ul className="bfds-list">
+          <BfDsListItem>Static Item</BfDsListItem>
+          <BfDsListItem active onClick={() => alert("Active and clickable")}>
+            Active Clickable Item
+          </BfDsListItem>
+          <BfDsListItem onClick={() => alert("Just clickable")}>
+            Clickable Item
+          </BfDsListItem>
+          <BfDsListItem disabled>Disabled Item</BfDsListItem>
+        </ul>
+      </div>
+    </div>
+  );
+};

--- a/apps/bfDs/components/BfDsTextArea.tsx
+++ b/apps/bfDs/components/BfDsTextArea.tsx
@@ -1,0 +1,296 @@
+import * as React from "react";
+import { useBfDsFormContext } from "./BfDsForm.tsx";
+
+export type BfDsTextAreaState = "default" | "error" | "success" | "disabled";
+
+export type BfDsTextAreaProps =
+  & {
+    // Form context props
+    name?: string;
+
+    // Standalone props
+    value?: string;
+    onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+
+    // Common props
+    label?: string;
+    placeholder?: string;
+    required?: boolean;
+    state?: BfDsTextAreaState;
+    errorMessage?: string;
+    successMessage?: string;
+    helpText?: string;
+    className?: string;
+    resize?: "none" | "both" | "horizontal" | "vertical";
+  }
+  & Omit<
+    React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+    "value" | "onChange"
+  >;
+
+export function BfDsTextArea({
+  name,
+  value: standaloneProp,
+  onChange: standaloneOnChange,
+  label,
+  placeholder,
+  required = false,
+  state = "default",
+  errorMessage,
+  successMessage,
+  helpText,
+  className,
+  disabled,
+  id,
+  resize = "vertical",
+  ...props
+}: BfDsTextAreaProps) {
+  const formContext = useBfDsFormContext();
+  const textAreaId = id || React.useId();
+  const helpTextId = `${textAreaId}-help`;
+  const errorId = `${textAreaId}-error`;
+  const successId = `${textAreaId}-success`;
+
+  // Determine if we're in form context or standalone mode
+  const isInFormContext = formContext !== null && name !== undefined;
+
+  // Get value and onChange from form context or standalone props
+  const value = isInFormContext && formContext?.data && name
+    ? (formContext.data[name as keyof typeof formContext.data] as string) ?? ""
+    : standaloneProp ?? "";
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    if (isInFormContext && formContext?.onChange && formContext?.data && name) {
+      formContext.onChange({ ...formContext.data, [name]: e.target.value });
+    } else if (standaloneOnChange) {
+      standaloneOnChange(e);
+    }
+  };
+
+  // Get error state from form context if available
+  const formError = isInFormContext && formContext?.errors && name
+    ? formContext.errors[name as keyof typeof formContext.errors]
+    : undefined;
+  const actualErrorMessage =
+    (formError as unknown as { message?: string })?.message ||
+    errorMessage;
+  const actualState = disabled ? "disabled" : (formError ? "error" : state);
+
+  const classes = [
+    "bfds-textarea",
+    `bfds-textarea--${actualState}`,
+    `bfds-textarea--resize-${resize}`,
+    className,
+  ].filter(Boolean).join(" ");
+
+  const containerClasses = [
+    "bfds-textarea-container",
+    `bfds-textarea-container--${actualState}`,
+  ].filter(Boolean).join(" ");
+
+  return (
+    <div className={containerClasses}>
+      {label && (
+        <label htmlFor={textAreaId} className="bfds-textarea-label">
+          {label}
+          {required && <span className="bfds-textarea-required">*</span>}
+        </label>
+      )}
+      <textarea
+        {...props}
+        id={textAreaId}
+        name={name}
+        className={classes}
+        placeholder={placeholder}
+        disabled={disabled || actualState === "disabled"}
+        required={required}
+        value={value}
+        onChange={handleChange}
+        aria-describedby={[
+          helpText ? helpTextId : null,
+          actualErrorMessage ? errorId : null,
+          successMessage ? successId : null,
+        ].filter(Boolean).join(" ") || undefined}
+        aria-invalid={actualState === "error"}
+      />
+      {helpText && (
+        <div id={helpTextId} className="bfds-textarea-help">
+          {helpText}
+        </div>
+      )}
+      {actualState === "error" && actualErrorMessage && (
+        <div id={errorId} className="bfds-textarea-error" role="alert">
+          {actualErrorMessage}
+        </div>
+      )}
+      {actualState === "success" && successMessage && (
+        <div id={successId} className="bfds-textarea-success">
+          {successMessage}
+        </div>
+      )}
+    </div>
+  );
+}
+
+BfDsTextArea.Example = function BfDsTextAreaExample() {
+  const [value1, setValue1] = React.useState("");
+  const [value2, setValue2] = React.useState(
+    "This is some existing content in the textarea that demonstrates how it looks with text.",
+  );
+  const [value3, setValue3] = React.useState(
+    "Valid content that passed validation",
+  );
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "24px",
+        padding: "24px",
+        backgroundColor: "var(--bfds-background)",
+        color: "var(--bfds-text)",
+        fontFamily: "system-ui, -apple-system, sans-serif",
+        maxWidth: "600px",
+      }}
+    >
+      <h2>BfDsTextArea Examples</h2>
+
+      <div>
+        <h3>Standalone Mode</h3>
+        <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+          <BfDsTextArea
+            label="Your Message"
+            placeholder="Enter your message here..."
+            value={value1}
+            onChange={(e) => setValue1(e.target.value)}
+            helpText="This is a standalone textarea field"
+            rows={3}
+          />
+          <BfDsTextArea
+            label="Description"
+            placeholder="Describe your project..."
+            required
+            value={value2}
+            onChange={(e) => setValue2(e.target.value)}
+            rows={4}
+          />
+        </div>
+      </div>
+
+      <div>
+        <h3>TextArea States</h3>
+        <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+          <BfDsTextArea
+            label="Error State"
+            placeholder="Enter some content"
+            state="error"
+            errorMessage="Content is too short"
+            rows={3}
+            value=""
+            onChange={() => {}}
+          />
+          <BfDsTextArea
+            label="Success State"
+            placeholder="Valid content"
+            state="success"
+            value={value3}
+            onChange={(e) => setValue3(e.target.value)}
+            successMessage="Content looks great!"
+            rows={3}
+          />
+          <BfDsTextArea
+            label="Disabled State"
+            placeholder="Cannot edit this"
+            state="disabled"
+            value="This content cannot be edited"
+            rows={3}
+            onChange={() => {}}
+          />
+        </div>
+      </div>
+
+      <div>
+        <h3>Resize Options</h3>
+        <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+          <BfDsTextArea
+            label="No Resize"
+            placeholder="Cannot be resized"
+            resize="none"
+            rows={2}
+            value=""
+            onChange={() => {}}
+          />
+          <BfDsTextArea
+            label="Horizontal Resize"
+            placeholder="Can be resized horizontally"
+            resize="horizontal"
+            rows={2}
+            value=""
+            onChange={() => {}}
+          />
+          <BfDsTextArea
+            label="Vertical Resize (Default)"
+            placeholder="Can be resized vertically"
+            resize="vertical"
+            rows={2}
+            value=""
+            onChange={() => {}}
+          />
+          <BfDsTextArea
+            label="Both Directions"
+            placeholder="Can be resized in both directions"
+            resize="both"
+            rows={2}
+            value=""
+            onChange={() => {}}
+          />
+        </div>
+      </div>
+
+      <div>
+        <h3>Different Sizes</h3>
+        <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+          <BfDsTextArea
+            label="Small (2 rows)"
+            placeholder="Small textarea"
+            rows={2}
+            value=""
+            onChange={() => {}}
+          />
+          <BfDsTextArea
+            label="Medium (4 rows)"
+            placeholder="Medium textarea"
+            rows={4}
+            value=""
+            onChange={() => {}}
+          />
+          <BfDsTextArea
+            label="Large (6 rows)"
+            placeholder="Large textarea"
+            rows={6}
+            value=""
+            onChange={() => {}}
+          />
+        </div>
+      </div>
+
+      <div>
+        <h3>Without Label</h3>
+        <BfDsTextArea
+          placeholder="Just a placeholder with help text"
+          helpText="This textarea has no label but includes help text"
+          rows={3}
+          value=""
+          onChange={() => {}}
+        />
+      </div>
+
+      <p>
+        <strong>Note:</strong>{" "}
+        Form context integration will be demonstrated in the BfDsForm examples
+        once complete.
+      </p>
+    </div>
+  );
+};

--- a/apps/bfDs/demo/Demo.tsx
+++ b/apps/bfDs/demo/Demo.tsx
@@ -1,6 +1,10 @@
 import { BfDsButton } from "../components/BfDsButton.tsx";
 import { BfDsIcon } from "../components/BfDsIcon.tsx";
 import { BfDsTabs } from "../components/BfDsTabs.tsx";
+import { BfDsForm } from "../components/BfDsForm.tsx";
+import { BfDsInput } from "../components/BfDsInput.tsx";
+import { BfDsTextArea } from "../components/BfDsTextArea.tsx";
+import { BfDsFormSubmitButton } from "../components/BfDsFormSubmitButton.tsx";
 
 export function BfDsDemo() {
   return (
@@ -8,6 +12,10 @@ export function BfDsDemo() {
       <BfDsButton.Example />
       <BfDsIcon.Example />
       <BfDsTabs.Example />
+      <BfDsForm.Example />
+      <BfDsInput.Example />
+      <BfDsTextArea.Example />
+      <BfDsFormSubmitButton.Example />
     </div>
   );
 }

--- a/apps/bfDs/demo/Demo.tsx
+++ b/apps/bfDs/demo/Demo.tsx
@@ -6,6 +6,8 @@ import { BfDsForm } from "../components/BfDsForm.tsx";
 import { BfDsInput } from "../components/BfDsInput.tsx";
 import { BfDsTextArea } from "../components/BfDsTextArea.tsx";
 import { BfDsFormSubmitButton } from "../components/BfDsFormSubmitButton.tsx";
+import { BfDsList } from "../components/BfDsList.tsx";
+import { BfDsListItem } from "../components/BfDsListItem.tsx";
 
 type ComponentSection = {
   id: string;
@@ -64,6 +66,20 @@ const componentSections: Array<ComponentSection> = [
     description: "Form submission buttons with automatic integration",
     component: BfDsFormSubmitButton.Example,
     category: "Form",
+  },
+  {
+    id: "list",
+    name: "List",
+    description: "Simple, clean lists with navigation patterns",
+    component: BfDsList.Example,
+    category: "Navigation",
+  },
+  {
+    id: "list-item",
+    name: "List Item",
+    description: "Individual list items with states and interactions",
+    component: BfDsListItem.Example,
+    category: "Navigation",
   },
 ];
 
@@ -138,56 +154,29 @@ export function BfDsDemo() {
             >
               {categoryName}
             </h3>
-            {sections.map((section) => (
-              <button
-                key={section.id}
-                type="button"
-                onClick={() => setActiveSection(section.id)}
-                style={{
-                  width: "100%",
-                  padding: "12px 24px",
-                  border: "none",
-                  background: activeSection === section.id
-                    ? "var(--bfds-primary)"
-                    : "transparent",
-                  color: activeSection === section.id
-                    ? "var(--bfds-background)"
-                    : "var(--bfds-text)",
-                  textAlign: "left",
-                  cursor: "pointer",
-                  borderLeft: activeSection === section.id
-                    ? "3px solid var(--bfds-primary)"
-                    : "3px solid transparent",
-                  transition: "all 0.2s ease-in-out",
-                  fontSize: "14px",
-                  fontWeight: activeSection === section.id ? "500" : "400",
-                }}
-                onMouseEnter={(e) => {
-                  if (activeSection !== section.id) {
-                    e.currentTarget.style.backgroundColor =
-                      "var(--bfds-background-active)";
-                  }
-                }}
-                onMouseLeave={(e) => {
-                  if (activeSection !== section.id) {
-                    e.currentTarget.style.backgroundColor = "transparent";
-                  }
-                }}
-              >
-                <div style={{ marginBottom: "4px" }}>{section.name}</div>
-                <div
-                  style={{
-                    fontSize: "12px",
-                    color: activeSection === section.id
-                      ? "var(--bfds-background)"
-                      : "var(--bfds-text-secondary)",
-                    lineHeight: "1.3",
-                  }}
+            <BfDsList>
+              {sections.map((section) => (
+                <BfDsListItem
+                  key={section.id}
+                  active={activeSection === section.id}
+                  onClick={() => setActiveSection(section.id)}
+                  className="demo-sidebar-item"
                 >
-                  {section.description}
-                </div>
-              </button>
-            ))}
+                  <div style={{ marginBottom: "4px" }}>{section.name}</div>
+                  <div
+                    style={{
+                      fontSize: "12px",
+                      color: activeSection === section.id
+                        ? "var(--bfds-background)"
+                        : "var(--bfds-text-secondary)",
+                      lineHeight: "1.3",
+                    }}
+                  >
+                    {section.description}
+                  </div>
+                </BfDsListItem>
+              ))}
+            </BfDsList>
           </div>
         ))}
       </nav>

--- a/apps/bfDs/demo/Demo.tsx
+++ b/apps/bfDs/demo/Demo.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { BfDsButton } from "../components/BfDsButton.tsx";
 import { BfDsIcon } from "../components/BfDsIcon.tsx";
 import { BfDsTabs } from "../components/BfDsTabs.tsx";
@@ -6,16 +7,201 @@ import { BfDsInput } from "../components/BfDsInput.tsx";
 import { BfDsTextArea } from "../components/BfDsTextArea.tsx";
 import { BfDsFormSubmitButton } from "../components/BfDsFormSubmitButton.tsx";
 
+type ComponentSection = {
+  id: string;
+  name: string;
+  description: string;
+  component: React.ComponentType;
+  category: "Core" | "Form" | "Navigation";
+};
+
+const componentSections: Array<ComponentSection> = [
+  {
+    id: "button",
+    name: "Button",
+    description: "Interactive buttons with variants, sizes, and icon support",
+    component: BfDsButton.Example,
+    category: "Core",
+  },
+  {
+    id: "icon",
+    name: "Icon",
+    description: "SVG icons with customizable sizes and colors",
+    component: BfDsIcon.Example,
+    category: "Core",
+  },
+  {
+    id: "tabs",
+    name: "Tabs",
+    description: "Tab navigation with nested subtabs and keyboard support",
+    component: BfDsTabs.Example,
+    category: "Navigation",
+  },
+  {
+    id: "form",
+    name: "Form",
+    description: "Complete form system with context and validation",
+    component: BfDsForm.Example,
+    category: "Form",
+  },
+  {
+    id: "input",
+    name: "Input",
+    description: "Text inputs with states and dual-mode operation",
+    component: BfDsInput.Example,
+    category: "Form",
+  },
+  {
+    id: "textarea",
+    name: "TextArea",
+    description: "Multi-line text inputs with resize options",
+    component: BfDsTextArea.Example,
+    category: "Form",
+  },
+  {
+    id: "submit-button",
+    name: "Submit Button",
+    description: "Form submission buttons with automatic integration",
+    component: BfDsFormSubmitButton.Example,
+    category: "Form",
+  },
+];
+
 export function BfDsDemo() {
+  const [activeSection, setActiveSection] = React.useState<string>("button");
+
+  const categories = React.useMemo(() => {
+    const categoryMap = new Map<string, Array<ComponentSection>>();
+    componentSections.forEach((section) => {
+      const existing = categoryMap.get(section.category) || [];
+      categoryMap.set(section.category, [...existing, section]);
+    });
+    return categoryMap;
+  }, []);
+
+  const ActiveComponent =
+    componentSections.find((s) => s.id === activeSection)?.component ||
+    BfDsButton.Example;
+
   return (
-    <div>
-      <BfDsButton.Example />
-      <BfDsIcon.Example />
-      <BfDsTabs.Example />
-      <BfDsForm.Example />
-      <BfDsInput.Example />
-      <BfDsTextArea.Example />
-      <BfDsFormSubmitButton.Example />
+    <div
+      style={{
+        display: "flex",
+        minHeight: "100vh",
+        backgroundColor: "var(--bfds-background)",
+        color: "var(--bfds-text)",
+        fontFamily: "system-ui, -apple-system, sans-serif",
+      }}
+    >
+      {/* Sidebar */}
+      <nav
+        style={{
+          width: "300px",
+          backgroundColor: "var(--bfds-background-hover)",
+          borderRight: "1px solid var(--bfds-border)",
+          padding: "24px 0",
+          overflowY: "auto",
+          position: "sticky",
+          top: 0,
+          height: "100vh",
+        }}
+      >
+        <div style={{ padding: "0 24px", marginBottom: "32px" }}>
+          <h1
+            style={{ margin: "0 0 8px 0", fontSize: "24px", fontWeight: "600" }}
+          >
+            BfDs Demo
+          </h1>
+          <p
+            style={{
+              margin: 0,
+              color: "var(--bfds-text-secondary)",
+              fontSize: "14px",
+            }}
+          >
+            Interactive examples of BfDs design system components
+          </p>
+        </div>
+
+        {Array.from(categories.entries()).map(([categoryName, sections]) => (
+          <div key={categoryName} style={{ marginBottom: "24px" }}>
+            <h3
+              style={{
+                margin: "0 0 12px 0",
+                padding: "0 24px",
+                fontSize: "12px",
+                fontWeight: "600",
+                textTransform: "uppercase",
+                letterSpacing: "0.05em",
+                color: "var(--bfds-text-muted)",
+              }}
+            >
+              {categoryName}
+            </h3>
+            {sections.map((section) => (
+              <button
+                key={section.id}
+                type="button"
+                onClick={() => setActiveSection(section.id)}
+                style={{
+                  width: "100%",
+                  padding: "12px 24px",
+                  border: "none",
+                  background: activeSection === section.id
+                    ? "var(--bfds-primary)"
+                    : "transparent",
+                  color: activeSection === section.id
+                    ? "var(--bfds-background)"
+                    : "var(--bfds-text)",
+                  textAlign: "left",
+                  cursor: "pointer",
+                  borderLeft: activeSection === section.id
+                    ? "3px solid var(--bfds-primary)"
+                    : "3px solid transparent",
+                  transition: "all 0.2s ease-in-out",
+                  fontSize: "14px",
+                  fontWeight: activeSection === section.id ? "500" : "400",
+                }}
+                onMouseEnter={(e) => {
+                  if (activeSection !== section.id) {
+                    e.currentTarget.style.backgroundColor =
+                      "var(--bfds-background-active)";
+                  }
+                }}
+                onMouseLeave={(e) => {
+                  if (activeSection !== section.id) {
+                    e.currentTarget.style.backgroundColor = "transparent";
+                  }
+                }}
+              >
+                <div style={{ marginBottom: "4px" }}>{section.name}</div>
+                <div
+                  style={{
+                    fontSize: "12px",
+                    color: activeSection === section.id
+                      ? "var(--bfds-background)"
+                      : "var(--bfds-text-secondary)",
+                    lineHeight: "1.3",
+                  }}
+                >
+                  {section.description}
+                </div>
+              </button>
+            ))}
+          </div>
+        ))}
+      </nav>
+
+      {/* Main Content */}
+      <main
+        style={{
+          flex: 1,
+          overflowY: "auto",
+          minWidth: 0, // Prevents flex item from growing beyond container
+        }}
+      >
+        <ActiveComponent />
+      </main>
     </div>
   );
 }

--- a/apps/bfDs/index.ts
+++ b/apps/bfDs/index.ts
@@ -18,3 +18,28 @@ export type {
   BfDsTabsProps,
   BfDsTabsState,
 } from "./components/BfDsTabs.tsx";
+
+export { BfDsForm } from "./components/BfDsForm.tsx";
+export type {
+  BfDsFormElementProps,
+  BfDsFormValue,
+} from "./components/BfDsForm.tsx";
+
+export { BfDsInput } from "./components/BfDsInput.tsx";
+export type {
+  BfDsInputProps,
+  BfDsInputState,
+} from "./components/BfDsInput.tsx";
+
+export { BfDsTextArea } from "./components/BfDsTextArea.tsx";
+export type {
+  BfDsTextAreaProps,
+  BfDsTextAreaState,
+} from "./components/BfDsTextArea.tsx";
+
+export { BfDsFormSubmitButton } from "./components/BfDsFormSubmitButton.tsx";
+export type {
+  BfDsFormSubmitButtonProps,
+} from "./components/BfDsFormSubmitButton.tsx";
+
+export { useBfDsFormContext } from "./components/BfDsForm.tsx";

--- a/apps/bfDs/index.ts
+++ b/apps/bfDs/index.ts
@@ -43,3 +43,8 @@ export type {
 } from "./components/BfDsFormSubmitButton.tsx";
 
 export { useBfDsFormContext } from "./components/BfDsForm.tsx";
+
+export { BfDsList } from "./components/BfDsList.tsx";
+
+export { BfDsListItem } from "./components/BfDsListItem.tsx";
+export type { BfDsListItemProps } from "./components/BfDsListItem.tsx";

--- a/apps/bfDs/memos/plans/2025-06-23-bfds-lite-creation.md
+++ b/apps/bfDs/memos/plans/2025-06-23-bfds-lite-creation.md
@@ -38,8 +38,8 @@ as part of the 2025-06-25 design system migration.
 
 ### ✅ Completed
 
-- [x] Created `apps/bfDsLite` directory structure
-- [x] **BfDsLiteButton** component with:
+- [x] Created `apps/bfDs` directory structure
+- [x] **BfDsButton** component with:
   - 4 variants: primary, secondary, outline, ghost
   - 3 sizes: small, medium, large
   - Hover and active states
@@ -47,13 +47,13 @@ as part of the 2025-06-25 design system migration.
   - TypeScript types
   - **Icon support**: `icon`, `iconPosition`, `iconOnly` props
   - **Round icon-only buttons**: Perfectly circular design
-- [x] **BfDsLiteIcon** component with:
+- [x] **BfDsIcon** component with:
   - 80+ icons from existing bfDs system
   - 3 sizes: small (16px), medium (20px), large (24px)
   - Color customization with CSS variable integration
   - TypeScript-safe icon names using `keyof typeof icons`
   - Searchable example component with grid layout
-- [x] **BfDsLiteTabs** component with:
+- [x] **BfDsTabs** component with:
   - Multiple tab support with controlled/uncontrolled modes
   - **Nested subtabs** for hierarchical navigation
   - **Keyboard navigation** (arrow keys, Home/End, Enter/Space)
@@ -62,11 +62,22 @@ as part of the 2025-06-25 design system migration.
   - **Smooth content transitions** with fade-in animations
   - **2 variants** (primary, secondary) and **3 sizes** (small, medium, large)
   - **Comprehensive accessibility** with ARIA attributes and roles
-- [x] CSS variables system for theming
+- [x] **BfDsForm** system with smart dual-mode components:
+  - **BfDsForm**: Context provider for centralized form state management
+  - **BfDsInput**: Text input with
+    error/success/disabled/focus/required/placeholder states
+  - **BfDsTextArea**: Textarea with resize options and all input states
+  - **BfDsFormSubmitButton**: Submit button with form integration
+  - **Dual mode operation**: Components auto-detect form context vs standalone
+    usage
+  - **TypeScript-first**: Strong typing with proper form data integration
+  - **Complete accessibility**: ARIA attributes and semantic HTML
+- [x] CSS variables system for theming with additional form states (error,
+      success, focus)
 - [x] Example component pattern (`Component.Example`)
-- [x] Demo page setup with Button, Icon, and Tabs examples
+- [x] Demo page setup with Button, Icon, Tabs, and Form examples
 - [x] CSS moved to static folder (per system requirements)
-- [x] Main index.ts exports
+- [x] Main index.ts exports with all form components
 - [x] Icon library moved to `lib/icons.ts`
 
 ### 🔄 In Progress
@@ -76,7 +87,9 @@ as part of the 2025-06-25 design system migration.
 ### 📋 Todo
 
 - [ ] Additional core components:
-  - [ ] Input/TextField
+  - [x] ~~Input/TextField~~ ✅ **Completed** (BfDsInput with dual-mode
+        operation)
+  - [x] ~~TextArea~~ ✅ **Completed** (BfDsTextArea with resize options)
   - [ ] Select/Dropdown
   - [ ] Checkbox
   - [ ] Radio
@@ -86,7 +99,8 @@ as part of the 2025-06-25 design system migration.
   - [ ] Container
   - [ ] Grid
   - [ ] Stack
-- [ ] Form components integration
+- [x] ~~Form components integration~~ ✅ **Completed** (Full form system with
+      context)
 - [ ] Typography system
 - [ ] Testing setup
 - [ ] Integration with existing apps
@@ -94,21 +108,25 @@ as part of the 2025-06-25 design system migration.
 ## File Structure
 
 ```
-apps/bfDsLite/
+apps/bfDs/
 ├── components/
-│   ├── BfDsLiteButton.tsx (with .Example and icon support)
-│   ├── BfDsLiteIcon.tsx (with .Example)
-│   └── BfDsLiteTabs.tsx (with .Example and subtabs support)
+│   ├── BfDsButton.tsx (with .Example and icon support)
+│   ├── BfDsIcon.tsx (with .Example)
+│   ├── BfDsTabs.tsx (with .Example and subtabs support)
+│   ├── BfDsForm.tsx (with .Example and context provider)
+│   ├── BfDsInput.tsx (with .Example and dual-mode operation)
+│   ├── BfDsTextArea.tsx (with .Example and resize options)
+│   └── BfDsFormSubmitButton.tsx (with .Example and form integration)
 ├── lib/
 │   └── icons.ts (80+ icon definitions)
 ├── demo/
-│   └── Demo.tsx
+│   └── Demo.tsx (comprehensive showcase)
 ├── memos/
 │   └── plans/
 │       └── 2025-06-23-bfds-lite-creation.md
-└── index.ts
+└── index.ts (complete exports)
 
-CSS: static/bfDsLiteStyle.css (comprehensive styling)
+CSS: static/bfDsStyle.css (comprehensive styling with form states)
 ```
 
 ## Design Decisions
@@ -117,8 +135,7 @@ CSS: static/bfDsLiteStyle.css (comprehensive styling)
    for better performance and easier theming
 2. **Component.Example pattern**: Each component has an attached Example
    component for demos
-3. **BEM-like naming**: `.bfds-lite-button--variant` for clear CSS class
-   structure
+3. **BEM-like naming**: `.bfds-button--variant` for clear CSS class structure
 4. **TypeScript-first**: Strong typing for all props and variants using
    `keyof typeof` patterns
 5. **Minimal dependencies**: Keeping the design system lightweight
@@ -128,15 +145,19 @@ CSS: static/bfDsLiteStyle.css (comprehensive styling)
    modern appearance
 8. **Inline SVG icons**: Performance-optimized with no HTTP requests, using
    existing icon library
+9. **Smart dual-mode components**: Form components automatically detect context
+   and adapt between standalone and form-integrated modes
+10. **Form state management**: Centralized form context with TypeScript-safe
+    data handling and error management
 
 ## Next Steps
 
-1. Add more core components following the same patterns (Input, Select, Modal,
-   etc.)
+1. Add more core components following the same patterns (Select, Checkbox,
+   Radio, Modal, etc.)
 2. Enhance demo page with more interactive examples
 3. Document component APIs comprehensively
 4. Set up testing infrastructure
-5. Plan migration strategy from bfDs to bfDsLite
+5. Plan migration strategy from legacy design system to bfDs
 
 ## Recent Achievements (2025-06-23)
 
@@ -151,6 +172,20 @@ CSS: static/bfDsLiteStyle.css (comprehensive styling)
   navigation, and comprehensive accessibility features
 - ✅ **Hierarchical UI patterns** supporting complex application layouts with
   main tabs and contextual subtabs
+
+## Recent Achievements (2025-07-01)
+
+- ✅ **Complete form system implemented** with smart dual-mode components
+- ✅ **BfDsForm context provider** for centralized form state management
+- ✅ **BfDsInput component** with all input states and dual-mode operation
+- ✅ **BfDsTextArea component** with resize options and form integration
+- ✅ **BfDsFormSubmitButton** with automatic form integration
+- ✅ **CSS form styling** with error, success, focus, and disabled states
+- ✅ **TypeScript-safe form handling** with proper type inference
+- ✅ **Complete accessibility** with ARIA attributes and semantic HTML
+- ✅ **Comprehensive examples** demonstrating both standalone and form context
+  usage
+- ✅ **Production ready** with successful PRs submitted and integrated
 
 ## Notes
 

--- a/apps/boltFoundry/routes.ts
+++ b/apps/boltFoundry/routes.ts
@@ -1,3 +1,4 @@
+import { BfDsDemo } from "@bfmono/apps/bfDs/demo/Demo.tsx";
 import { PageUIDemo } from "@bfmono/apps/boltFoundry/pages/PageUIDemo.tsx";
 import { EditorPage as LexicalDemo } from "@bfmono/apps/boltFoundry/components/lexical/LexicalDemo.tsx";
 import { Plinko } from "@bfmono/apps/boltFoundry/pages/Plinko.tsx";
@@ -19,7 +20,8 @@ export type RouteGuts = {
 export type RouteMap = Map<string, RouteGuts>;
 
 export const appRoutes: RouteMap = new Map([
-  ["/ui", { Component: PageUIDemo }],
+  ["/ui", { Component: BfDsDemo }],
+  ["/ui-old", { Component: PageUIDemo }],
   ["/justin", { Component: LexicalDemo }],
   ["/plinko", { Component: Plinko }],
   ["/deckDemo", { Component: Decks }],

--- a/static/bfDsStyle.css
+++ b/static/bfDsStyle.css
@@ -2,6 +2,11 @@
   --bfds-primary: #ffd700;
   --bfds-primary-hover: #e6c200;
   --bfds-primary-active: #ccad00;
+  --bfds-primary-08: rgba(255, 215, 0, 0.08);
+  --bfds-primary-06: rgba(255, 215, 0, 0.06);
+  --bfds-primary-04: rgba(255, 215, 0, 0.04);
+  --bfds-primary-02: rgba(255, 215, 0, 0.02);
+  --bfds-primary-01: rgba(255, 215, 0, 0.01);
 
   --bfds-background: #141516;
   --bfds-background-hover: #1f2021;
@@ -28,6 +33,53 @@
   
   --bfds-focus: #3b82f6;
   --bfds-focus-outline: rgba(59, 130, 246, 0.3);
+}
+
+/* List */
+
+.bfds-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  background-color: var(--bfds-background);
+}
+
+.bfds-list-item {
+  display: block;
+  width: 100%;
+  padding: 12px 16px;
+  margin: 0;
+  background: none;
+  border: none;
+  color: var(--bfds-text);
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 400;
+  text-align: left;
+  border-left: 3px solid transparent;
+  transition: all 0.2s ease-in-out;
+  cursor: default;
+}
+
+.bfds-list-item--clickable {
+  cursor: pointer;
+}
+
+.bfds-list-item--clickable:hover:not(.bfds-list-item--disabled):not(.bfds-list-item--active) {
+  background-color: var(--bfds-primary-08);
+}
+
+.bfds-list-item--active {
+  background-color: var(--bfds-primary);
+  color: var(--bfds-background);
+  border-left-color: var(--bfds-primary);
+  font-weight: 500;
+}
+
+.bfds-list-item--disabled {
+  color: var(--bfds-text-muted);
+  cursor: not-allowed;
+  opacity: 0.6;
 }
 
 /* Icon */

--- a/static/bfDsStyle.css
+++ b/static/bfDsStyle.css
@@ -17,6 +17,17 @@
 
   --bfds-border: #3a3b3c;
   --bfds-border-hover: #4a4b4c;
+  
+  --bfds-error: #ef4444;
+  --bfds-error-hover: #dc2626;
+  --bfds-error-background: #1f1415;
+  
+  --bfds-success: #10b981;
+  --bfds-success-hover: #059669;
+  --bfds-success-background: #0f1f1a;
+  
+  --bfds-focus: #3b82f6;
+  --bfds-focus-outline: rgba(59, 130, 246, 0.3);
 }
 
 /* Icon */
@@ -372,4 +383,234 @@
 
 .bfds-tabs--secondary .bfds-subtab--active {
   border-bottom-color: var(--bfds-secondary);
+}
+
+/* Form */
+
+.bfds-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* Input */
+
+.bfds-input-container {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.bfds-input-label {
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--bfds-text);
+  line-height: 1.4;
+}
+
+.bfds-input-required {
+  color: var(--bfds-error);
+  margin-left: 2px;
+}
+
+.bfds-input {
+  padding: 12px 16px;
+  border: 1px solid var(--bfds-border);
+  border-radius: 6px;
+  background-color: var(--bfds-background);
+  color: var(--bfds-text);
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 14px;
+  line-height: 1.4;
+  transition: all 0.2s ease-in-out;
+  outline: none;
+}
+
+.bfds-input::placeholder {
+  color: var(--bfds-text-muted);
+}
+
+.bfds-input:focus {
+  border-color: var(--bfds-focus);
+  box-shadow: 0 0 0 3px var(--bfds-focus-outline);
+}
+
+.bfds-input:hover:not(:disabled):not(:focus) {
+  border-color: var(--bfds-border-hover);
+}
+
+/* Input states */
+.bfds-input--error {
+  border-color: var(--bfds-error);
+  background-color: var(--bfds-error-background);
+}
+
+.bfds-input--error:focus {
+  border-color: var(--bfds-error);
+  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.3);
+}
+
+.bfds-input--success {
+  border-color: var(--bfds-success);
+  background-color: var(--bfds-success-background);
+}
+
+.bfds-input--success:focus {
+  border-color: var(--bfds-success);
+  box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.3);
+}
+
+.bfds-input--disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  background-color: var(--bfds-background-hover);
+}
+
+/* Input help text */
+.bfds-input-help {
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 12px;
+  color: var(--bfds-text-secondary);
+  line-height: 1.3;
+}
+
+.bfds-input-error {
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 12px;
+  color: var(--bfds-error);
+  line-height: 1.3;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.bfds-input-success {
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 12px;
+  color: var(--bfds-success);
+  line-height: 1.3;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+/* TextArea */
+
+.bfds-textarea-container {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.bfds-textarea-label {
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--bfds-text);
+  line-height: 1.4;
+}
+
+.bfds-textarea-required {
+  color: var(--bfds-error);
+  margin-left: 2px;
+}
+
+.bfds-textarea {
+  padding: 12px 16px;
+  border: 1px solid var(--bfds-border);
+  border-radius: 6px;
+  background-color: var(--bfds-background);
+  color: var(--bfds-text);
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  transition: all 0.2s ease-in-out;
+  outline: none;
+  min-height: 80px;
+}
+
+.bfds-textarea::placeholder {
+  color: var(--bfds-text-muted);
+}
+
+.bfds-textarea:focus {
+  border-color: var(--bfds-focus);
+  box-shadow: 0 0 0 3px var(--bfds-focus-outline);
+}
+
+.bfds-textarea:hover:not(:disabled):not(:focus) {
+  border-color: var(--bfds-border-hover);
+}
+
+/* TextArea resize options */
+.bfds-textarea--resize-none {
+  resize: none;
+}
+
+.bfds-textarea--resize-both {
+  resize: both;
+}
+
+.bfds-textarea--resize-horizontal {
+  resize: horizontal;
+}
+
+.bfds-textarea--resize-vertical {
+  resize: vertical;
+}
+
+/* TextArea states */
+.bfds-textarea--error {
+  border-color: var(--bfds-error);
+  background-color: var(--bfds-error-background);
+}
+
+.bfds-textarea--error:focus {
+  border-color: var(--bfds-error);
+  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.3);
+}
+
+.bfds-textarea--success {
+  border-color: var(--bfds-success);
+  background-color: var(--bfds-success-background);
+}
+
+.bfds-textarea--success:focus {
+  border-color: var(--bfds-success);
+  box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.3);
+}
+
+.bfds-textarea--disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  background-color: var(--bfds-background-hover);
+}
+
+/* TextArea help text */
+.bfds-textarea-help {
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 12px;
+  color: var(--bfds-text-secondary);
+  line-height: 1.3;
+}
+
+.bfds-textarea-error {
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 12px;
+  color: var(--bfds-error);
+  line-height: 1.3;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.bfds-textarea-success {
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 12px;
+  color: var(--bfds-success);
+  line-height: 1.3;
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }


### PR DESCRIPTION

Implement new list components for navigation patterns with clean styling and interactive states.

Changes:
- Add BfDsList component for semantic list containers
- Add BfDsListItem component with active, disabled, and clickable states
- Implement transparent primary color variants (08, 06, 04, 02, 01 opacity levels)
- Add comprehensive examples and documentation
- Use new BfDsList for Demo sidebar

Test plan:
1. Run demo: `bff devTools`
2. Navigate to List and List Item examples
3. Verify all component states work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/1318).
* __->__ #1318
* #1297
* #1296
* #1295