### PR TITLE
Add comprehensive JSDoc documentation to all BfDs components

### DIFF
--- a/.replit
+++ b/.replit
@@ -163,6 +163,14 @@ localPort = 5000
 externalPort = 5000
 
 [[ports]]
+localPort = 5003
+externalPort = 8080
+
+[[ports]]
+localPort = 5007
+externalPort = 8081
+
+[[ports]]
 localPort = 8000
 
 [[ports]]

--- a/apps/bfDs/components/BfDsButton.tsx
+++ b/apps/bfDs/components/BfDsButton.tsx
@@ -9,14 +9,23 @@ export type BfDsButtonVariant =
   | "ghost";
 
 export type BfDsButtonProps = {
+  /** Button content text or elements */
   children?: React.ReactNode;
+  /** Size variant for button */
   size?: BfDsButtonSize;
+  /** Visual style variant */
   variant?: BfDsButtonVariant;
+  /** Disables button interaction */
   disabled?: boolean;
+  /** Click event handler */
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  /** Additional CSS classes */
   className?: string;
+  /** Icon name or custom icon element */
   icon?: BfDsIconName | React.ReactNode;
+  /** Position of icon relative to text */
   iconPosition?: "left" | "right";
+  /** When true, shows only icon without text */
   iconOnly?: boolean;
 } & React.ButtonHTMLAttributes<HTMLButtonElement>;
 

--- a/apps/bfDs/components/BfDsCheckbox.tsx
+++ b/apps/bfDs/components/BfDsCheckbox.tsx
@@ -4,13 +4,26 @@ import { BfDsIcon } from "./BfDsIcon.tsx";
 import { BfDsFormSubmitButton } from "./BfDsFormSubmitButton.tsx";
 
 export type BfDsCheckboxProps = {
+  // Form context props
+  /** Form field name for data binding */
   name?: string;
+
+  // Standalone props
+  /** Whether the checkbox is checked */
   checked?: boolean;
+  /** Callback when check state changes */
   onChange?: (checked: boolean) => void;
+
+  // Common props
+  /** Label text displayed next to checkbox */
   label?: string;
-  disabled?: boolean;
+  /** Required for validation */
   required?: boolean;
+  /** Disables component */
+  disabled?: boolean;
+  /** Additional CSS classes */
   className?: string;
+  /** Element ID */
   id?: string;
 };
 

--- a/apps/bfDs/components/BfDsCheckbox.tsx
+++ b/apps/bfDs/components/BfDsCheckbox.tsx
@@ -1,0 +1,215 @@
+import * as React from "react";
+import { BfDsForm, useBfDsFormContext } from "./BfDsForm.tsx";
+import { BfDsIcon } from "./BfDsIcon.tsx";
+import { BfDsFormSubmitButton } from "./BfDsFormSubmitButton.tsx";
+
+export type BfDsCheckboxProps = {
+  name?: string;
+  checked?: boolean;
+  onChange?: (checked: boolean) => void;
+  label?: string;
+  disabled?: boolean;
+  required?: boolean;
+  className?: string;
+  id?: string;
+};
+
+export function BfDsCheckbox({
+  name,
+  checked,
+  onChange,
+  label,
+  disabled = false,
+  required = false,
+  className,
+  id,
+}: BfDsCheckboxProps) {
+  const formContext = useBfDsFormContext();
+  const isInForm = !!formContext;
+
+  // Use form context if available
+  const actualChecked = isInForm
+    ? (formContext.data as Record<string, unknown>)?.[name || ""] === true
+    : checked || false;
+  const actualOnChange = isInForm
+    ? (newChecked: boolean) => {
+      if (name && formContext.onChange && formContext.data) {
+        formContext.onChange({
+          ...(formContext.data as Record<string, unknown>),
+          [name]: newChecked,
+        });
+      }
+    }
+    : onChange;
+
+  const checkboxClasses = [
+    "bfds-checkbox",
+    actualChecked && "bfds-checkbox--checked",
+    disabled && "bfds-checkbox--disabled",
+    className,
+  ].filter(Boolean).join(" ");
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (actualOnChange) {
+      actualOnChange(e.target.checked);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      if (actualOnChange && !disabled) {
+        actualOnChange(!actualChecked);
+      }
+    }
+  };
+
+  return (
+    <label className="bfds-checkbox-wrapper">
+      <input
+        type="checkbox"
+        id={id}
+        name={name}
+        checked={actualChecked}
+        onChange={handleChange}
+        disabled={disabled}
+        required={required}
+        className="bfds-checkbox-input"
+      />
+      <div
+        className={checkboxClasses}
+        role="checkbox"
+        aria-checked={actualChecked}
+        tabIndex={disabled ? -1 : 0}
+        onKeyDown={handleKeyDown}
+      >
+        {actualChecked && (
+          <BfDsIcon
+            name="check"
+            size="small"
+            className="bfds-checkbox-icon"
+          />
+        )}
+      </div>
+      {label && (
+        <span className="bfds-checkbox-label">
+          {label}
+          {required && <span className="bfds-checkbox-required">*</span>}
+        </span>
+      )}
+    </label>
+  );
+}
+
+BfDsCheckbox.Example = function BfDsCheckboxExample() {
+  const [standaloneChecked, setStandaloneChecked] = React.useState(false);
+  const [formData, setFormData] = React.useState({
+    terms: false,
+    newsletter: false,
+    notifications: false,
+  });
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "32px",
+        padding: "24px",
+        backgroundColor: "var(--bfds-background)",
+        color: "var(--bfds-text)",
+        fontFamily: "system-ui, -apple-system, sans-serif",
+        maxWidth: "600px",
+      }}
+    >
+      <h2>BfDsCheckbox Examples</h2>
+
+      <div>
+        <h3>Standalone Checkbox</h3>
+        <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+          <BfDsCheckbox
+            label="I agree to the terms and conditions"
+            checked={standaloneChecked}
+            onChange={setStandaloneChecked}
+          />
+          <p>Checked: {standaloneChecked ? "Yes" : "No"}</p>
+        </div>
+      </div>
+
+      <div>
+        <h3>With BfDsForm Integration</h3>
+        <BfDsForm
+          initialData={formData}
+          onSubmit={(data) => {
+            alert(`Form submitted: ${JSON.stringify(data, null, 2)}`);
+            setFormData(data);
+          }}
+        >
+          <div
+            style={{ display: "flex", flexDirection: "column", gap: "16px" }}
+          >
+            <BfDsCheckbox
+              name="terms"
+              label="I agree to the terms and conditions"
+              required
+            />
+
+            <BfDsCheckbox
+              name="newsletter"
+              label="Subscribe to newsletter"
+            />
+
+            <BfDsCheckbox
+              name="notifications"
+              label="Enable push notifications"
+            />
+
+            <BfDsFormSubmitButton text="Submit Form" />
+          </div>
+        </BfDsForm>
+      </div>
+
+      <div>
+        <h3>States</h3>
+        <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+          <BfDsCheckbox
+            label="Unchecked"
+            checked={false}
+            onChange={() => {}}
+          />
+
+          <BfDsCheckbox
+            label="Checked"
+            checked
+            onChange={() => {}}
+          />
+
+          <BfDsCheckbox
+            label="Disabled Unchecked"
+            checked={false}
+            disabled
+            onChange={() => {}}
+          />
+
+          <BfDsCheckbox
+            label="Disabled Checked"
+            checked
+            disabled
+            onChange={() => {}}
+          />
+
+          <BfDsCheckbox
+            label="Required"
+            required
+            onChange={() => {}}
+          />
+
+          <BfDsCheckbox
+            label="No Label"
+            onChange={() => {}}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/bfDs/components/BfDsForm.tsx
+++ b/apps/bfDs/components/BfDsForm.tsx
@@ -30,8 +30,11 @@ const BfDsFormContext = createContext<BfDsFormValue<unknown> | null>(null);
 type BfDsFormProps<T = Record<string, string | number | boolean | null>> =
   & React.PropsWithChildren<BfDsFormCallbacks<T>>
   & {
+    /** Initial form data values */
     initialData: T;
+    /** Additional CSS classes */
     className?: string;
+    /** Test ID for testing purposes */
     testId?: string;
   };
 

