### PR TITLE
Add PORT environment variable fallback for web server

### DIFF
--- a/apps/web/web.tsx
+++ b/apps/web/web.tsx
@@ -31,7 +31,11 @@ async function handleRequestWrapper(req: Request): Promise<Response> {
 }
 
 // Use the port from environment or default 8000
-const port = Number(getConfigurationVariable("WEB_PORT") ?? 8000);
+const port = Number(
+  getConfigurationVariable("PORT") ??
+    getConfigurationVariable("WEB_PORT") ??
+    8000,
+);
 
 // Start the server if this is the main module
 if (import.meta.main) {


### PR DESCRIPTION
Support standard PORT environment variable for deployment compatibility,
while maintaining backward compatibility with WEB_PORT.

Changes:
- Add PORT as primary environment variable option in apps/web/web.tsx
- Maintain fallback chain: PORT → WEB_PORT → 8000
- Improve deployment flexibility for standard hosting platforms

Test plan:
1. Run web server: `bft devTools`
2. Test with PORT=3000: `PORT=3000 bft devTools`
3. Test with WEB_PORT=4000: `WEB_PORT=4000 bft devTools`
4. Verify fallback to 8000 when neither is set

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/1350)
<!-- GitContextEnd -->