### PR TITLE
Add BfDb migration plan for AibffConversation to proper BfDb nodes

### DIFF
--- a/apps/aibff/memos/plans/2025-07-aibff-gui-right-panel-redesign.md
+++ b/apps/aibff/memos/plans/2025-07-aibff-gui-right-panel-redesign.md
@@ -1,0 +1,278 @@
+# aibff GUI Right Panel Redesign Implementation Memo
+
+**Date:** 2025-07-02  
+**Status:** Planning  
+**Phase:** Design & Implementation  
+
+## Overview
+
+Complete redesign of the aibff GUI right panel to support a comprehensive 7-step workflow for building LLM evaluation graders. This will replace the existing `TabbedEditor` component with an entirely new component built from scratch.
+
+## Current State Analysis
+
+### Existing Right Panel Structure (To Be Removed)
+- `TabbedEditor` component with 5 tabs:
+  - Input Samples (JSONL editor)
+  - Actor Deck (Markdown editor) 
+  - Grader Deck (Markdown editor)
+  - Ground Truth (Data editor)
+  - Notes (Markdown editor)
+
+### Issues with Current Implementation
+- Static text editors without workflow integration
+- No specialized UI for different content types
+- Missing key workflow steps (calibration, feedback, file management)
+- No AI assistance integration in right panel
+
+## New 7-Step Workflow Design
+
+### Step-by-Step Process
+1. **Input Samples** - Collect evaluation input data (JSONL format)
+2. **System Prompt** - Define AI assistant behavior (text/markdown)
+3. **Output Samples** - AI-generated outputs matching OpenAI completions format (JSONL)
+4. **Eval Prompt** - Evaluation criteria and grader instructions (text/markdown)
+5. **Eval Output** - Calibration results and evaluation data (read-only display)
+6. **Fix** - AI-powered feedback and improvement suggestions (interactive UI)
+7. **Edit** - Directory browser and file management (file explorer UI)
+
+## Technical Implementation Plan
+
+### 1. New Component Architecture
+
+```
+WorkflowPanel (new root component)
+├── WorkflowTabs (tab navigation)
+├── InputSamplesTab (existing functionality)
+├── SystemPromptTab (renamed from Actor Deck)
+├── OutputSamplesTab (new JSONL editor)
+├── EvalPromptTab (renamed from Grader Deck)
+├── EvalOutputTab (new results display)
+├── FixTab (new AI feedback UI)
+└── EditTab (new file browser)
+```
+
+### 2. Tab-Specific Implementation Details
+
+#### InputSamplesTab
+- **Reuse existing functionality** from current Input Samples tab
+- JSONL format editing
+- Auto-save with status indicators
+- (JSONL validation to be added later)
+
+#### SystemPromptTab  
+- **Migrate content** from current Actor Deck tab
+- Text/markdown editor for AI behavior definition
+- Auto-save functionality
+
+#### OutputSamplesTab
+- **New implementation** with identical UI to InputSamplesTab
+- JSONL editor for OpenAI completions format
+- Auto-save functionality
+- (JSONL validation to be added later)
+
+#### EvalPromptTab
+- **Migrate content** from current Grader Deck tab  
+- Text/markdown editor for evaluation instructions
+- Auto-save functionality
+
+#### EvalOutputTab
+- **Placeholder implementation** for Justin's calibration work
+- Read-only display component
+- Data visualization for evaluation results
+- Empty state with "Coming soon" message
+
+#### FixTab
+- **Placeholder implementation** for AI feedback functionality
+- Empty state with "Coming soon" message
+- (AI feedback UI to be implemented later)
+
+#### EditTab
+- **New file browser/manager** for conversation directory
+- Tree view of conversation files
+- Inline editing capabilities
+- File operations (create, delete, rename)
+
+### 3. Data Management
+
+#### AibffConversation Extension
+The existing `AibffConversation` class needs to be extended to support the workflow tab data:
+
+**Current Implementation:**
+- File-based storage in `@bfmono/tmp/conversations/`
+- Main conversation stored as `{conversationId}.md` with TOML frontmatter
+- Messages array with user/assistant roles
+- Markdown parsing and serialization
+
+**Required Extensions:**
+- Add workflow file management methods:
+  - `getInputSamples()` / `setInputSamples(content: string)`
+  - `getSystemPrompt()` / `setSystemPrompt(content: string)`
+  - `getOutputSamples()` / `setOutputSamples(content: string)`
+  - `getEvalPrompt()` / `setEvalPrompt(content: string)`
+  - `getEvalOutput()` / `setEvalOutput(content: string)`
+  - `listFiles()` - for Edit tab directory listing
+
+**File Management:**
+- Each workflow tab content stored as separate file in conversation directory
+- Automatic file creation on first write
+- Debounced save operations (2-second delay)
+- File watching for external changes (future enhancement)
+
+#### File Structure
+```
+aibff-conversations/{conversationId}/
+├── {conversationId}.md         # Main conversation (existing)
+├── input-samples.jsonl         # Input samples tab data
+├── system-prompt.md           # System prompt tab data  
+├── output-samples.jsonl       # Output samples tab data
+├── eval-prompt.md            # Eval prompt tab data
+└── eval-output.json          # Eval output tab data (placeholder)
+```
+
+#### GraphQL Schema
+```graphql
+type AibffConversation {
+  id: String!
+  created_at: String!
+  updated_at: String!
+  messages: [AibffMessage!]!
+  inputSamples: String          # Content of input-samples.jsonl
+  systemPrompt: String          # Content of system-prompt.md
+  outputSamples: String         # Content of output-samples.jsonl
+  evalPrompt: String           # Content of eval-prompt.md
+  evalOutput: String           # Content of eval-output.json
+  files: [ConversationFile!]!  # Directory listing for Edit tab
+}
+
+input ConversationUpdateInput {
+  inputSamples: String
+  systemPrompt: String
+  outputSamples: String
+  evalPrompt: String
+}
+```
+
+#### GraphQL Operations
+- `query getConversation(id: String!)` - Get complete conversation data including all workflow files
+- `mutation updateConversation(id: String!, input: ConversationUpdateInput!)` - Update workflow file contents
+
+## Implementation Phases
+
+### Phase 1: Core Tab Structure
+- [ ] Extend `AibffConversation` class with workflow file methods
+- [ ] Replace `replaceGraderDeck` tool call with new workflow tool calls
+- [ ] Create new `WorkflowPanel` component
+- [ ] Implement basic tab navigation
+- [ ] Migrate InputSamples and SystemPrompt tabs
+- [ ] Update GraphQL resolvers to use extended conversation methods
+
+### Phase 2: New Content Tabs
+- [ ] Implement OutputSamplesTab (validation deferred)
+- [ ] Migrate EvalPromptTab from Grader Deck
+- [ ] Create placeholder EvalOutputTab
+- [ ] Add remaining workflow file methods to AibffConversation
+- [ ] Update GraphQL schema and resolvers for all workflow fields
+
+### Phase 3: Advanced Features
+- [ ] Create EditTab file browser
+- [ ] Enhanced file operations and management
+- [ ] FixTab placeholder (AI feedback deferred)
+
+### Phase 4: Polish & Integration
+- [ ] UI/UX improvements and consistency
+- [ ] Error handling and validation
+- [ ] Performance optimizations
+- [ ] Integration testing with existing chat interface
+
+## Technical Considerations
+
+### Test-Driven Development (TDD)
+**IMPORTANT**: Follow TDD practices throughout implementation as specified in `decks/cards/testing.card.md`
+
+- Write tests first for all new AibffConversation methods
+- Test-driven component development for WorkflowPanel
+- Unit tests for each tab component
+- Integration tests for tool call functionality
+- End-to-end tests for complete workflow
+- Test file I/O operations with mock file system
+
+### UI/UX Design
+- **Component Strategy**: Prioritize using BfDs components first
+- If required component doesn't exist in BfDs, create app-local component rather than inline code
+- Loading states and error handling
+- Empty states for new conversations
+- Proper error messages for file operations
+
+
+
+### Anti-Goals
+- **No JSONL validation** - Keep implementation simple, validation can be added later
+- **No file watching** - Don't implement external file change detection
+- **No collaborative editing** - Single user experience only
+- **No export/import** - Focus on core workflow functionality
+- **No BfNode integration** - Keep using file-based system for now
+
+### Integration Points
+- Chat interface tool calls for modifying tab content
+- AI assistant integration for Fix tab functionality
+- Existing conversation persistence system
+- Real-time updates between chat and right panel
+- GraphQL integration with existing Isograph client
+
+### AI Tool Calls
+
+Replace the existing `replaceGraderDeck` with specific tool calls for each workflow tab:
+
+**Update Operations:**
+```typescript
+updateInputSamples(content: string) -> { success: boolean, message?: string }
+updateSystemPrompt(content: string) -> { success: boolean, message?: string }
+updateOutputSamples(content: string) -> { success: boolean, message?: string }
+updateEvalPrompt(content: string) -> { success: boolean, message?: string }
+```
+
+**Read Operations:**
+```typescript
+getInputSamples() -> string
+getSystemPrompt() -> string  
+getOutputSamples() -> string
+getEvalPrompt() -> string
+getEvalOutput() -> string
+getConversationFiles() -> Array<{name: string, size: number, modified: string}>
+```
+
+**Design Rationale:**
+- Separate tool calls per tab for clarity and type safety
+- Update calls return success status only (no content echo)
+- Explicit get/set separation for better AI usability
+- Each tab can have independent validation and processing
+
+## Success Criteria
+
+1. **Complete Right Panel Redesign**: Replace TabbedEditor with new WorkflowPanel component
+2. **7-Step Workflow Implementation**: All tabs functional (Input Samples, System Prompt, Output Samples, Eval Prompt, Eval Output, Fix, Edit)
+3. **File-Based Storage**: Extended AibffConversation class with separate workflow files
+4. **AI Tool Call Integration**: New workflow-specific tool calls replace replaceGraderDeck
+5. **Placeholder Tabs**: Eval Output and Fix tabs show "Coming soon" placeholders
+6. **Directory Browser**: Edit tab displays conversation files with basic operations
+
+## Risks & Mitigation
+
+### Technical Risks
+- **Component complexity**: Building WorkflowPanel from scratch
+  - *Mitigation*: Follow TDD practices and use existing BfDs components
+- **File I/O operations**: Managing multiple workflow files per conversation
+  - *Mitigation*: Extend proven AibffConversation class patterns
+- **Tool call integration**: Replacing existing replaceGraderDeck functionality
+  - *Mitigation*: Implement incrementally, test each tool call separately
+
+## Next Steps
+
+1. **Architecture Review**: Validate component structure and tool call design
+2. **TDD Setup**: Prepare test framework for AibffConversation extensions
+3. **Component Design**: Plan WorkflowPanel component structure using BfDs
+4. **Implementation Start**: Begin Phase 1 development
+
+---
+
+*This memo will be updated as implementation progresses and requirements evolve.*