--- a/apps/bfDs/components/BfDsFormSubmitButton.tsx
+++ b/apps/bfDs/components/BfDsFormSubmitButton.tsx
@@ -4,7 +4,9 @@ import { BfDsButton, type BfDsButtonProps } from "./BfDsButton.tsx";
 export type BfDsFormSubmitButtonProps =
   & Omit<BfDsButtonProps, "type" | "onClick">
   & {
+    /** Button text (defaults to "Submit") */
     text?: string;
+    /** Optional click handler called before form submission */
     onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
   };
 

--- a/apps/bfDs/components/BfDsIcon.tsx
+++ b/apps/bfDs/components/BfDsIcon.tsx
@@ -9,9 +9,13 @@ export type BfDsIconName = keyof typeof icons;
 export type BfDsIconSize = "small" | "medium" | "large";
 
 export type BfDsIconProps = {
+  /** Name of the icon to display */
   name: BfDsIconName;
+  /** Size variant for icon */
   size?: BfDsIconSize;
+  /** Custom color override */
   color?: string;
+  /** Additional CSS classes */
   className?: string;
 } & Omit<React.SVGProps<SVGSVGElement>, "children">;
 

--- a/apps/bfDs/components/BfDsInput.tsx
+++ b/apps/bfDs/components/BfDsInput.tsx
@@ -5,20 +5,31 @@ export type BfDsInputState = "default" | "error" | "success" | "disabled";
 
 export type BfDsInputProps = {
   // Form context props
+  /** Form field name for data binding */
   name?: string;
 
   // Standalone props
+  /** Current input value */
   value?: string;
+  /** Change event handler */
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 
   // Common props
+  /** Label text displayed above input */
   label?: string;
+  /** Placeholder text when empty */
   placeholder?: string;
+  /** Required for validation */
   required?: boolean;
+  /** Visual state of the input */
   state?: BfDsInputState;
+  /** Error message to display */
   errorMessage?: string;
+  /** Success message to display */
   successMessage?: string;
+  /** Help text displayed below input */
   helpText?: string;
+  /** Additional CSS classes */
   className?: string;
 } & Omit<React.InputHTMLAttributes<HTMLInputElement>, "value" | "onChange">;
 

--- a/apps/bfDs/components/BfDsList.tsx
+++ b/apps/bfDs/components/BfDsList.tsx
@@ -1,7 +1,9 @@
 import * as React from "react";
 
 type BfDsListProps = {
+  /** List items (typically BfDsListItem components) */
   children: React.ReactNode;
+  /** Additional CSS classes */
   className?: string;
 };
 

--- a/apps/bfDs/components/BfDsListItem.tsx
+++ b/apps/bfDs/components/BfDsListItem.tsx
@@ -1,10 +1,15 @@
 import * as React from "react";
 
 export type BfDsListItemProps = {
+  /** Content to display in the list item */
   children: React.ReactNode;
+  /** When true, shows active state styling */
   active?: boolean;
+  /** When true, disables interaction and shows disabled styling */
   disabled?: boolean;
+  /** Click handler - when provided, renders as button instead of li */
   onClick?: () => void;
+  /** Additional CSS classes */
   className?: string;
 };
 

