### PR TITLE
Add Extend API data pipeline for Munch Insights

### DIFF
--- a/apps/aibff/gui/__tests__/tab-screenshots.e2e.ts
+++ b/apps/aibff/gui/__tests__/tab-screenshots.e2e.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env -S deno test -A
+
+import { delay } from "@std/async";
+import { getLogger } from "@bfmono/packages/logger/logger.ts";
+import {
+  navigateTo,
+  setupE2ETest,
+  teardownE2ETest,
+} from "@bfmono/infra/testing/e2e/setup.ts";
+
+const logger = getLogger(import.meta);
+
+Deno.test("aibff GUI accordion screenshots", async () => {
+  const context = await setupE2ETest({
+    baseUrl: "http://localhost:4000",
+  });
+
+  const sections = [
+    { id: "input-variables", label: "Input Variables" },
+    { id: "system-prompt", label: "System Prompt" },
+    { id: "test-conversation", label: "Test Conversation" },
+    { id: "saved-results", label: "Saved Results" },
+    { id: "calibration", label: "Calibration" },
+    { id: "eval-prompt", label: "Eval Prompt" },
+    { id: "run-eval", label: "Run Eval" },
+    { id: "files", label: "Files" },
+  ];
+
+  try {
+    await navigateTo(context, "/");
+
+    // Wait for page to load
+    await context.page.waitForSelector('[style*="width: 400px"]', {
+      timeout: 10000,
+    });
+
+    // Take initial screenshot
+    await context.takeScreenshot("aibff-gui-accordion-initial");
+    logger.info("Initial accordion screenshot captured");
+
+    // Get all buttons and try to find accordion section buttons
+    const buttons = await context.page.$$("button");
+    logger.info(`Found ${buttons.length} buttons on the page`);
+
+    // Take screenshot before clicking anything
+    await context.takeScreenshot("aibff-gui-accordion-before-clicks");
+
+    for (let i = 0; i < buttons.length; i++) {
+      try {
+        const button = buttons[i];
+        const text = await button.evaluate((el) => el.textContent?.trim());
+        logger.info(`Button ${i}: "${text}"`);
+
+        // Check if this button contains one of our accordion section names
+        const matchingSection = sections.find((section) =>
+          text && text.includes(section.label)
+        );
+        if (matchingSection) {
+          logger.info(
+            `Clicking on accordion section: ${matchingSection.label}`,
+          );
+          await button.click();
+          await delay(1000);
+          await context.takeScreenshot(
+            `aibff-gui-accordion-${matchingSection.id}`,
+          );
+          logger.info(
+            `Screenshot captured for accordion section: ${matchingSection.label}`,
+          );
+        }
+      } catch (error) {
+        logger.error(`Error with button ${i}:`, error);
+      }
+    }
+
+    // Take final screenshot
+    await context.takeScreenshot("aibff-gui-accordion-final");
+    logger.info("Final accordion screenshot captured");
+  } finally {
+    await teardownE2ETest(context);
+  }
+});