--- a/apps/bfDb/nodeTypes/aibff/AibffConversation.test.ts
+++ b/apps/bfDb/nodeTypes/aibff/AibffConversation.test.ts
@@ -7,7 +7,7 @@ async function cleanupTestConversations() {
     const dir = AibffConversation.getConversationsDirectory();
     for await (const entry of Deno.readDir(dir)) {
       if (entry.name.startsWith("conv-test-")) {
-        await Deno.remove(`${dir}/${entry.name}`);
+        await Deno.remove(`${dir}/${entry.name}`, { recursive: true });
       }
     }
   } catch {
@@ -172,7 +172,7 @@ Deno.test("AibffConversation - isRecentlyCreated", async () => {
 
   // Manually modify the created_at in the file
   const filename =
-    `${AibffConversation.getConversationsDirectory()}/conv-test-old.md`;
+    `${AibffConversation.getConversationsDirectory()}/conv-test-old/conv-test-old.md`;
   const content = await Deno.readTextFile(filename);
   const oldDate = new Date(Date.now() - 20000).toISOString(); // 20 seconds ago
   const modifiedContent = content.replace(
@@ -210,7 +210,7 @@ Deno.test("AibffConversation - markdown format", async () => {
 
   // Read the raw file to check format
   const filename =
-    `${AibffConversation.getConversationsDirectory()}/conv-test-markdown.md`;
+    `${AibffConversation.getConversationsDirectory()}/conv-test-markdown/conv-test-markdown.md`;
   const content = await Deno.readTextFile(filename);
 
   // Check frontmatter
@@ -248,6 +248,117 @@ Deno.test("AibffConversation - static create method", async () => {
 
   // Verify it was saved
   assertEquals(await conv2.exists(), true);
+
+  await cleanupTestConversations();
+});
+
+// Workflow file method tests
+Deno.test("AibffConversation - workflow files - input samples", async () => {
+  await cleanupTestConversations();
+
+  const conversation = await AibffConversation.create();
+  const inputSamples = '{"input": "test sample 1"}\n{"input": "test sample 2"}';
+  
+  // Set input samples
+  await conversation.setInputSamples(inputSamples);
+  
+  // Get input samples
+  const retrieved = await conversation.getInputSamples();
+  assertEquals(retrieved, inputSamples);
+
+  await cleanupTestConversations();
+});
+
+Deno.test("AibffConversation - workflow files - system prompt", async () => {
+  await cleanupTestConversations();
+
+  const conversation = await AibffConversation.create();
+  const systemPrompt = "You are a helpful AI assistant that provides clear and concise answers.";
+  
+  // Set system prompt
+  await conversation.setSystemPrompt(systemPrompt);
+  
+  // Get system prompt
+  const retrieved = await conversation.getSystemPrompt();
+  assertEquals(retrieved, systemPrompt);
+
+  await cleanupTestConversations();
+});
+
+Deno.test("AibffConversation - workflow files - output samples", async () => {
+  await cleanupTestConversations();
+
+  const conversation = await AibffConversation.create();
+  const outputSamples = '{"choices": [{"message": {"content": "response 1"}}]}\n{"choices": [{"message": {"content": "response 2"}}]}';
+  
+  // Set output samples
+  await conversation.setOutputSamples(outputSamples);
+  
+  // Get output samples
+  const retrieved = await conversation.getOutputSamples();
+  assertEquals(retrieved, outputSamples);
+
+  await cleanupTestConversations();
+});
+
+Deno.test("AibffConversation - workflow files - eval prompt", async () => {
+  await cleanupTestConversations();
+
+  const conversation = await AibffConversation.create();
+  const evalPrompt = "# Evaluation Criteria\n\nRate the response on accuracy and helpfulness.";
+  
+  // Set eval prompt
+  await conversation.setEvalPrompt(evalPrompt);
+  
+  // Get eval prompt
+  const retrieved = await conversation.getEvalPrompt();
+  assertEquals(retrieved, evalPrompt);
+
+  await cleanupTestConversations();
+});
+
+Deno.test("AibffConversation - workflow files - eval output", async () => {
+  await cleanupTestConversations();
+
+  const conversation = await AibffConversation.create();
+  const evalOutput = '{"results": [{"score": 8, "reasoning": "Good response"}]}';
+  
+  // Set eval output
+  await conversation.setEvalOutput(evalOutput);
+  
+  // Get eval output
+  const retrieved = await conversation.getEvalOutput();
+  assertEquals(retrieved, evalOutput);
+
+  await cleanupTestConversations();
+});
+
+Deno.test("AibffConversation - workflow files - list files", async () => {
+  await cleanupTestConversations();
+
+  const conversation = await AibffConversation.create();
+  await conversation.save(); // Save the main conversation file
+  
+  // Create some workflow files
+  await conversation.setInputSamples('{"test": "input"}');
+  await conversation.setSystemPrompt("Test system prompt");
+  await conversation.setOutputSamples('{"test": "output"}');
+  
+  // List files
+  const files = await conversation.listFiles();
+  
+  // Should include the main conversation file and workflow files
+  const fileNames = files.map(f => f.name).sort();
+  assertEquals(fileNames.includes(`${conversation.getId()}.md`), true);
+  assertEquals(fileNames.includes("input-samples.jsonl"), true);
+  assertEquals(fileNames.includes("system-prompt.md"), true);
+  assertEquals(fileNames.includes("output-samples.jsonl"), true);
+  
+  // Check file properties
+  const inputFile = files.find(f => f.name === "input-samples.jsonl");
+  assertExists(inputFile);
+  assertExists(inputFile.size);
+  assertExists(inputFile.modified);
 
   await cleanupTestConversations();
 });

--- a/apps/bfDb/nodeTypes/aibff/AibffConversation.ts
+++ b/apps/bfDb/nodeTypes/aibff/AibffConversation.ts
@@ -97,20 +97,16 @@ export class AibffConversation {
 
   // Persistence methods
   async save(): Promise<void> {
-    try {
-      await Deno.mkdir(this.conversationsDir, { recursive: true });
-    } catch {
-      // Directory might already exist
-    }
+    await this.ensureConversationDirectory();
 
     const content = this.toMarkdown();
-    const filename = `${this.conversationsDir}/${this.metadata.id}.md`;
+    const filename = `${this.getConversationDirectory()}/${this.metadata.id}.md`;
     await Deno.writeTextFile(filename, content);
     logger.debug(`Saved conversation ${this.metadata.id}`);
   }
 
   async loadFromFile(): Promise<void> {
-    const filename = `${this.conversationsDir}/${this.metadata.id}.md`;
+    const filename = `${this.getConversationDirectory()}/${this.metadata.id}.md`;
 
     try {
       const markdown = await Deno.readTextFile(filename);
@@ -126,7 +122,7 @@ export class AibffConversation {
 
   async exists(): Promise<boolean> {
     try {
-      const filename = `${this.conversationsDir}/${this.metadata.id}.md`;
+      const filename = `${this.getConversationDirectory()}/${this.metadata.id}.md`;
       await Deno.stat(filename);
       return true;
     } catch {
@@ -261,5 +257,106 @@ ${msg.content}`;
   // Static method to get conversations directory
   static getConversationsDirectory(): string {
     return AibffConversation.conversationsDir;
+  }
+
+  // Workflow file methods
+  private getConversationDirectory(): string {
+    return `${this.conversationsDir}/${this.metadata.id}`;
+  }
+
+  private getWorkflowFilePath(filename: string): string {
+    return `${this.getConversationDirectory()}/${filename}`;
+  }
+
+  private async ensureConversationDirectory(): Promise<void> {
+    try {
+      await Deno.mkdir(this.getConversationDirectory(), { recursive: true });
+    } catch {
+      // Directory might already exist
+    }
+  }
+
+  private async readWorkflowFile(filename: string): Promise<string> {
+    try {
+      const filePath = this.getWorkflowFilePath(filename);
+      return await Deno.readTextFile(filePath);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return "";
+      }
+      throw error;
+    }
+  }
+
+  private async writeWorkflowFile(filename: string, content: string): Promise<void> {
+    await this.ensureConversationDirectory();
+    const filePath = this.getWorkflowFilePath(filename);
+    await Deno.writeTextFile(filePath, content);
+  }
+
+  async getInputSamples(): Promise<string> {
+    return await this.readWorkflowFile("input-samples.jsonl");
+  }
+
+  async setInputSamples(content: string): Promise<void> {
+    await this.writeWorkflowFile("input-samples.jsonl", content);
+  }
+
+  async getSystemPrompt(): Promise<string> {
+    return await this.readWorkflowFile("system-prompt.md");
+  }
+
+  async setSystemPrompt(content: string): Promise<void> {
+    await this.writeWorkflowFile("system-prompt.md", content);
+  }
+
+  async getOutputSamples(): Promise<string> {
+    return await this.readWorkflowFile("output-samples.jsonl");
+  }
+
+  async setOutputSamples(content: string): Promise<void> {
+    await this.writeWorkflowFile("output-samples.jsonl", content);
+  }
+
+  async getEvalPrompt(): Promise<string> {
+    return await this.readWorkflowFile("eval-prompt.md");
+  }
+
+  async setEvalPrompt(content: string): Promise<void> {
+    await this.writeWorkflowFile("eval-prompt.md", content);
+  }
+
+  async getEvalOutput(): Promise<string> {
+    return await this.readWorkflowFile("eval-output.json");
+  }
+
+  async setEvalOutput(content: string): Promise<void> {
+    await this.writeWorkflowFile("eval-output.json", content);
+  }
+
+  async listFiles(): Promise<Array<{ name: string; size: number; modified: string }>> {
+    try {
+      await this.ensureConversationDirectory();
+      const files: Array<{ name: string; size: number; modified: string }> = [];
+      
+      for await (const entry of Deno.readDir(this.getConversationDirectory())) {
+        if (entry.isFile) {
+          const filePath = this.getWorkflowFilePath(entry.name);
+          const stat = await Deno.stat(filePath);
+          files.push({
+            name: entry.name,
+            size: stat.size,
+            modified: stat.mtime?.toISOString() || new Date().toISOString(),
+          });
+        }
+      }
+      
+      return files;
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return [];
+      }
+      throw error;
+    }
   }
 }

--- a/memos/plans/2025-07-02-aibff-conversation-bfdb-migration.md
+++ b/memos/plans/2025-07-02-aibff-conversation-bfdb-migration.md
@@ -1,0 +1,166 @@
+# Implementation Plan: Migrate AibffConversation to Proper BfDb Nodes
+
+**Date:** 2025-07-02  
+**Type:** Implementation Plan  
+**Status:** Planning  
+
+## Overview
+
+Convert the current file-based `AibffConversation` system to use proper BfDb nodes with structured data storage, maintaining backward compatibility through export functionality.
+
+**Significance:** This will be the first "real" BfDb nodes for the BfDb system, establishing patterns for future node implementations without organization/user/CurrentViewer complexity.
+
+## Current State Analysis
+
+### Existing Implementation
+- **Location:** `apps/bfDb/nodeTypes/aibff/AibffConversation.ts`
+- **Storage:** File-based in `/tmp/conversations/` as markdown with TOML frontmatter
+- **Structure:** Standalone class, not integrated with BfDb ecosystem
+- **Limitations:**
+  - No BfDb integration (doesn't extend BfNode)
+  - No GraphQL exposure
+  - Limited querying capabilities
+  - No relations to other entities
+  - Ad-hoc file storage instead of unified storage layer
+
+### Target Architecture
+- **BfAiConversation:** Main conversation node
+- **BfAiMessage:** Individual message nodes with relations
+- **Storage:** Structured data in BfDb storage system
+- **GraphQL:** Future integration for API access
+
+## Technical Specifications
+
+### Node Definitions
+
+#### BfAiConversation (BfDb Only - No GraphQL Initially)
+```typescript
+export class BfAiConversation extends BfNode<InferProps<typeof BfAiConversation>> {
+  // Skip GraphQL spec initially - focus on BfDb functionality
+  static override gqlSpec = undefined;
+
+  static override bfNodeSpec = this.defineBfNode((node) =>
+    node
+      .string("title")
+      .many("messages", () => import("./BfAiMessage.ts").then(m => m.BfAiMessage))
+  );
+}
+```
+
+#### BfAiMessage (BfDb Only - No GraphQL Initially)
+```typescript
+export class BfAiMessage extends BfNode<InferProps<typeof BfAiMessage>> {
+  // Skip GraphQL spec initially - focus on BfDb functionality  
+  static override gqlSpec = undefined;
+
+  static override bfNodeSpec = this.defineBfNode((node) =>
+    node
+      .string("role")        // user, assistant, system
+      .string("content")     // message content
+      .string("timestamp")   // ISO timestamp
+      .one("conversation", () => import("./BfAiConversation.ts").then(m => m.BfAiConversation))
+  );
+}
+```
+
+## Implementation Phases
+
+### Phase 1: BfAiConversation Node (BfDb Only)
+**Goal:** Create conversation node with BfDb functionality, no GraphQL
+
+**Tasks:**
+1. Create `BfAiConversation` node extending BfNode
+2. Add `title` field with `bfNodeSpec` only (no `gqlSpec`)
+3. Add temporary `messages` field as JSON for simplicity
+4. Add to BfDb node registry (`apps/bfDb/models/__generated__/nodeTypesList.ts`)
+5. Test basic CRUD operations through BfDb storage layer
+6. Verify storage, caching, and metadata work correctly
+
+**Acceptance Criteria:**
+- Can create, read, update, delete conversations via BfDb
+- BfDb storage integration working (not GraphQL)
+- Standard metadata (bfGid, timestamps) handled properly
+- No GraphQL exposure yet
+- Happy path tests covering basic CRUD operations
+
+### Phase 2: BfAiMessage Node and Relations (BfDb Only)
+**Goal:** Add message nodes with relations, still BfDb only
+
+**Tasks:**
+1. Create `BfAiMessage` node with `bfNodeSpec` only (no `gqlSpec`)
+2. Add `role`, `content`, `timestamp` fields
+3. Add edge relationship: `BfAiConversation` → `BfAiMessage`
+4. Remove temporary JSON messages field from `BfAiConversation`
+5. Update registry to include both nodes
+6. Test conversation + message creation and querying via BfDb
+
+**Acceptance Criteria:**
+- Messages stored as separate BfDb nodes
+- Proper relations between conversations and messages work in BfDb
+- Can query messages independently through BfDb
+- Maintains referential integrity
+- Still no GraphQL exposure
+- Happy path tests covering basic relations and message operations
+
+### Phase 3: GraphQL Integration (Future)
+**Goal:** Add GraphQL exposure after BfDb is stable
+
+**Tasks:**
+1. Audit current GraphQL setup and relay connections configuration
+2. Verify existing nodes work properly with relay connections
+3. Add `gqlSpec` to both `BfAiConversation` and `BfAiMessage`
+4. Test GraphQL queries and mutations
+5. Ensure GraphQL relations work properly with relay patterns
+6. Add to GraphQL schema generation
+7. Write happy path GraphQL tests for basic queries and relations
+
+**Acceptance Criteria:**
+- Relay connections properly configured and understood
+- Conversations and messages queryable via GraphQL
+- Relations work in GraphQL context with proper relay patterns
+- Schema properly generated
+- Maintains BfDb functionality
+- Happy path GraphQL tests verify nodes exist and relations work
+
+## File Structure
+
+```
+apps/bfDb/nodeTypes/
+├── BfAiConversation.ts     # New conversation node
+├── BfAiMessage.ts          # New message node
+└── aibff/
+    └── AibffConversation.ts # Keep existing (deprecated)
+```
+
+## Migration Strategy
+
+**No Migration Required:** Starting fresh, existing file-based conversations can remain in place for reference.
+
+**Future Integration:** Once stable, update aibff to use new BfDb nodes instead of file-based system.
+
+## Key Design Decisions
+
+1. **First Real Application BfDb Nodes:** Establish patterns for application-specific nodes beyond content/infrastructure
+2. **Learn from Existing:** Use patterns from BlogPost, PublishedDocument, GithubRepoStats as examples
+3. **Separate Message Nodes:** Enables individual message querying and future relations
+4. **BfDb First, GraphQL Later:** Establish solid BfDb functionality before adding GraphQL complexity
+5. **No Export Initially:** Keep scope focused on core BfDb functionality
+6. **Bf Prefix:** Follow BfDb naming conventions (BfAiConversation vs AibffConversation)
+
+## Success Criteria
+
+- [ ] BfAiConversation and BfAiMessage nodes created and registered
+- [ ] Full CRUD operations working through BfDb
+- [ ] Relations between conversations and messages functional
+- [ ] Performance comparable to current file-based system
+- [ ] Clean patterns established for future BfDb node development
+- [ ] Ready for future aibff integration
+
+## Future Considerations
+
+- Add CurrentViewer integration for multi-tenancy
+- Relate conversations to BfPerson/BfOrganization
+- Add conversation metadata (tags, categories, etc.)
+- Implement search/indexing for conversation content
+- Add export functionality (gzip downloads, markdown format)
+- Add bulk operations for conversation management


### PR DESCRIPTION

Document implementation plan to migrate file-based AibffConversation system
to proper BfDb nodes with structured data storage and relations.

Changes:
- Add comprehensive migration plan for BfAiConversation and BfAiMessage nodes
- Define 3-phase implementation approach: BfDb only, relations, then GraphQL
- Specify node definitions with bfNodeSpec (no gqlSpec initially)
- Document file structure and migration strategy
- Establish patterns for first real application-specific BfDb nodes

Test plan:
1. Review implementation plan structure and phasing
2. Validate node definitions follow BfDb patterns
3. Confirm migration strategy maintains backward compatibility
4. Verify plan establishes good patterns for future BfDb node development

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