--- a/apps/bfDs/components/BfDsRadio.tsx
+++ b/apps/bfDs/components/BfDsRadio.tsx
@@ -3,24 +3,42 @@ import { BfDsForm, useBfDsFormContext } from "./BfDsForm.tsx";
 import { BfDsFormSubmitButton } from "./BfDsFormSubmitButton.tsx";
 
 export type BfDsRadioOption = {
+  /** The value submitted when this option is selected */
   value: string;
+  /** Display text shown for this option */
   label: string;
+  /** When true, this option cannot be selected */
   disabled?: boolean;
 };
 
 export type BfDsRadioSize = "small" | "medium" | "large";
 
 export type BfDsRadioProps = {
+  // Form context props
+  /** Form field name for data binding (required for radio groups) */
   name: string;
+
+  // Standalone props
+  /** Currently selected value */
   value?: string;
+  /** Selection change callback */
   onChange?: (value: string) => void;
+
+  // Common props
+  /** Array of radio button options */
   options: Array<BfDsRadioOption>;
-  disabled?: boolean;
-  required?: boolean;
-  className?: string;
-  orientation?: "vertical" | "horizontal";
-  size?: BfDsRadioSize;
+  /** Group label displayed above radio buttons */
   label?: string;
+  /** Required for validation */
+  required?: boolean;
+  /** Disables entire radio group */
+  disabled?: boolean;
+  /** Layout direction of radio buttons */
+  orientation?: "vertical" | "horizontal";
+  /** Size variant for radio buttons */
+  size?: BfDsRadioSize;
+  /** Additional CSS classes */
+  className?: string;
 };
 
 export function BfDsRadio({

--- a/apps/bfDs/components/BfDsRadio.tsx
+++ b/apps/bfDs/components/BfDsRadio.tsx
@@ -1,0 +1,284 @@
+import * as React from "react";
+import { BfDsForm, useBfDsFormContext } from "./BfDsForm.tsx";
+import { BfDsFormSubmitButton } from "./BfDsFormSubmitButton.tsx";
+
+export type BfDsRadioOption = {
+  value: string;
+  label: string;
+  disabled?: boolean;
+};
+
+export type BfDsRadioSize = "small" | "medium" | "large";
+
+export type BfDsRadioProps = {
+  name: string;
+  value?: string;
+  onChange?: (value: string) => void;
+  options: Array<BfDsRadioOption>;
+  disabled?: boolean;
+  required?: boolean;
+  className?: string;
+  orientation?: "vertical" | "horizontal";
+  size?: BfDsRadioSize;
+  label?: string;
+};
+
+export function BfDsRadio({
+  name,
+  value,
+  onChange,
+  options,
+  disabled = false,
+  required = false,
+  className,
+  orientation = "vertical",
+  size = "medium",
+  label,
+}: BfDsRadioProps) {
+  const formContext = useBfDsFormContext();
+  const isInForm = !!formContext;
+
+  // Use form context if available
+  const actualValue = isInForm
+    ? (formContext.data as Record<string, unknown>)?.[name] as string || ""
+    : value || "";
+  const actualOnChange = isInForm
+    ? (newValue: string) => {
+      if (formContext.onChange && formContext.data) {
+        formContext.onChange({
+          ...(formContext.data as Record<string, unknown>),
+          [name]: newValue,
+        });
+      }
+    }
+    : onChange;
+
+  const radioGroupClasses = [
+    "bfds-radio-group",
+    `bfds-radio-group--${orientation}`,
+    `bfds-radio-group--${size}`,
+    disabled && "bfds-radio-group--disabled",
+    className,
+  ].filter(Boolean).join(" ");
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (actualOnChange) {
+      actualOnChange(e.target.value);
+    }
+  };
+
+  const radioGroupContent = (
+    <div className={radioGroupClasses} role="radiogroup">
+      {options.map((option, index) => {
+        const isChecked = actualValue === option.value;
+        const isDisabled = disabled || option.disabled;
+        const radioId = `${name}-${option.value}`;
+
+        const radioClasses = [
+          "bfds-radio",
+          `bfds-radio--${size}`,
+          isChecked && "bfds-radio--checked",
+          isDisabled && "bfds-radio--disabled",
+        ].filter(Boolean).join(" ");
+
+        return (
+          <label key={option.value} className="bfds-radio-wrapper">
+            <input
+              type="radio"
+              id={radioId}
+              name={name}
+              value={option.value}
+              checked={isChecked}
+              onChange={handleChange}
+              disabled={isDisabled}
+              required={required && index === 0} // Only first radio needs required for validation
+              className="bfds-radio-input"
+            />
+            <div
+              className={radioClasses}
+              role="radio"
+              aria-checked={isChecked}
+            >
+              {isChecked && <div className="bfds-radio-dot" />}
+            </div>
+            <span className="bfds-radio-label">
+              {option.label}
+            </span>
+          </label>
+        );
+      })}
+    </div>
+  );
+
+  if (label) {
+    return (
+      <fieldset className="bfds-radio-fieldset">
+        <legend className="bfds-input-label">
+          {label}
+          {required && <span className="bfds-input-required">*</span>}
+        </legend>
+        {radioGroupContent}
+      </fieldset>
+    );
+  }
+
+  return radioGroupContent;
+}
+
+BfDsRadio.Example = function BfDsRadioExample() {
+  const [standaloneValue, setStandaloneValue] = React.useState("");
+  const [formData, setFormData] = React.useState({
+    size: "",
+    theme: "",
+    plan: "",
+  });
+
+  const sizeOptions: Array<BfDsRadioOption> = [
+    { value: "small", label: "Small" },
+    { value: "medium", label: "Medium" },
+    { value: "large", label: "Large" },
+  ];
+
+  const themeOptions: Array<BfDsRadioOption> = [
+    { value: "light", label: "Light Theme" },
+    { value: "dark", label: "Dark Theme" },
+    { value: "auto", label: "Auto (System)" },
+  ];
+
+  const planOptions: Array<BfDsRadioOption> = [
+    { value: "free", label: "Free Plan" },
+    { value: "pro", label: "Pro Plan" },
+    { value: "enterprise", label: "Enterprise Plan" },
+    { value: "beta", label: "Beta Plan", disabled: true },
+  ];
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "32px",
+        padding: "24px",
+        backgroundColor: "var(--bfds-background)",
+        color: "var(--bfds-text)",
+        fontFamily: "system-ui, -apple-system, sans-serif",
+        maxWidth: "600px",
+      }}
+    >
+      <h2>BfDsRadio Examples</h2>
+
+      <div>
+        <h3>Standalone Radio Group</h3>
+        <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+          <BfDsRadio
+            name="standalone-size"
+            label="Size Selection"
+            options={sizeOptions}
+            value={standaloneValue}
+            onChange={setStandaloneValue}
+            required
+          />
+          <p>Selected: {standaloneValue || "None"}</p>
+        </div>
+      </div>
+
+      <div>
+        <h3>With BfDsForm Integration</h3>
+        <BfDsForm
+          initialData={formData}
+          onSubmit={(data) => {
+            alert(`Form submitted: ${JSON.stringify(data, null, 2)}`);
+            setFormData(data);
+          }}
+        >
+          <div
+            style={{ display: "flex", flexDirection: "column", gap: "16px" }}
+          >
+            <BfDsRadio
+              name="size"
+              label="Size"
+              options={sizeOptions}
+              required
+            />
+
+            <BfDsRadio
+              name="theme"
+              label="Theme"
+              options={themeOptions}
+              orientation="horizontal"
+            />
+
+            <BfDsRadio
+              name="plan"
+              label="Plan"
+              options={planOptions}
+            />
+
+            <BfDsFormSubmitButton text="Submit Form" />
+          </div>
+        </BfDsForm>
+      </div>
+
+      <div>
+        <h3>Orientations</h3>
+        <div style={{ display: "flex", flexDirection: "column", gap: "24px" }}>
+          <BfDsRadio
+            name="vertical-example"
+            label="Vertical Layout (default)"
+            options={themeOptions}
+            orientation="vertical"
+          />
+
+          <BfDsRadio
+            name="horizontal-example"
+            label="Horizontal Layout"
+            options={themeOptions}
+            orientation="horizontal"
+          />
+        </div>
+      </div>
+
+      <div>
+        <h3>Sizes</h3>
+        <div style={{ display: "flex", flexDirection: "column", gap: "24px" }}>
+          <BfDsRadio
+            name="small-example"
+            label="Small Size"
+            options={[{ value: "small", label: "Small" }]}
+            size="small"
+          />
+          <BfDsRadio
+            name="medium-example"
+            label="Medium Size"
+            options={[{ value: "medium", label: "Medium" }]}
+            size="medium"
+          />
+          <BfDsRadio
+            name="large-example"
+            label="Large Size"
+            options={[{ value: "large", label: "Large" }]}
+            size="large"
+          />
+        </div>
+      </div>
+
+      <div>
+        <h3>States</h3>
+        <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+          <BfDsRadio
+            name="disabled-example"
+            label="Disabled Group"
+            options={sizeOptions}
+            disabled
+          />
+
+          <BfDsRadio
+            name="mixed-disabled-example"
+            label="Mixed Disabled Options"
+            options={planOptions}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/bfDs/components/BfDsSelect.tsx
+++ b/apps/bfDs/components/BfDsSelect.tsx
@@ -4,22 +4,40 @@ import { BfDsIcon } from "./BfDsIcon.tsx";
 import { BfDsFormSubmitButton } from "./BfDsFormSubmitButton.tsx";
 
 export type BfDsSelectOption = {
+  /** The value submitted when this option is selected */
   value: string;
+  /** Display text shown for this option */
   label: string;
+  /** When true, this option cannot be selected */
   disabled?: boolean;
 };
 
 export type BfDsSelectProps = {
+  // Form context props
+  /** Form field name for data binding */
   name?: string;
+
+  // Standalone props
+  /** Currently selected value */
   value?: string;
+  /** Selection change callback */
   onChange?: (value: string) => void;
+
+  // Common props
+  /** Array of selectable options */
   options: Array<BfDsSelectOption>;
+  /** Placeholder when nothing selected */
   placeholder?: string;
-  disabled?: boolean;
-  required?: boolean;
-  className?: string;
-  id?: string;
+  /** Field label */
   label?: string;
+  /** Required for validation */
+  required?: boolean;
+  /** Disables component */
+  disabled?: boolean;
+  /** Additional CSS classes */
+  className?: string;
+  /** Element ID */
+  id?: string;
 };
 
 export function BfDsSelect({

--- a/apps/bfDs/components/BfDsSelect.tsx
+++ b/apps/bfDs/components/BfDsSelect.tsx
@@ -1,0 +1,242 @@
+import * as React from "react";
+import { BfDsForm, useBfDsFormContext } from "./BfDsForm.tsx";
+import { BfDsIcon } from "./BfDsIcon.tsx";
+import { BfDsFormSubmitButton } from "./BfDsFormSubmitButton.tsx";
+
+export type BfDsSelectOption = {
+  value: string;
+  label: string;
+  disabled?: boolean;
+};
+
+export type BfDsSelectProps = {
+  name?: string;
+  value?: string;
+  onChange?: (value: string) => void;
+  options: Array<BfDsSelectOption>;
+  placeholder?: string;
+  disabled?: boolean;
+  required?: boolean;
+  className?: string;
+  id?: string;
+  label?: string;
+};
+
+export function BfDsSelect({
+  name,
+  value,
+  onChange,
+  options,
+  placeholder = "Select...",
+  disabled = false,
+  required = false,
+  className,
+  id,
+  label,
+}: BfDsSelectProps) {
+  const formContext = useBfDsFormContext();
+  const isInForm = !!formContext;
+  const selectId = id || React.useId();
+
+  // Use form context if available
+  const actualValue = isInForm
+    ? (formContext.data as Record<string, unknown>)?.[name || ""] as string ||
+      ""
+    : value || "";
+  const actualOnChange = isInForm
+    ? (newValue: string) => {
+      if (name && formContext.onChange && formContext.data) {
+        formContext.onChange({
+          ...(formContext.data as Record<string, unknown>),
+          [name]: newValue,
+        });
+      }
+    }
+    : onChange;
+
+  const selectClasses = [
+    "bfds-select",
+    disabled && "bfds-select--disabled",
+    className,
+  ].filter(Boolean).join(" ");
+
+  const containerClasses = [
+    "bfds-select-container",
+    disabled && "bfds-select-container--disabled",
+  ].filter(Boolean).join(" ");
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    if (actualOnChange) {
+      actualOnChange(e.target.value);
+    }
+  };
+
+  return (
+    <div className={containerClasses}>
+      {label && (
+        <label htmlFor={selectId} className="bfds-select-label">
+          {label}
+          {required && <span className="bfds-select-required">*</span>}
+        </label>
+      )}
+      <div className="bfds-select-wrapper">
+        <select
+          id={selectId}
+          name={name}
+          value={actualValue}
+          onChange={handleChange}
+          disabled={disabled}
+          required={required}
+          className={selectClasses}
+        >
+          {placeholder && (
+            <option value="" disabled>
+              {placeholder}
+            </option>
+          )}
+          {options.map((option) => (
+            <option
+              key={option.value}
+              value={option.value}
+              disabled={option.disabled}
+            >
+              {option.label}
+            </option>
+          ))}
+        </select>
+        <BfDsIcon
+          name="triangleDown"
+          size="small"
+          className="bfds-select-icon"
+        />
+      </div>
+    </div>
+  );
+}
+
+BfDsSelect.Example = function BfDsSelectExample() {
+  const [standaloneValue, setStandaloneValue] = React.useState("");
+  const [formData, setFormData] = React.useState({
+    country: "",
+    size: "",
+    priority: "",
+  });
+
+  const countryOptions: Array<BfDsSelectOption> = [
+    { value: "us", label: "United States" },
+    { value: "ca", label: "Canada" },
+    { value: "uk", label: "United Kingdom" },
+    { value: "de", label: "Germany" },
+    { value: "fr", label: "France" },
+  ];
+
+  const sizeOptions: Array<BfDsSelectOption> = [
+    { value: "xs", label: "Extra Small" },
+    { value: "s", label: "Small" },
+    { value: "m", label: "Medium" },
+    { value: "l", label: "Large" },
+    { value: "xl", label: "Extra Large" },
+  ];
+
+  const priorityOptions: Array<BfDsSelectOption> = [
+    { value: "low", label: "Low Priority" },
+    { value: "medium", label: "Medium Priority" },
+    { value: "high", label: "High Priority" },
+    { value: "urgent", label: "Urgent", disabled: true },
+  ];
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "32px",
+        padding: "24px",
+        backgroundColor: "var(--bfds-background)",
+        color: "var(--bfds-text)",
+        fontFamily: "system-ui, -apple-system, sans-serif",
+        maxWidth: "600px",
+      }}
+    >
+      <h2>BfDsSelect Examples</h2>
+
+      <div>
+        <h3>Standalone Select</h3>
+        <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+          <BfDsSelect
+            label="Country"
+            options={countryOptions}
+            value={standaloneValue}
+            onChange={setStandaloneValue}
+            placeholder="Choose a country"
+          />
+          <p>Selected: {standaloneValue || "None"}</p>
+        </div>
+      </div>
+
+      <div>
+        <h3>With BfDsForm Integration</h3>
+        <BfDsForm
+          initialData={formData}
+          onSubmit={(data) => {
+            alert(`Form submitted: ${JSON.stringify(data, null, 2)}`);
+            setFormData(data);
+          }}
+        >
+          <div
+            style={{ display: "flex", flexDirection: "column", gap: "16px" }}
+          >
+            <BfDsSelect
+              name="country"
+              label="Country"
+              options={countryOptions}
+              placeholder="Select country"
+              required
+            />
+
+            <BfDsSelect
+              name="size"
+              label="Size"
+              options={sizeOptions}
+              placeholder="Select size"
+            />
+
+            <BfDsSelect
+              name="priority"
+              label="Priority"
+              options={priorityOptions}
+              placeholder="Select priority"
+            />
+
+            <BfDsFormSubmitButton text="Submit Form" />
+          </div>
+        </BfDsForm>
+      </div>
+
+      <div>
+        <h3>States</h3>
+        <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+          <BfDsSelect
+            label="Disabled"
+            options={countryOptions}
+            placeholder="This is disabled"
+            disabled
+          />
+
+          <BfDsSelect
+            label="Required"
+            options={countryOptions}
+            placeholder="This is required"
+            required
+          />
+
+          <BfDsSelect
+            label="With Disabled Options"
+            options={priorityOptions}
+            placeholder="Some options disabled"
+          />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/bfDs/components/BfDsTabs.tsx
+++ b/apps/bfDs/components/BfDsTabs.tsx
@@ -2,21 +2,34 @@ import * as React from "react";
 import { BfDsIcon, type BfDsIconName } from "./BfDsIcon.tsx";
 
 export type BfDsTabItem = {
+  /** Unique identifier for the tab */
   id: string;
+  /** Display text for the tab */
   label: string;
+  /** Content to show when tab is active */
   content: React.ReactNode;
+  /** Optional icon to display in tab */
   icon?: BfDsIconName;
+  /** When true, tab cannot be selected */
   disabled?: boolean;
+  /** Optional nested subtabs */
   subtabs?: Array<BfDsTabItem>;
 };
 
 export type BfDsTabsProps = {
+  /** Array of tab items to display */
   tabs: Array<BfDsTabItem>;
+  /** Currently active tab ID (controlled) */
   activeTab?: string;
+  /** Default active tab ID (uncontrolled) */
   defaultActiveTab?: string;
+  /** Callback when tab selection changes */
   onTabChange?: (tabId: string) => void;
+  /** Additional CSS classes */
   className?: string;
+  /** Visual style variant */
   variant?: "primary" | "secondary";
+  /** Size variant for tabs */
   size?: "small" | "medium" | "large";
 };
 

