### PR TITLE
Remove required prop from BfDsToggle component

### DIFF
--- a/apps/bfDs/components/BfDsCallout.tsx
+++ b/apps/bfDs/components/BfDsCallout.tsx
@@ -1,0 +1,272 @@
+import * as React from "react";
+import { BfDsIcon } from "./BfDsIcon.tsx";
+
+export type BfDsCalloutVariant = "info" | "success" | "warning" | "error";
+
+export type BfDsCalloutProps = {
+  /** The main message to display */
+  message: string;
+  /** Visual variant of the callout */
+  variant?: BfDsCalloutVariant;
+  /** Optional detailed content (like JSON data) */
+  details?: string;
+  /** Whether details are expanded by default */
+  defaultExpanded?: boolean;
+  /** Whether to show the callout */
+  visible?: boolean;
+  /** Callback when callout is dismissed */
+  onDismiss?: () => void;
+  /** Auto-dismiss after milliseconds (0 = no auto-dismiss) */
+  autoDismiss?: number;
+  /** Additional CSS classes */
+  className?: string;
+};
+
+export function BfDsCallout({
+  message,
+  variant = "info",
+  details,
+  defaultExpanded = false,
+  visible = true,
+  onDismiss,
+  autoDismiss = 0,
+  className,
+}: BfDsCalloutProps) {
+  const [isExpanded, setIsExpanded] = React.useState(defaultExpanded);
+  const [isVisible, setIsVisible] = React.useState(visible);
+
+  // Auto-dismiss functionality
+  React.useEffect(() => {
+    if (visible && autoDismiss > 0) {
+      const timer = setTimeout(() => {
+        setIsVisible(false);
+        onDismiss?.();
+      }, autoDismiss);
+      return () => clearTimeout(timer);
+    }
+  }, [visible, autoDismiss, onDismiss]);
+
+  // Update visibility when prop changes
+  React.useEffect(() => {
+    setIsVisible(visible);
+  }, [visible]);
+
+  if (!isVisible) return null;
+
+  const handleDismiss = () => {
+    setIsVisible(false);
+    onDismiss?.();
+  };
+
+  const iconName = {
+    info: "infoCircle" as const,
+    success: "checkCircle" as const,
+    warning: "infoCircle" as const,
+    error: "cross" as const,
+  }[variant];
+
+  const calloutClasses = [
+    "bfds-callout",
+    `bfds-callout--${variant}`,
+    className,
+  ].filter(Boolean).join(" ");
+
+  return (
+    <div className={calloutClasses}>
+      <div className="bfds-callout-header">
+        <div className="bfds-callout-icon">
+          <BfDsIcon name={iconName} size="small" />
+        </div>
+        <div className="bfds-callout-content">
+          <div className="bfds-callout-message">{message}</div>
+          {details && (
+            <button
+              className="bfds-callout-toggle"
+              onClick={() => setIsExpanded(!isExpanded)}
+              type="button"
+            >
+              {isExpanded ? "Hide details" : "Show details"}
+              <BfDsIcon
+                name={isExpanded ? "arrowUp" : "arrowDown"}
+                size="small"
+              />
+            </button>
+          )}
+        </div>
+        {onDismiss && (
+          <button
+            className="bfds-callout-dismiss"
+            onClick={handleDismiss}
+            type="button"
+            aria-label="Dismiss notification"
+          >
+            <BfDsIcon name="cross" size="small" />
+          </button>
+        )}
+      </div>
+      {details && isExpanded && (
+        <div className="bfds-callout-details">
+          <pre>{details}</pre>
+        </div>
+      )}
+    </div>
+  );
+}
+
+BfDsCallout.Example = function BfDsCalloutExample() {
+  const [notifications, setNotifications] = React.useState<
+    Array<{
+      id: number;
+      message: string;
+      variant: BfDsCalloutVariant;
+      details?: string;
+    }>
+  >([]);
+  const [nextId, setNextId] = React.useState(1);
+
+  const addNotification = (
+    message: string,
+    variant: BfDsCalloutVariant,
+    details?: string,
+  ) => {
+    setNotifications(
+      (prev) => [...prev, { id: nextId, message, variant, details }],
+    );
+    setNextId((prev) => prev + 1);
+  };
+
+  const removeNotification = (id: number) => {
+    setNotifications((prev) => prev.filter((n) => n.id !== id));
+  };
+
+  const sampleData = {
+    name: "John Doe",
+    email: "john@example.com",
+    preferences: {
+      theme: "dark",
+      notifications: true,
+    },
+  };
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "24px",
+        padding: "24px",
+        backgroundColor: "var(--bfds-background)",
+        color: "var(--bfds-text)",
+        fontFamily: "system-ui, -apple-system, sans-serif",
+        maxWidth: "600px",
+      }}
+    >
+      <h2>BfDsCallout Examples</h2>
+
+      <div>
+        <h3>Static Examples</h3>
+        <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+          <BfDsCallout
+            message="This is an informational message"
+            variant="info"
+          />
+          <BfDsCallout
+            message="Operation completed successfully!"
+            variant="success"
+          />
+          <BfDsCallout
+            message="Please review your settings"
+            variant="warning"
+          />
+          <BfDsCallout
+            message="An error occurred while processing"
+            variant="error"
+          />
+        </div>
+      </div>
+
+      <div>
+        <h3>With Details</h3>
+        <BfDsCallout
+          message="Form submitted successfully"
+          variant="success"
+          details={JSON.stringify(sampleData, null, 2)}
+          onDismiss={() => {}}
+        />
+      </div>
+
+      <div>
+        <h3>Dynamic Notifications</h3>
+        <div
+          style={{
+            display: "flex",
+            gap: "12px",
+            flexWrap: "wrap",
+            marginBottom: "16px",
+          }}
+        >
+          <button
+            type="button"
+            onClick={() => addNotification("Info notification", "info")}
+            style={{
+              padding: "8px 16px",
+              backgroundColor: "var(--bfds-primary)",
+              color: "var(--bfds-background)",
+              border: "none",
+              borderRadius: "4px",
+              cursor: "pointer",
+            }}
+          >
+            Add Info
+          </button>
+          <button
+            type="button"
+            onClick={() => addNotification("Success!", "success")}
+            style={{
+              padding: "8px 16px",
+              backgroundColor: "var(--bfds-success)",
+              color: "var(--bfds-background)",
+              border: "none",
+              borderRadius: "4px",
+              cursor: "pointer",
+            }}
+          >
+            Add Success
+          </button>
+          <button
+            type="button"
+            onClick={() =>
+              addNotification(
+                "Form data saved",
+                "success",
+                JSON.stringify(sampleData, null, 2),
+              )}
+            style={{
+              padding: "8px 16px",
+              backgroundColor: "var(--bfds-success)",
+              color: "var(--bfds-background)",
+              border: "none",
+              borderRadius: "4px",
+              cursor: "pointer",
+            }}
+          >
+            Add with Details
+          </button>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+          {notifications.map((notification) => (
+            <BfDsCallout
+              key={notification.id}
+              message={notification.message}
+              variant={notification.variant}
+              details={notification.details}
+              onDismiss={() => removeNotification(notification.id)}
+              autoDismiss={5000}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/bfDs/components/BfDsCheckbox.tsx
+++ b/apps/bfDs/components/BfDsCheckbox.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { BfDsForm, useBfDsFormContext } from "./BfDsForm.tsx";
 import { BfDsIcon } from "./BfDsIcon.tsx";
+import { BfDsCallout } from "./BfDsCallout.tsx";
 import { BfDsFormSubmitButton } from "./BfDsFormSubmitButton.tsx";
 
 export type BfDsCheckboxProps = {
@@ -121,6 +122,11 @@ BfDsCheckbox.Example = function BfDsCheckboxExample() {
     newsletter: false,
     notifications: false,
   });
+  const [notification, setNotification] = React.useState({
+    message: "",
+    details: "",
+    visible: false,
+  });
 
   return (
     <div
@@ -153,9 +159,13 @@ BfDsCheckbox.Example = function BfDsCheckboxExample() {
         <h3>With BfDsForm Integration</h3>
         <BfDsForm
           initialData={formData}
-          onSubmit={(data) => {
-            alert(`Form submitted: ${JSON.stringify(data, null, 2)}`);
-            setFormData(data);
+          onSubmit={(data: unknown) => {
+            setNotification({
+              message: "Form submitted successfully!",
+              details: JSON.stringify(data, null, 2),
+              visible: true,
+            });
+            setFormData(data as typeof formData);
           }}
         >
           <div
@@ -180,6 +190,15 @@ BfDsCheckbox.Example = function BfDsCheckboxExample() {
             <BfDsFormSubmitButton text="Submit Form" />
           </div>
         </BfDsForm>
+        <BfDsCallout
+          message={notification.message}
+          variant="success"
+          details={notification.details}
+          visible={notification.visible}
+          onDismiss={() =>
+            setNotification({ message: "", details: "", visible: false })}
+          autoDismiss={5000}
+        />
       </div>
 
       <div>

--- a/apps/bfDs/components/BfDsForm.tsx
+++ b/apps/bfDs/components/BfDsForm.tsx
@@ -1,5 +1,13 @@
 import * as React from "react";
 import { getLogger } from "@bfmono/packages/logger/logger.ts";
+import { BfDsCallout } from "./BfDsCallout.tsx";
+import { BfDsInput } from "./BfDsInput.tsx";
+import { BfDsTextArea } from "./BfDsTextArea.tsx";
+import { BfDsSelect } from "./BfDsSelect.tsx";
+import { BfDsCheckbox } from "./BfDsCheckbox.tsx";
+import { BfDsRadio } from "./BfDsRadio.tsx";
+import { BfDsToggle } from "./BfDsToggle.tsx";
+import { BfDsFormSubmitButton } from "./BfDsFormSubmitButton.tsx";
 
 const { useState, createContext, useContext } = React;
 const logger = getLogger(import.meta);
@@ -100,34 +108,39 @@ export type BfDsFormElementProps<
 };
 
 BfDsForm.Example = function BfDsFormExample() {
-  // Import components dynamically to avoid circular dependencies
-  const BfDsInput = React.lazy(() =>
-    import("./BfDsInput.tsx").then((m) => ({ default: m.BfDsInput }))
-  );
-  const BfDsTextArea = React.lazy(() =>
-    import("./BfDsTextArea.tsx").then((m) => ({ default: m.BfDsTextArea }))
-  );
-  const BfDsFormSubmitButton = React.lazy(() =>
-    import("./BfDsFormSubmitButton.tsx").then((m) => ({
-      default: m.BfDsFormSubmitButton,
-    }))
-  );
-
   type ExampleFormData = {
     name: string;
     email: string;
     message: string;
+    country: string;
+    newsletter: boolean;
+    contactMethod: string;
+    notifications: boolean;
   };
 
   const exampleInitialFormData: ExampleFormData = {
     name: "John Doe",
     email: "john@example.com",
     message: "Hello world!",
+    country: "us",
+    newsletter: false,
+    contactMethod: "email",
+    notifications: true,
   };
+
+  const [notification, setNotification] = useState({
+    message: "",
+    details: "",
+    visible: false,
+  });
 
   function exampleOnSubmit(value: ExampleFormData) {
     logger.info("Form submitted:", value);
-    alert(`Form submitted with: ${JSON.stringify(value, null, 2)}`);
+    setNotification({
+      message: "Form submitted successfully!",
+      details: JSON.stringify(value, null, 2),
+      visible: true,
+    });
   }
 
   function exampleOnChange(value: ExampleFormData) {
@@ -151,40 +164,76 @@ BfDsForm.Example = function BfDsFormExample() {
 
       <div>
         <h3>Complete Form with Context Integration</h3>
-        <React.Suspense fallback={<div>Loading form components...</div>}>
-          <BfDsForm<ExampleFormData>
-            onSubmit={exampleOnSubmit}
-            onChange={exampleOnChange}
-            initialData={exampleInitialFormData}
+        <p style={{ margin: "0 0 16px 0", color: "var(--bfds-text-muted)" }}>
+          All form fields automatically sync with centralized form state without
+          individual value/onChange props.
+        </p>
+        <BfDsForm<ExampleFormData>
+          onSubmit={exampleOnSubmit}
+          onChange={exampleOnChange}
+          initialData={exampleInitialFormData}
+        >
+          <div
+            style={{ display: "flex", flexDirection: "column", gap: "16px" }}
           >
-            <div
-              style={{ display: "flex", flexDirection: "column", gap: "16px" }}
-            >
-              <BfDsInput
-                name="name"
-                label="Your Name"
-                placeholder="Enter your name"
-                required
-                helpText="This input gets its value from form context"
-              />
-              <BfDsInput
-                name="email"
-                label="Email Address"
-                type="email"
-                placeholder="email@example.com"
-                required
-              />
-              <BfDsTextArea
-                name="message"
-                label="Message"
-                placeholder="Enter your message..."
-                rows={4}
-                helpText="This textarea also uses form context"
-              />
-              <BfDsFormSubmitButton text="Submit Form" />
-            </div>
-          </BfDsForm>
-        </React.Suspense>
+            <BfDsInput
+              name="name"
+              label="Your Name"
+              placeholder="Enter your name"
+              required
+            />
+            <BfDsInput
+              name="email"
+              label="Email Address"
+              type="email"
+              placeholder="email@example.com"
+              required
+            />
+            <BfDsTextArea
+              name="message"
+              label="Message"
+              placeholder="Enter your message..."
+              rows={4}
+            />
+            <BfDsSelect
+              name="country"
+              label="Country"
+              options={[
+                { value: "us", label: "United States" },
+                { value: "ca", label: "Canada" },
+                { value: "uk", label: "United Kingdom" },
+                { value: "au", label: "Australia" },
+              ]}
+            />
+            <BfDsCheckbox
+              name="newsletter"
+              label="Subscribe to newsletter"
+            />
+            <BfDsRadio
+              name="contactMethod"
+              label="Preferred Contact Method"
+              options={[
+                { value: "email", label: "Email" },
+                { value: "phone", label: "Phone" },
+                { value: "text", label: "Text Message" },
+              ]}
+            />
+            <BfDsToggle
+              name="notifications"
+              label="Push notifications"
+            />
+            <BfDsFormSubmitButton text="Submit Complete Form" />
+          </div>
+        </BfDsForm>
+        <BfDsCallout
+          message={notification.message}
+          variant="success"
+          details={notification.details}
+          visible={notification.visible}
+          onDismiss={() =>
+            setNotification({ message: "", details: "", visible: false })}
+          autoDismiss={5000}
+        />
       </div>
 
       <div>
@@ -194,6 +243,10 @@ BfDsForm.Example = function BfDsFormExample() {
           <li>No need to pass value/onChange to each field</li>
           <li>Form-level validation and error handling</li>
           <li>Centralized form submission logic</li>
+          <li>
+            Support for all input types: text, select, checkbox, radio, toggle
+          </li>
+          <li>TypeScript-safe form data with proper type inference</li>
         </ul>
       </div>
     </div>

--- a/apps/bfDs/components/BfDsFormSubmitButton.tsx
+++ b/apps/bfDs/components/BfDsFormSubmitButton.tsx
@@ -1,5 +1,8 @@
-import type * as React from "react";
+import * as React from "react";
 import { BfDsButton, type BfDsButtonProps } from "./BfDsButton.tsx";
+import { BfDsCallout } from "./BfDsCallout.tsx";
+import { BfDsForm } from "./BfDsForm.tsx";
+import { BfDsInput } from "./BfDsInput.tsx";
 
 export type BfDsFormSubmitButtonProps =
   & Omit<BfDsButtonProps, "type" | "onClick">
@@ -36,10 +39,12 @@ export function BfDsFormSubmitButton({
 }
 
 BfDsFormSubmitButton.Example = function BfDsFormSubmitButtonExample() {
-  const handleStandaloneClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
-    alert("Standalone submit button clicked!");
-  };
+  const [formData, setFormData] = React.useState({ name: "" });
+  const [notification, setNotification] = React.useState({
+    message: "",
+    details: "",
+    visible: false,
+  });
 
   return (
     <div
@@ -57,113 +62,44 @@ BfDsFormSubmitButton.Example = function BfDsFormSubmitButtonExample() {
       <h2>BfDsFormSubmitButton Examples</h2>
 
       <div>
-        <h3>Standalone Mode</h3>
-        <div style={{ display: "flex", gap: "12px", flexWrap: "wrap" }}>
-          <BfDsFormSubmitButton
-            text="Submit Form"
-            onClick={handleStandaloneClick}
-          />
-          <BfDsFormSubmitButton
-            text="Save"
-            variant="secondary"
-            onClick={handleStandaloneClick}
-          />
-          <BfDsFormSubmitButton
-            variant="outline"
-            onClick={handleStandaloneClick}
-          >
-            Custom Content
-          </BfDsFormSubmitButton>
-        </div>
-      </div>
-
-      <div>
-        <h3>Different Variants</h3>
-        <div style={{ display: "flex", gap: "12px", flexWrap: "wrap" }}>
-          <BfDsFormSubmitButton
-            text="Primary Submit"
-            variant="primary"
-            onClick={handleStandaloneClick}
-          />
-          <BfDsFormSubmitButton
-            text="Secondary Submit"
-            variant="secondary"
-            onClick={handleStandaloneClick}
-          />
-          <BfDsFormSubmitButton
-            text="Outline Submit"
-            variant="outline"
-            onClick={handleStandaloneClick}
-          />
-          <BfDsFormSubmitButton
-            text="Ghost Submit"
-            variant="ghost"
-            onClick={handleStandaloneClick}
-          />
-        </div>
-      </div>
-
-      <div>
-        <h3>Different Sizes</h3>
-        <div
-          style={{
-            display: "flex",
-            gap: "12px",
-            alignItems: "center",
-            flexWrap: "wrap",
+        <h3>Form Integration</h3>
+        <p style={{ margin: "0 0 16px 0", color: "var(--bfds-text-muted)" }}>
+          Submit button automatically integrates with form context for
+          submission handling.
+        </p>
+        <BfDsForm
+          initialData={formData}
+          onSubmit={(data) => {
+            setNotification({
+              message: "Form submitted successfully!",
+              details: JSON.stringify(data, null, 2),
+              visible: true,
+            });
+            setFormData(data as typeof formData);
           }}
         >
-          <BfDsFormSubmitButton
-            text="Small"
-            size="small"
-            onClick={handleStandaloneClick}
-          />
-          <BfDsFormSubmitButton
-            text="Medium"
-            size="medium"
-            onClick={handleStandaloneClick}
-          />
-          <BfDsFormSubmitButton
-            text="Large"
-            size="large"
-            onClick={handleStandaloneClick}
-          />
-        </div>
+          <div
+            style={{ display: "flex", flexDirection: "column", gap: "16px" }}
+          >
+            <BfDsInput
+              name="name"
+              label="Your Name"
+              placeholder="Enter your name"
+              required
+            />
+            <BfDsFormSubmitButton text="Submit Form" />
+          </div>
+        </BfDsForm>
+        <BfDsCallout
+          message={notification.message}
+          variant="success"
+          details={notification.details}
+          visible={notification.visible}
+          onDismiss={() =>
+            setNotification({ message: "", details: "", visible: false })}
+          autoDismiss={5000}
+        />
       </div>
-
-      <div>
-        <h3>With Icons</h3>
-        <div style={{ display: "flex", gap: "12px", flexWrap: "wrap" }}>
-          <BfDsFormSubmitButton
-            text="Save"
-            icon="checkmark"
-            onClick={handleStandaloneClick}
-          />
-          <BfDsFormSubmitButton
-            text="Send"
-            icon="arrowRight"
-            iconPosition="right"
-            onClick={handleStandaloneClick}
-          />
-        </div>
-      </div>
-
-      <div>
-        <h3>States</h3>
-        <div style={{ display: "flex", gap: "12px", flexWrap: "wrap" }}>
-          <BfDsFormSubmitButton
-            text="Disabled"
-            disabled
-            onClick={handleStandaloneClick}
-          />
-        </div>
-      </div>
-
-      <p>
-        <strong>Note:</strong>{" "}
-        Form context integration will be demonstrated in the BfDsForm examples
-        once complete.
-      </p>
     </div>
   );
 };

--- a/apps/bfDs/components/BfDsList.tsx
+++ b/apps/bfDs/components/BfDsList.tsx
@@ -1,4 +1,6 @@
 import * as React from "react";
+import { BfDsCallout } from "./BfDsCallout.tsx";
+import { BfDsListItem } from "./BfDsListItem.tsx";
 
 type BfDsListProps = {
   /** List items (typically BfDsListItem components) */
@@ -21,9 +23,10 @@ export function BfDsList({ children, className }: BfDsListProps) {
 }
 
 BfDsList.Example = function BfDsListExample() {
-  const BfDsListItem = React.lazy(() =>
-    import("./BfDsListItem.tsx").then((m) => ({ default: m.BfDsListItem }))
-  );
+  const [notification, setNotification] = React.useState({
+    message: "",
+    visible: false,
+  });
 
   return (
     <div
@@ -42,43 +45,53 @@ BfDsList.Example = function BfDsListExample() {
 
       <div>
         <h3>Simple List</h3>
-        <React.Suspense fallback={<div>Loading...</div>}>
-          <BfDsList>
-            <BfDsListItem>Home</BfDsListItem>
-            <BfDsListItem>About</BfDsListItem>
-            <BfDsListItem>Services</BfDsListItem>
-            <BfDsListItem>Contact</BfDsListItem>
-          </BfDsList>
-        </React.Suspense>
+        <BfDsList>
+          <BfDsListItem>Home</BfDsListItem>
+          <BfDsListItem>About</BfDsListItem>
+          <BfDsListItem>Services</BfDsListItem>
+          <BfDsListItem>Contact</BfDsListItem>
+        </BfDsList>
       </div>
 
       <div>
         <h3>Navigation List</h3>
-        <React.Suspense fallback={<div>Loading...</div>}>
-          <BfDsList>
-            <BfDsListItem active>Dashboard</BfDsListItem>
-            <BfDsListItem>Projects</BfDsListItem>
-            <BfDsListItem>Team</BfDsListItem>
-            <BfDsListItem disabled>Settings</BfDsListItem>
-          </BfDsList>
-        </React.Suspense>
+        <BfDsList>
+          <BfDsListItem active>Dashboard</BfDsListItem>
+          <BfDsListItem>Projects</BfDsListItem>
+          <BfDsListItem>Team</BfDsListItem>
+          <BfDsListItem disabled>Settings</BfDsListItem>
+        </BfDsList>
       </div>
 
       <div>
         <h3>Clickable List</h3>
-        <React.Suspense fallback={<div>Loading...</div>}>
-          <BfDsList>
-            <BfDsListItem onClick={() => alert("Clicked Item 1")}>
-              Clickable Item 1
-            </BfDsListItem>
-            <BfDsListItem onClick={() => alert("Clicked Item 2")}>
-              Clickable Item 2
-            </BfDsListItem>
-            <BfDsListItem onClick={() => alert("Clicked Item 3")}>
-              Clickable Item 3
-            </BfDsListItem>
-          </BfDsList>
-        </React.Suspense>
+        <BfDsList>
+          <BfDsListItem
+            onClick={() =>
+              setNotification({ message: "Clicked Item 1", visible: true })}
+          >
+            Clickable Item 1
+          </BfDsListItem>
+          <BfDsListItem
+            onClick={() =>
+              setNotification({ message: "Clicked Item 2", visible: true })}
+          >
+            Clickable Item 2
+          </BfDsListItem>
+          <BfDsListItem
+            onClick={() =>
+              setNotification({ message: "Clicked Item 3", visible: true })}
+          >
+            Clickable Item 3
+          </BfDsListItem>
+        </BfDsList>
+        <BfDsCallout
+          message={notification.message}
+          variant="info"
+          visible={notification.visible}
+          onDismiss={() => setNotification({ message: "", visible: false })}
+          autoDismiss={3000}
+        />
       </div>
     </div>
   );

--- a/apps/bfDs/components/BfDsListItem.tsx
+++ b/apps/bfDs/components/BfDsListItem.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { BfDsCallout } from "./BfDsCallout.tsx";
 
 export type BfDsListItemProps = {
   /** Content to display in the list item */
@@ -53,6 +54,10 @@ export function BfDsListItem({
 }
 
 BfDsListItem.Example = function BfDsListItemExample() {
+  const [notification, setNotification] = React.useState({
+    message: "",
+    visible: false,
+  });
   return (
     <div
       style={{
@@ -80,13 +85,23 @@ BfDsListItem.Example = function BfDsListItemExample() {
       <div>
         <h3>Clickable Items</h3>
         <ul className="bfds-list">
-          <BfDsListItem onClick={() => alert("Clicked Item 1")}>
+          <BfDsListItem
+            onClick={() =>
+              setNotification({ message: "Clicked Item 1", visible: true })}
+          >
             Clickable Item 1
           </BfDsListItem>
-          <BfDsListItem onClick={() => alert("Clicked Item 2")}>
+          <BfDsListItem
+            onClick={() =>
+              setNotification({ message: "Clicked Item 2", visible: true })}
+          >
             Clickable Item 2
           </BfDsListItem>
-          <BfDsListItem onClick={() => alert("Clicked Item 3")} disabled>
+          <BfDsListItem
+            onClick={() =>
+              setNotification({ message: "Clicked Item 3", visible: true })}
+            disabled
+          >
             Disabled Clickable Item
           </BfDsListItem>
         </ul>
@@ -96,15 +111,32 @@ BfDsListItem.Example = function BfDsListItemExample() {
         <h3>Mixed Usage</h3>
         <ul className="bfds-list">
           <BfDsListItem>Static Item</BfDsListItem>
-          <BfDsListItem active onClick={() => alert("Active and clickable")}>
+          <BfDsListItem
+            active
+            onClick={() =>
+              setNotification({
+                message: "Active and clickable",
+                visible: true,
+              })}
+          >
             Active Clickable Item
           </BfDsListItem>
-          <BfDsListItem onClick={() => alert("Just clickable")}>
+          <BfDsListItem
+            onClick={() =>
+              setNotification({ message: "Just clickable", visible: true })}
+          >
             Clickable Item
           </BfDsListItem>
           <BfDsListItem disabled>Disabled Item</BfDsListItem>
         </ul>
       </div>
+      <BfDsCallout
+        message={notification.message}
+        variant="info"
+        visible={notification.visible}
+        onDismiss={() => setNotification({ message: "", visible: false })}
+        autoDismiss={3000}
+      />
     </div>
   );
 };

--- a/apps/bfDs/components/BfDsRadio.tsx
+++ b/apps/bfDs/components/BfDsRadio.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { BfDsForm, useBfDsFormContext } from "./BfDsForm.tsx";
+import { BfDsCallout } from "./BfDsCallout.tsx";
 import { BfDsFormSubmitButton } from "./BfDsFormSubmitButton.tsx";
 
 export type BfDsRadioOption = {
@@ -150,6 +151,11 @@ BfDsRadio.Example = function BfDsRadioExample() {
     theme: "",
     plan: "",
   });
+  const [notification, setNotification] = React.useState({
+    message: "",
+    details: "",
+    visible: false,
+  });
 
   const sizeOptions: Array<BfDsRadioOption> = [
     { value: "small", label: "Small" },
@@ -204,9 +210,13 @@ BfDsRadio.Example = function BfDsRadioExample() {
         <h3>With BfDsForm Integration</h3>
         <BfDsForm
           initialData={formData}
-          onSubmit={(data) => {
-            alert(`Form submitted: ${JSON.stringify(data, null, 2)}`);
-            setFormData(data);
+          onSubmit={(data: unknown) => {
+            setNotification({
+              message: "Form submitted successfully!",
+              details: JSON.stringify(data, null, 2),
+              visible: true,
+            });
+            setFormData(data as typeof formData);
           }}
         >
           <div
@@ -235,6 +245,15 @@ BfDsRadio.Example = function BfDsRadioExample() {
             <BfDsFormSubmitButton text="Submit Form" />
           </div>
         </BfDsForm>
+        <BfDsCallout
+          message={notification.message}
+          variant="success"
+          details={notification.details}
+          visible={notification.visible}
+          onDismiss={() =>
+            setNotification({ message: "", details: "", visible: false })}
+          autoDismiss={5000}
+        />
       </div>
 
       <div>

--- a/apps/bfDs/components/BfDsSelect.tsx
+++ b/apps/bfDs/components/BfDsSelect.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { BfDsForm, useBfDsFormContext } from "./BfDsForm.tsx";
 import { BfDsIcon } from "./BfDsIcon.tsx";
+import { BfDsCallout } from "./BfDsCallout.tsx";
 import { BfDsFormSubmitButton } from "./BfDsFormSubmitButton.tsx";
 
 export type BfDsSelectOption = {
@@ -139,6 +140,11 @@ BfDsSelect.Example = function BfDsSelectExample() {
     size: "",
     priority: "",
   });
+  const [notification, setNotification] = React.useState({
+    message: "",
+    details: "",
+    visible: false,
+  });
 
   const countryOptions: Array<BfDsSelectOption> = [
     { value: "us", label: "United States" },
@@ -196,9 +202,13 @@ BfDsSelect.Example = function BfDsSelectExample() {
         <h3>With BfDsForm Integration</h3>
         <BfDsForm
           initialData={formData}
-          onSubmit={(data) => {
-            alert(`Form submitted: ${JSON.stringify(data, null, 2)}`);
-            setFormData(data);
+          onSubmit={(data: unknown) => {
+            setNotification({
+              message: "Form submitted successfully!",
+              details: JSON.stringify(data, null, 2),
+              visible: true,
+            });
+            setFormData(data as typeof formData);
           }}
         >
           <div
@@ -229,6 +239,15 @@ BfDsSelect.Example = function BfDsSelectExample() {
             <BfDsFormSubmitButton text="Submit Form" />
           </div>
         </BfDsForm>
+        <BfDsCallout
+          message={notification.message}
+          variant="success"
+          details={notification.details}
+          visible={notification.visible}
+          onDismiss={() =>
+            setNotification({ message: "", details: "", visible: false })}
+          autoDismiss={5000}
+        />
       </div>
 
       <div>

--- a/apps/bfDs/components/BfDsToggle.tsx
+++ b/apps/bfDs/components/BfDsToggle.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { BfDsForm, useBfDsFormContext } from "./BfDsForm.tsx";
+import { BfDsCallout } from "./BfDsCallout.tsx";
 import { BfDsFormSubmitButton } from "./BfDsFormSubmitButton.tsx";
 
 export type BfDsToggleSize = "small" | "medium" | "large";
@@ -18,8 +19,6 @@ export type BfDsToggleProps = {
   // Common props
   /** Label text displayed next to toggle */
   label?: string;
-  /** Required for validation */
-  required?: boolean;
   /** Disables component */
   disabled?: boolean;
   /** Size variant for toggle switch */
@@ -36,7 +35,6 @@ export function BfDsToggle({
   onChange,
   label,
   disabled = false,
-  required = false,
   className,
   id,
   size = "medium",
@@ -91,7 +89,6 @@ export function BfDsToggle({
         checked={actualChecked}
         onChange={handleChange}
         disabled={disabled}
-        required={required}
         className="bfds-toggle-input"
       />
       <div
@@ -108,7 +105,6 @@ export function BfDsToggle({
       {label && (
         <span className="bfds-toggle-label">
           {label}
-          {required && <span className="bfds-toggle-required">*</span>}
         </span>
       )}
     </label>
@@ -121,6 +117,11 @@ BfDsToggle.Example = function BfDsToggleExample() {
     darkMode: false,
     notifications: false,
     autoSave: false,
+  });
+  const [notification, setNotification] = React.useState({
+    message: "",
+    details: "",
+    visible: false,
   });
 
   return (
@@ -155,8 +156,12 @@ BfDsToggle.Example = function BfDsToggleExample() {
         <BfDsForm
           initialData={formData}
           onSubmit={(data) => {
-            alert(`Form submitted: ${JSON.stringify(data, null, 2)}`);
-            setFormData(data);
+            setNotification({
+              message: "Form submitted successfully!",
+              details: JSON.stringify(data, null, 2),
+              visible: true,
+            });
+            setFormData(data as typeof formData);
           }}
         >
           <div
@@ -175,12 +180,20 @@ BfDsToggle.Example = function BfDsToggleExample() {
             <BfDsToggle
               name="autoSave"
               label="Auto-save documents"
-              required
             />
 
             <BfDsFormSubmitButton text="Submit Form" />
           </div>
         </BfDsForm>
+        <BfDsCallout
+          message={notification.message}
+          variant="success"
+          details={notification.details}
+          visible={notification.visible}
+          onDismiss={() =>
+            setNotification({ message: "", details: "", visible: false })}
+          autoDismiss={5000}
+        />
       </div>
 
       <div>
@@ -238,11 +251,7 @@ BfDsToggle.Example = function BfDsToggleExample() {
             onChange={() => {}}
           />
 
-          <BfDsToggle
-            label="Required"
-            required
-            onChange={() => {}}
-          />
+          <BfDsToggle label="Without onChange Handler" />
 
           <BfDsToggle
             label="No Label"

--- a/apps/bfDs/components/__tests__/BfDsToggle.test.tsx
+++ b/apps/bfDs/components/__tests__/BfDsToggle.test.tsx
@@ -112,37 +112,6 @@ Deno.test("BfDsToggle renders in disabled state", () => {
   );
 });
 
-Deno.test("BfDsToggle renders with required attribute", () => {
-  const { doc } = render(
-    <BfDsToggle
-      label="Required toggle"
-      required
-      checked={false}
-      onChange={() => {}}
-    />,
-  );
-
-  const input = doc?.querySelector(
-    "input[type='checkbox']",
-  ) as HTMLInputElement;
-  const labelSpan = doc?.querySelector(".bfds-toggle-label");
-  const requiredSpan = doc?.querySelector(".bfds-toggle-required");
-
-  assertExists(input, "Toggle input should exist");
-  assertExists(labelSpan, "Label should exist");
-  assertExists(requiredSpan, "Required indicator should exist");
-  assertEquals(
-    input?.hasAttribute("required"),
-    true,
-    "Input should have required attribute",
-  );
-  assertEquals(
-    requiredSpan?.textContent,
-    "*",
-    "Required indicator should show asterisk",
-  );
-});
-
 Deno.test("BfDsToggle renders with different sizes", () => {
   const sizes = ["small", "medium", "large"] as const;
 

--- a/apps/bfDs/demo/Demo.tsx
+++ b/apps/bfDs/demo/Demo.tsx
@@ -12,6 +12,7 @@ import { BfDsSelect } from "../components/BfDsSelect.tsx";
 import { BfDsCheckbox } from "../components/BfDsCheckbox.tsx";
 import { BfDsRadio } from "../components/BfDsRadio.tsx";
 import { BfDsToggle } from "../components/BfDsToggle.tsx";
+import { BfDsCallout } from "../components/BfDsCallout.tsx";
 
 type ComponentSection = {
   id: string;
@@ -112,6 +113,13 @@ const componentSections: Array<ComponentSection> = [
     description: "Toggle switches with smooth animations and sizes",
     component: BfDsToggle.Example,
     category: "Form",
+  },
+  {
+    id: "callout",
+    name: "Callout",
+    description: "Notification system with variants and auto-dismiss",
+    component: BfDsCallout.Example,
+    category: "Core",
   },
 ];
 

--- a/static/bfDsStyle.css
+++ b/static/bfDsStyle.css
@@ -579,7 +579,7 @@
   line-height: 1.5;
   transition: all 0.2s ease-in-out;
   outline: none;
-  min-height: 80px;
+  min-height: 2.5em;
 }
 
 .bfds-textarea::placeholder {
@@ -759,13 +759,17 @@
   font-weight: 400;
   line-height: 1.4;
   color: var(--bfds-text);
+  position: relative;
 }
 
 .bfds-checkbox-input {
   position: absolute;
   opacity: 0;
-  width: 0;
-  height: 0;
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  z-index: 1;
+  cursor: pointer;
 }
 
 .bfds-checkbox {
@@ -826,6 +830,17 @@
   opacity: 0.6;
 }
 
+/* Checkbox validation states - only show error styling when focused and invalid */
+.bfds-checkbox-input:invalid:focus + .bfds-checkbox {
+  outline: 2px solid var(--bfds-error);
+  outline-offset: 2px;
+}
+
+/* Show error styling after user has tried to submit (when form has was-validated class) */
+.was-validated .bfds-checkbox-input:invalid + .bfds-checkbox {
+  border-color: var(--bfds-error);
+}
+
 /* Radio */
 
 .bfds-radio-group {
@@ -857,13 +872,17 @@
   font-weight: 400;
   line-height: 1.4;
   color: var(--bfds-text);
+  position: relative;
 }
 
 .bfds-radio-input {
   position: absolute;
   opacity: 0;
-  width: 0;
-  height: 0;
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  z-index: 1;
+  cursor: pointer;
 }
 
 .bfds-radio {
@@ -925,6 +944,17 @@
 
 .bfds-radio-wrapper:has(.bfds-radio--disabled) .bfds-radio-label {
   opacity: 0.6;
+}
+
+/* Radio validation states - only show error styling when focused and invalid */
+.bfds-radio-input:invalid:focus + .bfds-radio {
+  outline: 2px solid var(--bfds-error);
+  outline-offset: 2px;
+}
+
+/* Show error styling after user has tried to submit (when form has was-validated class) */
+.was-validated .bfds-radio-input:invalid + .bfds-radio {
+  border-color: var(--bfds-error);
 }
 
 /* Radio sizes */
@@ -1065,16 +1095,130 @@
   user-select: none;
 }
 
-.bfds-toggle-required {
-  color: var(--bfds-error);
-}
-
 .bfds-toggle-wrapper:has(.bfds-toggle--disabled) {
   cursor: not-allowed;
 }
 
 .bfds-toggle-wrapper:has(.bfds-toggle--disabled) .bfds-toggle-label {
   opacity: 0.6;
+}
+
+/* Callout */
+
+.bfds-callout {
+  padding: 16px;
+  border-radius: 8px;
+  border: 1px solid;
+  margin: 8px 0;
+  animation: bfds-callout-fade-in 0.3s ease-in-out;
+}
+
+@keyframes bfds-callout-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.bfds-callout-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.bfds-callout-icon {
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.bfds-callout-content {
+  flex: 1;
+}
+
+.bfds-callout-message {
+  font-weight: 500;
+  margin-bottom: 8px;
+}
+
+.bfds-callout-toggle {
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 14px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 0;
+  text-decoration: underline;
+  opacity: 0.8;
+}
+
+.bfds-callout-toggle:hover {
+  opacity: 1;
+}
+
+.bfds-callout-dismiss {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  opacity: 0.6;
+  flex-shrink: 0;
+}
+
+.bfds-callout-dismiss:hover {
+  opacity: 1;
+  background-color: rgba(0, 0, 0, 0.1);
+}
+
+.bfds-callout-details {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.bfds-callout-details pre {
+  background-color: rgba(0, 0, 0, 0.2);
+  padding: 12px;
+  border-radius: 4px;
+  font-size: 12px;
+  line-height: 1.4;
+  overflow-x: auto;
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+/* Callout variants */
+
+.bfds-callout--info {
+  background-color: rgba(59, 130, 246, 0.1);
+  border-color: rgba(59, 130, 246, 0.3);
+  color: #93c5fd;
+}
+
+.bfds-callout--success {
+  background-color: rgba(34, 197, 94, 0.1);
+  border-color: rgba(34, 197, 94, 0.3);
+  color: #86efac;
+}
+
+.bfds-callout--warning {
+  background-color: rgba(245, 158, 11, 0.1);
+  border-color: rgba(245, 158, 11, 0.3);
+  color: #fcd34d;
+}
+
+.bfds-callout--error {
+  background-color: rgba(239, 68, 68, 0.1);
+  border-color: rgba(239, 68, 68, 0.3);
+  color: #fca5a5;
 }
 
 /* Toggle sizes */
@@ -1118,4 +1262,125 @@
 
 .bfds-toggle--large.bfds-toggle--checked .bfds-toggle-thumb {
   transform: translateX(24px);
+}
+
+/* Callout */
+
+.bfds-callout {
+  display: flex;
+  flex-direction: column;
+  padding: 16px;
+  border-radius: 8px;
+  border: 1px solid;
+  margin: 8px 0;
+  font-family: system-ui, -apple-system, sans-serif;
+  transition: all 0.2s ease-in-out;
+}
+
+.bfds-callout-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.bfds-callout-icon {
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.bfds-callout-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.bfds-callout-message {
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.4;
+  margin: 0 0 8px 0;
+}
+
+.bfds-callout-toggle {
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 12px;
+  font-weight: 400;
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  text-decoration: underline;
+  opacity: 0.8;
+  transition: opacity 0.2s ease-in-out;
+}
+
+.bfds-callout-toggle:hover {
+  opacity: 1;
+}
+
+.bfds-callout-dismiss {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  opacity: 0.6;
+  transition: all 0.2s ease-in-out;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.bfds-callout-dismiss:hover {
+  opacity: 1;
+  background-color: rgba(0, 0, 0, 0.1);
+}
+
+.bfds-callout-details {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid;
+  border-color: inherit;
+  opacity: 0.8;
+}
+
+.bfds-callout-details pre {
+  margin: 0;
+  padding: 8px 12px;
+  background-color: rgba(0, 0, 0, 0.05);
+  border-radius: 4px;
+  font-size: 12px;
+  line-height: 1.4;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+/* Callout variants */
+.bfds-callout--info {
+  background-color: #f0f9ff;
+  border-color: #0ea5e9;
+  color: #0c4a6e;
+}
+
+.bfds-callout--success {
+  background-color: #f0fdf4;
+  border-color: #22c55e;
+  color: #14532d;
+}
+
+.bfds-callout--warning {
+  background-color: #fefce8;
+  border-color: #eab308;
+  color: #713f12;
+}
+
+.bfds-callout--error {
+  background-color: #fef2f2;
+  border-color: #ef4444;
+  color: #7f1d1d;
 }


### PR DESCRIPTION

Remove required functionality from toggle component as toggles should not
be required from UX perspective. Update tests and examples accordingly.

Changes:
- Remove required prop from BfDsToggleProps interface
- Remove required prop handling in component implementation
- Remove required attribute from input element
- Remove required indicator (*) from label display
- Update component examples to remove required usage
- Update tests to remove required-related test cases
- Maintain all other toggle functionality (sizes, states, form integration)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/1332).
* #1337
* #1335
* #1334
* #1333
* __->__ #1332
* #1331
* #1330
* #1329