--- a/customers/munchinsights.com/scripts/extend-pipeline.ts
+++ b/customers/munchinsights.com/scripts/extend-pipeline.ts
@@ -1,0 +1,226 @@
+#!/usr/bin/env -S deno run --allow-net --allow-env --allow-write --allow-read
+
+/**
+ * Complete pipeline to fetch invoice data from Extend API and convert to JSONL
+ * Usage: deno run --allow-net --allow-env --allow-write --allow-read extend-pipeline.ts [output-dir]
+ *
+ * Arguments:
+ *   output-dir: Directory to write output files (default: ./output)
+ */
+
+import { getConfigurationVariable } from "@bolt-foundry/get-configuration-var";
+import { ui } from "@bolt-foundry/cli-ui";
+import { ensureDir } from "@std/fs";
+import { join } from "@std/path";
+
+const EXTEND_API_KEY = getConfigurationVariable("EXTEND_API_KEY");
+const EXTEND_BASE_URL = "https://api.extend.ai";
+const OUTPUT_DIR = Deno.args[0] || "./output";
+
+interface ExtendFile {
+  id: string;
+  name: string;
+  createdAt: string;
+}
+
+interface SpatialTextResult {
+  fileId: string;
+  fileName: string;
+  createdAt: string;
+  markdown: string | null;
+  rawText: string | null;
+}
+
+interface JsonlEntry {
+  user: string;
+  assistant: string;
+  metadata: {
+    fileId: string;
+    fileName: string;
+    createdAt: string;
+  };
+}
+
+if (!EXTEND_API_KEY) {
+  ui.error("❌ EXTEND_API_KEY environment variable is required");
+  Deno.exit(1);
+}
+
+async function step1_fetchFiles(): Promise<Array<ExtendFile>> {
+  ui.info("🔄 Step 1: Fetching files from Extend API...");
+  await ensureDir(OUTPUT_DIR);
+
+  try {
+    const response = await fetch(`${EXTEND_BASE_URL}/files`, {
+      method: "GET",
+      headers: {
+        "Authorization": `Bearer ${EXTEND_API_KEY}`,
+        "x-extend-api-version": "2025-04-21",
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Extend API error: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const data = await response.json();
+    await Deno.writeTextFile(
+      join(OUTPUT_DIR, "extend_output.json"),
+      JSON.stringify(data, null, 2),
+    );
+
+    ui.info(
+      `✅ Step 1 complete: Fetched ${data?.files?.length || "unknown"} files`,
+    );
+    return data.files || [];
+  } catch (error) {
+    ui.error(
+      `❌ Step 1 failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    Deno.exit(1);
+  }
+}
+
+async function step2_fetchSpatialText(
+  files: Array<ExtendFile>,
+): Promise<Array<SpatialTextResult>> {
+  ui.info(`🔄 Step 2: Fetching spatial text for ${files.length} files...`);
+
+  const spatialTextResults: Array<SpatialTextResult> = [];
+
+  for (const file of files) {
+    ui.info(`📄 Processing file: ${file.name} (${file.id}`);
+
+    try {
+      const response = await fetch(
+        `${EXTEND_BASE_URL}/files/${file.id}?rawText=true&markdown=true`,
+        {
+          method: "GET",
+          headers: {
+            "Authorization": `Bearer ${EXTEND_API_KEY}`,
+            "x-extend-api-version": "2025-04-21",
+          },
+        },
+      );
+
+      if (!response.ok) {
+        ui.warn(
+          `⚠️  Failed to fetch file ${file.id}: ${response.status} ${response.statusText}`,
+        );
+        continue;
+      }
+
+      const fileData = await response.json();
+
+      spatialTextResults.push({
+        fileId: file.id,
+        fileName: file.name,
+        createdAt: file.createdAt,
+        markdown: fileData.file?.contents?.pages?.[0]?.markdown || null,
+        rawText: fileData.file?.contents?.rawText || null,
+      });
+
+      ui.info(`✅ Fetched spatial text for ${file.name}`);
+
+      // Small delay to avoid rate limiting
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    } catch (error) {
+      ui.warn(
+        `⚠️  Error processing file ${file.id}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+
+  await Deno.writeTextFile(
+    join(OUTPUT_DIR, "spatial_text_output.json"),
+    JSON.stringify(spatialTextResults, null, 2),
+  );
+  ui.info(
+    `✅ Step 2 complete: Fetched spatial text for ${spatialTextResults.length} files`,
+  );
+
+  return spatialTextResults;
+}
+
+async function step3_convertToJsonl(
+  spatialTextData: Array<SpatialTextResult>,
+): Promise<number> {
+  ui.info(
+    `🔄 Step 3: Converting ${spatialTextData.length} invoice spatial texts to JSONL...`,
+  );
+
+  const jsonlLines: Array<string> = [];
+
+  for (const invoice of spatialTextData) {
+    if (invoice.markdown) {
+      const jsonlEntry: JsonlEntry = {
+        user:
+          `Extract line items from this invoice spatial text:\n\n${invoice.markdown}`,
+        assistant:
+          "I'll extract the line items from this invoice. Let me analyze the spatial text and provide structured JSON output.",
+        metadata: {
+          fileId: invoice.fileId,
+          fileName: invoice.fileName,
+          createdAt: invoice.createdAt,
+        },
+      };
+
+      jsonlLines.push(JSON.stringify(jsonlEntry));
+    }
+  }
+
+  await Deno.writeTextFile(
+    join(OUTPUT_DIR, "invoice_spatial_text.jsonl"),
+    jsonlLines.join("\n") + "\n",
+  );
+  ui.info(
+    `✅ Step 3 complete: Converted ${jsonlLines.length} invoices to JSONL`,
+  );
+
+  return jsonlLines.length;
+}
+
+async function runPipeline(): Promise<void> {
+  ui.info("🚀 Starting Extend invoice extraction pipeline...");
+  ui.info(`📁 Output directory: ${OUTPUT_DIR}`);
+  ui.info("=====================================");
+
+  try {
+    // Step 1: Fetch file list
+    const files = await step1_fetchFiles();
+
+    // Step 2: Extract spatial text
+    const spatialTextData = await step2_fetchSpatialText(files);
+
+    // Step 3: Convert to JSONL
+    const jsonlCount = await step3_convertToJsonl(spatialTextData);
+
+    ui.info("=====================================");
+    ui.info("🎉 Pipeline completed successfully!");
+    ui.info(`📁 Files created in ${OUTPUT_DIR}:`);
+    ui.info(`   - extend_output.json (${files.length} files)`);
+    ui.info(
+      `   - spatial_text_output.json (${spatialTextData.length} invoices with spatial text)`,
+    );
+    ui.info(
+      `   - invoice_spatial_text.jsonl (${jsonlCount} training samples)`,
+    );
+  } catch (error) {
+    ui.error(
+      `❌ Pipeline failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    Deno.exit(1);
+  }
+}
+
+if (import.meta.main) {
+  await runPipeline();
+}


### PR DESCRIPTION

Create automated pipeline to fetch invoice data from Extend API and convert to JSONL format for training data preparation. This supports the line item extraction project by providing a clean data ingestion workflow.

Changes:
- Add customers/munchinsights.com/scripts/extend-pipeline.ts with full API integration
- Implement configurable output directory support (defaults to ./output)
- Add proper TypeScript interfaces for ExtendFile, SpatialTextResult, and JsonlEntry
- Replace console usage with @bolt-foundry/cli-ui for consistent logging
- Remove unused assert import from aibff e2e test file

Test plan:
1. Set EXTEND_API_KEY environment variable
2. Run: ./customers/munchinsights.com/scripts/extend-pipeline.ts
3. Verify output files are created in ./output directory
4. Run: bft lint to confirm no linting issues

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