--- a/apps/bfDs/components/BfDsTextArea.tsx
+++ b/apps/bfDs/components/BfDsTextArea.tsx
@@ -6,21 +6,33 @@ export type BfDsTextAreaState = "default" | "error" | "success" | "disabled";
 export type BfDsTextAreaProps =
   & {
     // Form context props
+    /** Form field name for data binding */
     name?: string;
 
     // Standalone props
+    /** Current textarea value */
     value?: string;
+    /** Change event handler */
     onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
 
     // Common props
+    /** Label text displayed above textarea */
     label?: string;
+    /** Placeholder text when empty */
     placeholder?: string;
+    /** Required for validation */
     required?: boolean;
+    /** Visual state of the textarea */
     state?: BfDsTextAreaState;
+    /** Error message to display */
     errorMessage?: string;
+    /** Success message to display */
     successMessage?: string;
+    /** Help text displayed below textarea */
     helpText?: string;
+    /** Additional CSS classes */
     className?: string;
+    /** Resize behavior for textarea */
     resize?: "none" | "both" | "horizontal" | "vertical";
   }
   & Omit<

--- a/apps/bfDs/components/BfDsToggle.tsx
+++ b/apps/bfDs/components/BfDsToggle.tsx
@@ -1,0 +1,241 @@
+import * as React from "react";
+import { BfDsForm, useBfDsFormContext } from "./BfDsForm.tsx";
+import { BfDsFormSubmitButton } from "./BfDsFormSubmitButton.tsx";
+
+export type BfDsToggleSize = "small" | "medium" | "large";
+
+export type BfDsToggleProps = {
+  name?: string;
+  checked?: boolean;
+  onChange?: (checked: boolean) => void;
+  label?: string;
+  disabled?: boolean;
+  required?: boolean;
+  className?: string;
+  id?: string;
+  size?: BfDsToggleSize;
+};
+
+export function BfDsToggle({
+  name,
+  checked,
+  onChange,
+  label,
+  disabled = false,
+  required = false,
+  className,
+  id,
+  size = "medium",
+}: BfDsToggleProps) {
+  const formContext = useBfDsFormContext();
+  const isInForm = !!formContext;
+
+  // Use form context if available
+  const actualChecked = isInForm
+    ? (formContext.data as Record<string, unknown>)?.[name || ""] === true
+    : checked || false;
+  const actualOnChange = isInForm
+    ? (newChecked: boolean) => {
+      if (name && formContext.onChange && formContext.data) {
+        formContext.onChange({
+          ...(formContext.data as Record<string, unknown>),
+          [name]: newChecked,
+        });
+      }
+    }
+    : onChange;
+
+  const toggleClasses = [
+    "bfds-toggle",
+    `bfds-toggle--${size}`,
+    actualChecked && "bfds-toggle--checked",
+    disabled && "bfds-toggle--disabled",
+    className,
+  ].filter(Boolean).join(" ");
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (actualOnChange) {
+      actualOnChange(e.target.checked);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      if (actualOnChange && !disabled) {
+        actualOnChange(!actualChecked);
+      }
+    }
+  };
+
+  return (
+    <label className="bfds-toggle-wrapper">
+      <input
+        type="checkbox"
+        id={id}
+        name={name}
+        checked={actualChecked}
+        onChange={handleChange}
+        disabled={disabled}
+        required={required}
+        className="bfds-toggle-input"
+      />
+      <div
+        className={toggleClasses}
+        role="switch"
+        aria-checked={actualChecked}
+        tabIndex={disabled ? -1 : 0}
+        onKeyDown={handleKeyDown}
+      >
+        <div className="bfds-toggle-track">
+          <div className="bfds-toggle-thumb" />
+        </div>
+      </div>
+      {label && (
+        <span className="bfds-toggle-label">
+          {label}
+          {required && <span className="bfds-toggle-required">*</span>}
+        </span>
+      )}
+    </label>
+  );
+}
+
+BfDsToggle.Example = function BfDsToggleExample() {
+  const [standaloneChecked, setStandaloneChecked] = React.useState(false);
+  const [formData, setFormData] = React.useState({
+    darkMode: false,
+    notifications: false,
+    autoSave: false,
+  });
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "32px",
+        padding: "24px",
+        backgroundColor: "var(--bfds-background)",
+        color: "var(--bfds-text)",
+        fontFamily: "system-ui, -apple-system, sans-serif",
+        maxWidth: "600px",
+      }}
+    >
+      <h2>BfDsToggle Examples</h2>
+
+      <div>
+        <h3>Standalone Toggle</h3>
+        <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+          <BfDsToggle
+            label="Enable feature"
+            checked={standaloneChecked}
+            onChange={setStandaloneChecked}
+          />
+          <p>Checked: {standaloneChecked ? "Yes" : "No"}</p>
+        </div>
+      </div>
+
+      <div>
+        <h3>With BfDsForm Integration</h3>
+        <BfDsForm
+          initialData={formData}
+          onSubmit={(data) => {
+            alert(`Form submitted: ${JSON.stringify(data, null, 2)}`);
+            setFormData(data);
+          }}
+        >
+          <div
+            style={{ display: "flex", flexDirection: "column", gap: "16px" }}
+          >
+            <BfDsToggle
+              name="darkMode"
+              label="Dark mode"
+            />
+
+            <BfDsToggle
+              name="notifications"
+              label="Push notifications"
+            />
+
+            <BfDsToggle
+              name="autoSave"
+              label="Auto-save documents"
+              required
+            />
+
+            <BfDsFormSubmitButton text="Submit Form" />
+          </div>
+        </BfDsForm>
+      </div>
+
+      <div>
+        <h3>Sizes</h3>
+        <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+          <BfDsToggle
+            label="Small toggle"
+            size="small"
+            checked
+            onChange={() => {}}
+          />
+
+          <BfDsToggle
+            label="Medium toggle (default)"
+            size="medium"
+            checked
+            onChange={() => {}}
+          />
+
+          <BfDsToggle
+            label="Large toggle"
+            size="large"
+            checked
+            onChange={() => {}}
+          />
+        </div>
+      </div>
+
+      <div>
+        <h3>States</h3>
+        <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+          <BfDsToggle
+            label="Unchecked"
+            checked={false}
+            onChange={() => {}}
+          />
+
+          <BfDsToggle
+            label="Checked"
+            checked
+            onChange={() => {}}
+          />
+
+          <BfDsToggle
+            label="Disabled Unchecked"
+            checked={false}
+            disabled
+            onChange={() => {}}
+          />
+
+          <BfDsToggle
+            label="Disabled Checked"
+            checked
+            disabled
+            onChange={() => {}}
+          />
+
+          <BfDsToggle
+            label="Required"
+            required
+            onChange={() => {}}
+          />
+
+          <BfDsToggle
+            label="No Label"
+            onChange={() => {}}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/bfDs/components/BfDsToggle.tsx
+++ b/apps/bfDs/components/BfDsToggle.tsx
@@ -5,15 +5,29 @@ import { BfDsFormSubmitButton } from "./BfDsFormSubmitButton.tsx";
 export type BfDsToggleSize = "small" | "medium" | "large";
 
 export type BfDsToggleProps = {
+  // Form context props
+  /** Form field name for data binding */
   name?: string;
+
+  // Standalone props
+  /** Whether the toggle is on/off */
   checked?: boolean;
+  /** Callback when toggle state changes */
   onChange?: (checked: boolean) => void;
+
+  // Common props
+  /** Label text displayed next to toggle */
   label?: string;
-  disabled?: boolean;
+  /** Required for validation */
   required?: boolean;
-  className?: string;
-  id?: string;
+  /** Disables component */
+  disabled?: boolean;
+  /** Size variant for toggle switch */
   size?: BfDsToggleSize;
+  /** Additional CSS classes */
+  className?: string;
+  /** Element ID */
+  id?: string;
 };
 
 export function BfDsToggle({

--- a/apps/bfDs/demo/Demo.tsx
+++ b/apps/bfDs/demo/Demo.tsx
@@ -8,6 +8,10 @@ import { BfDsTextArea } from "../components/BfDsTextArea.tsx";
 import { BfDsFormSubmitButton } from "../components/BfDsFormSubmitButton.tsx";
 import { BfDsList } from "../components/BfDsList.tsx";
 import { BfDsListItem } from "../components/BfDsListItem.tsx";
+import { BfDsSelect } from "../components/BfDsSelect.tsx";
+import { BfDsCheckbox } from "../components/BfDsCheckbox.tsx";
+import { BfDsRadio } from "../components/BfDsRadio.tsx";
+import { BfDsToggle } from "../components/BfDsToggle.tsx";
 
 type ComponentSection = {
   id: string;
@@ -80,6 +84,34 @@ const componentSections: Array<ComponentSection> = [
     description: "Individual list items with states and interactions",
     component: BfDsListItem.Example,
     category: "Navigation",
+  },
+  {
+    id: "select",
+    name: "Select",
+    description: "Dropdown selectors with form integration",
+    component: BfDsSelect.Example,
+    category: "Form",
+  },
+  {
+    id: "checkbox",
+    name: "Checkbox",
+    description: "Checkboxes with form integration and accessibility",
+    component: BfDsCheckbox.Example,
+    category: "Form",
+  },
+  {
+    id: "radio",
+    name: "Radio",
+    description: "Radio button groups with flexible layouts",
+    component: BfDsRadio.Example,
+    category: "Form",
+  },
+  {
+    id: "toggle",
+    name: "Toggle",
+    description: "Toggle switches with smooth animations and sizes",
+    component: BfDsToggle.Example,
+    category: "Form",
   },
 ];
 

--- a/apps/bfDs/index.ts
+++ b/apps/bfDs/index.ts
@@ -48,3 +48,25 @@ export { BfDsList } from "./components/BfDsList.tsx";
 
 export { BfDsListItem } from "./components/BfDsListItem.tsx";
 export type { BfDsListItemProps } from "./components/BfDsListItem.tsx";
+
+export { BfDsSelect } from "./components/BfDsSelect.tsx";
+export type {
+  BfDsSelectOption,
+  BfDsSelectProps,
+} from "./components/BfDsSelect.tsx";
+
+export { BfDsCheckbox } from "./components/BfDsCheckbox.tsx";
+export type { BfDsCheckboxProps } from "./components/BfDsCheckbox.tsx";
+
+export { BfDsRadio } from "./components/BfDsRadio.tsx";
+export type {
+  BfDsRadioOption,
+  BfDsRadioProps,
+  BfDsRadioSize,
+} from "./components/BfDsRadio.tsx";
+
+export { BfDsToggle } from "./components/BfDsToggle.tsx";
+export type {
+  BfDsToggleProps,
+  BfDsToggleSize,
+} from "./components/BfDsToggle.tsx";

--- a/apps/bfDs/memos/plans/2025-06-23-bfds-lite-creation.md
+++ b/apps/bfDs/memos/plans/2025-06-23-bfds-lite-creation.md
@@ -187,6 +187,16 @@ CSS: static/bfDsStyle.css (comprehensive styling with form states)
    and adapt between standalone and form-integrated modes
 10. **Form state management**: Centralized form context with TypeScript-safe
     data handling and error management
+11. **JSDoc documentation style**: Comprehensive inline documentation using
+    JSDoc comments for all component props with organized structure for form
+    components:
+    - **Form context props**: Props used for form integration (`name`)
+    - **Standalone props**: Props for controlled component usage (`value`,
+      `onChange`)
+    - **Common props**: Shared props for styling and behavior (`label`,
+      `disabled`, etc.)
+    - **Developer experience**: Documentation appears in VS Code IntelliSense
+      and TypeScript hover tooltips without runtime overhead or build complexity
 
 ## Next Steps
 

--- a/apps/bfDs/memos/plans/2025-06-23-bfds-lite-creation.md
+++ b/apps/bfDs/memos/plans/2025-06-23-bfds-lite-creation.md
@@ -72,12 +72,30 @@ as part of the 2025-06-25 design system migration.
     usage
   - **TypeScript-first**: Strong typing with proper form data integration
   - **Complete accessibility**: ARIA attributes and semantic HTML
+- [x] **BfDsList** and **BfDsListItem** components with:
+  - **BfDsList**: Simple `<ul>` wrapper with optional className
+  - **BfDsListItem**: Smart list item that renders as `<li>` or `<button>` based
+    on onClick prop
+  - **States**: active, disabled, clickable (auto-detected from onClick)
+  - **TypeScript safety**: Proper prop typing
+  - **Semantic HTML**: Uses appropriate element types
+- [x] **BfDsSelect**, **BfDsCheckbox**, **BfDsRadio**, and **BfDsToggle**
+      components with:
+  - **BfDsSelect**: Dropdown selector with form integration and disabled options
+  - **BfDsCheckbox**: Checkbox with keyboard navigation and ARIA support
+  - **BfDsRadio**: Radio button groups with flexible layouts and sizes
+  - **BfDsToggle**: Toggle switch with smooth animations and multiple sizes
+  - **Full form integration**: All components work with BfDsForm context
+  - **Accessibility**: ARIA attributes, keyboard navigation, semantic HTML
+  - **Multiple states**: disabled, required, checked/unchecked variants
+  - **TypeScript-first**: Strong typing with proper prop interfaces
 - [x] CSS variables system for theming with additional form states (error,
       success, focus)
 - [x] Example component pattern (`Component.Example`)
-- [x] Demo page setup with Button, Icon, Tabs, and Form examples
+- [x] Demo page setup with Button, Icon, Tabs, Form, List, Select, Checkbox,
+      Radio, and Toggle examples
 - [x] CSS moved to static folder (per system requirements)
-- [x] Main index.ts exports with all form components
+- [x] Main index.ts exports with all components
 - [x] Icon library moved to `lib/icons.ts`
 
 ### 🔄 In Progress
@@ -90,11 +108,25 @@ as part of the 2025-06-25 design system migration.
   - [x] ~~Input/TextField~~ ✅ **Completed** (BfDsInput with dual-mode
         operation)
   - [x] ~~TextArea~~ ✅ **Completed** (BfDsTextArea with resize options)
-  - [ ] Select/Dropdown
-  - [ ] Checkbox
-  - [ ] Radio
+  - [x] ~~List/ListItem~~ ✅ **Completed** (BfDsList and BfDsListItem with basic
+        states)
+  - [x] ~~Select/Dropdown~~ ✅ **Completed** (BfDsSelect with form integration)
+  - [x] ~~Checkbox~~ ✅ **Completed** (BfDsCheckbox with accessibility)
+  - [x] ~~Radio~~ ✅ **Completed** (BfDsRadio with flexible layouts)
+  - [x] ~~Toggle~~ ✅ **Completed** (BfDsToggle with smooth animations)
   - [ ] Modal
   - [ ] Toast/Notification
+- [ ] Enhanced List components:
+  - [ ] Icon support in BfDsListItem
+  - [ ] Multiple layout orientations (horizontal/vertical)
+  - [ ] Nested list support
+  - [ ] Drag and drop functionality
+  - [ ] Keyboard navigation (arrow keys)
+  - [ ] Multi-select capabilities
+  - [ ] Search/filter integration
+  - [ ] Virtual scrolling for large lists
+  - [ ] Sortable list items
+  - [ ] Expandable/collapsible list sections
 - [ ] Layout components:
   - [ ] Container
   - [ ] Grid
@@ -116,7 +148,13 @@ apps/bfDs/
 │   ├── BfDsForm.tsx (with .Example and context provider)
 │   ├── BfDsInput.tsx (with .Example and dual-mode operation)
 │   ├── BfDsTextArea.tsx (with .Example and resize options)
-│   └── BfDsFormSubmitButton.tsx (with .Example and form integration)
+│   ├── BfDsFormSubmitButton.tsx (with .Example and form integration)
+│   ├── BfDsList.tsx (with .Example)
+│   ├── BfDsListItem.tsx (with .Example)
+│   ├── BfDsSelect.tsx (with .Example and form integration)
+│   ├── BfDsCheckbox.tsx (with .Example and accessibility)
+│   ├── BfDsRadio.tsx (with .Example and flexible layouts)
+│   └── BfDsToggle.tsx (with .Example and animations)
 ├── lib/
 │   └── icons.ts (80+ icon definitions)
 ├── demo/
@@ -186,6 +224,19 @@ CSS: static/bfDsStyle.css (comprehensive styling with form states)
 - ✅ **Comprehensive examples** demonstrating both standalone and form context
   usage
 - ✅ **Production ready** with successful PRs submitted and integrated
+
+## Recent Achievements (2025-07-02)
+
+- ✅ **Four additional form components completed** expanding the design system
+- ✅ **BfDsSelect component** with dropdown functionality and form integration
+- ✅ **BfDsCheckbox component** with keyboard navigation and ARIA support
+- ✅ **BfDsRadio component** with flexible layouts, sizes, and fieldset support
+- ✅ **BfDsToggle component** with smooth animations and multiple sizes
+- ✅ **Enhanced demo integration** showcasing all new components
+- ✅ **Comprehensive CSS styling** for all form input states and interactions
+- ✅ **Full TypeScript typing** with proper prop interfaces and option types
+- ✅ **Accessibility compliance** with semantic HTML and keyboard navigation
+- ✅ **Form context integration** for all components with automatic detection
 
 ## Notes
 

--- a/static/bfDsStyle.css
+++ b/static/bfDsStyle.css
@@ -666,3 +666,456 @@
   align-items: center;
   gap: 4px;
 }
+
+/* Select */
+
+.bfds-select-container {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+}
+
+.bfds-select-label {
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--bfds-text);
+  line-height: 1.4;
+}
+
+.bfds-select-required {
+  color: var(--bfds-error);
+  margin-left: 2px;
+}
+
+.bfds-select-container--disabled .bfds-select-label {
+  opacity: 0.6;
+}
+
+.bfds-select-wrapper {
+  position: relative;
+  display: inline-block;
+  width: 100%;
+}
+
+.bfds-select {
+  display: block;
+  width: 100%;
+  padding: 12px 40px 12px 16px;
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.4;
+  color: var(--bfds-text);
+  background-color: var(--bfds-background);
+  border: 1px solid var(--bfds-border);
+  border-radius: 6px;
+  cursor: pointer;
+  outline: none;
+  transition: all 0.2s ease-in-out;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+}
+
+.bfds-select:hover:not(:disabled) {
+  border-color: var(--bfds-border-hover);
+}
+
+.bfds-select:focus {
+  border-color: var(--bfds-focus);
+  box-shadow: 0 0 0 3px var(--bfds-focus-outline);
+}
+
+.bfds-select--disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  background-color: var(--bfds-background-hover);
+}
+
+.bfds-select-icon {
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  color: var(--bfds-text-secondary);
+}
+
+.bfds-select--disabled + .bfds-select-icon {
+  opacity: 0.6;
+}
+
+/* Checkbox */
+
+.bfds-checkbox-wrapper {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.4;
+  color: var(--bfds-text);
+}
+
+.bfds-checkbox-input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.bfds-checkbox {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border: 1px solid var(--bfds-border);
+  border-radius: 3px;
+  background-color: var(--bfds-background);
+  transition: all 0.2s ease-in-out;
+  cursor: pointer;
+}
+
+.bfds-checkbox:hover:not(.bfds-checkbox--disabled) {
+  border-color: var(--bfds-border-hover);
+}
+
+.bfds-checkbox:focus-visible {
+  outline: 2px solid var(--bfds-focus);
+  outline-offset: 2px;
+}
+
+.bfds-checkbox--checked {
+  border-color: var(--bfds-primary);
+  background-color: var(--bfds-primary);
+}
+
+.bfds-checkbox--checked:hover:not(.bfds-checkbox--disabled) {
+  border-color: var(--bfds-primary-hover);
+  background-color: var(--bfds-primary-hover);
+}
+
+.bfds-checkbox--disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  background-color: var(--bfds-background-hover);
+}
+
+.bfds-checkbox-icon {
+  color: var(--bfds-background);
+}
+
+.bfds-checkbox-label {
+  user-select: none;
+}
+
+.bfds-checkbox-required {
+  color: var(--bfds-error);
+}
+
+.bfds-checkbox-wrapper:has(.bfds-checkbox--disabled) {
+  cursor: not-allowed;
+}
+
+.bfds-checkbox-wrapper:has(.bfds-checkbox--disabled) .bfds-checkbox-label {
+  opacity: 0.6;
+}
+
+/* Radio */
+
+.bfds-radio-group {
+  display: flex;
+  gap: 16px;
+}
+
+.bfds-radio-group--vertical {
+  flex-direction: column;
+}
+
+.bfds-radio-group--horizontal {
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+
+.bfds-radio-group--disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.bfds-radio-wrapper {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.4;
+  color: var(--bfds-text);
+}
+
+.bfds-radio-input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.bfds-radio {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border: 1px solid var(--bfds-border);
+  border-radius: 50%;
+  background-color: var(--bfds-background);
+  transition: all 0.2s ease-in-out;
+  cursor: pointer;
+  position: relative;
+}
+
+.bfds-radio:hover:not(.bfds-radio--disabled) {
+  border-color: var(--bfds-border-hover);
+}
+
+.bfds-radio:focus-visible {
+  outline: 2px solid var(--bfds-focus);
+  outline-offset: 2px;
+}
+
+.bfds-radio--checked {
+  border-color: var(--bfds-primary);
+}
+
+.bfds-radio--checked:hover:not(.bfds-radio--disabled) {
+  border-color: var(--bfds-primary-hover);
+}
+
+.bfds-radio--disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  background-color: var(--bfds-background-hover);
+}
+
+.bfds-radio-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: var(--bfds-primary);
+  transition: all 0.2s ease-in-out;
+}
+
+.bfds-radio--disabled .bfds-radio-dot {
+  background-color: var(--bfds-text-muted);
+}
+
+.bfds-radio-label {
+  user-select: none;
+}
+
+.bfds-radio-wrapper:has(.bfds-radio--disabled) {
+  cursor: not-allowed;
+}
+
+.bfds-radio-wrapper:has(.bfds-radio--disabled) .bfds-radio-label {
+  opacity: 0.6;
+}
+
+/* Radio sizes */
+.bfds-radio-group--small .bfds-radio-wrapper {
+  font-size: 12px;
+  gap: 6px;
+}
+
+.bfds-radio-group--small .bfds-radio {
+  width: 12px;
+  height: 12px;
+}
+
+.bfds-radio-group--small .bfds-radio-dot {
+  width: 6px;
+  height: 6px;
+}
+
+.bfds-radio-group--medium .bfds-radio-wrapper {
+  font-size: 14px;
+  gap: 8px;
+}
+
+.bfds-radio-group--medium .bfds-radio {
+  width: 16px;
+  height: 16px;
+}
+
+.bfds-radio-group--medium .bfds-radio-dot {
+  width: 8px;
+  height: 8px;
+}
+
+.bfds-radio-group--large .bfds-radio-wrapper {
+  font-size: 16px;
+  gap: 10px;
+}
+
+.bfds-radio-group--large .bfds-radio {
+  width: 20px;
+  height: 20px;
+}
+
+.bfds-radio-group--large .bfds-radio-dot {
+  width: 10px;
+  height: 10px;
+}
+
+/* Radio fieldset */
+.bfds-radio-fieldset {
+  border: 1px solid var(--bfds-border);
+  border-radius: 6px;
+  background-color: var(--bfds-background);
+  padding: 16px;
+  margin: 0;
+  transition: all 0.2s ease-in-out;
+}
+
+.bfds-radio-fieldset:hover {
+  border-color: var(--bfds-border-hover);
+}
+
+.bfds-radio-fieldset:focus-within {
+  border-color: var(--bfds-focus);
+  box-shadow: 0 0 0 3px var(--bfds-focus-outline);
+}
+
+/* Toggle */
+
+.bfds-toggle-wrapper {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.4;
+  color: var(--bfds-text);
+}
+
+.bfds-toggle-input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.bfds-toggle {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+}
+
+.bfds-toggle:focus-visible {
+  outline: 2px solid var(--bfds-focus);
+  outline-offset: 2px;
+}
+
+.bfds-toggle-track {
+  position: relative;
+  background-color: var(--bfds-secondary);
+  border-radius: 12px;
+  transition: all 0.2s ease-in-out;
+  cursor: pointer;
+}
+
+.bfds-toggle--checked .bfds-toggle-track {
+  background-color: var(--bfds-primary);
+}
+
+.bfds-toggle--disabled .bfds-toggle-track {
+  opacity: 0.6;
+  cursor: not-allowed;
+  background-color: var(--bfds-background-hover);
+}
+
+.bfds-toggle-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  background-color: var(--bfds-text);
+  border-radius: 50%;
+  transition: all 0.2s ease-in-out;
+  cursor: pointer;
+}
+
+.bfds-toggle--checked .bfds-toggle-thumb {
+  background-color: var(--bfds-background);
+}
+
+.bfds-toggle--disabled .bfds-toggle-thumb {
+  background-color: var(--bfds-text-muted);
+}
+
+.bfds-toggle-label {
+  user-select: none;
+}
+
+.bfds-toggle-required {
+  color: var(--bfds-error);
+}
+
+.bfds-toggle-wrapper:has(.bfds-toggle--disabled) {
+  cursor: not-allowed;
+}
+
+.bfds-toggle-wrapper:has(.bfds-toggle--disabled) .bfds-toggle-label {
+  opacity: 0.6;
+}
+
+/* Toggle sizes */
+.bfds-toggle--small .bfds-toggle-track {
+  width: 32px;
+  height: 16px;
+}
+
+.bfds-toggle--small .bfds-toggle-thumb {
+  width: 12px;
+  height: 12px;
+}
+
+.bfds-toggle--small.bfds-toggle--checked .bfds-toggle-thumb {
+  transform: translateX(16px);
+}
+
+.bfds-toggle--medium .bfds-toggle-track {
+  width: 40px;
+  height: 20px;
+}
+
+.bfds-toggle--medium .bfds-toggle-thumb {
+  width: 16px;
+  height: 16px;
+}
+
+.bfds-toggle--medium.bfds-toggle--checked .bfds-toggle-thumb {
+  transform: translateX(20px);
+}
+
+.bfds-toggle--large .bfds-toggle-track {
+  width: 48px;
+  height: 24px;
+}
+
+.bfds-toggle--large .bfds-toggle-thumb {
+  width: 20px;
+  height: 20px;
+}
+
+.bfds-toggle--large.bfds-toggle--checked .bfds-toggle-thumb {
+  transform: translateX(24px);
+}


### PR DESCRIPTION

Enhance developer experience with inline documentation that appears in VS Code
IntelliSense and TypeScript hover tooltips without runtime overhead.

Documentation style:
- Concise JSDoc comments for all component props and types
- Organized structure for form components (Form context / Standalone / Common props)
- Clear descriptions of prop purposes and expected values
- TypeScript-safe documentation that stays in sync with code

Components documented:
- Form components: BfDsInput, BfDsTextArea, BfDsSelect, BfDsCheckbox, BfDsRadio, BfDsToggle
- UI components: BfDsButton, BfDsIcon, BfDsTabs, BfDsList, BfDsListItem
- Form utilities: BfDsForm, BfDsFormSubmitButton

Benefits:
- No build complexity or external dependencies required
- Documentation appears automatically in TypeScript-aware editors
- Maintains consistency across the entire design system
- Improves onboarding for new developers using the components

Test plan:
1. Open any component file in VS Code
2. Hover over props to see JSDoc documentation
3. Use component in another file to see IntelliSense documentation
4. Verify no runtime impact on component usage

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/1324).
* #1328
* __->__ #1324
* #1323