### PR TITLE
Add CI command and type check support to BFT tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
             # Pre-cache dependencies
             npm install
             deno install
-            bff ci --include-bolt-foundry -g
+            bft ci --include-bolt-foundry -g
           "
 
       # Debug before save

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -77,23 +77,25 @@
     ".sl",
     ".direnv",
     ".git",
+    ".deno/**",
     "build",
     "static",
     "**/__TEMPLATE__.*",
     "**/*.disabled.*",
     "thirdParty",
     "**/npm",
-    "node_modules",
+    "node_modules/**",
+    "**/node_modules/**",
     "examples/**",
     "**/dist/**",
-    "packages/aibff"
+    "packages/aibff",
+    "apps/contacts/**"
   ],
   "lint": {
     "exclude": [
       "**/__generated__/**",
       "**/__isograph/**",
       "examples/**",
-      "apps/contacts/**",
       "**/dist/**"
     ],
     "plugins": ["./infra/lint/bolt-foundry.ts"],

--- a/infra/bft/tasks/check.bft.ts
+++ b/infra/bft/tasks/check.bft.ts
@@ -1,0 +1,30 @@
+import { runShellCommand } from "@bfmono/infra/bff/shellBase.ts";
+import { getLogger } from "@bfmono/packages/logger/logger.ts";
+import type { TaskDefinition } from "@bfmono/infra/bft/bft.ts";
+
+const logger = getLogger(import.meta);
+
+export async function checkCommand(options: Array<string>): Promise<number> {
+  logger.info("Running Deno type check...");
+
+  const args = ["deno", "check"];
+
+  // Add all arguments (no custom flags needed for basic check)
+  args.push(...options);
+
+  const result = await runShellCommand(args);
+
+  if (result === 0) {
+    logger.info("✨ Type check passed!");
+  } else {
+    logger.error("❌ Type check failed");
+  }
+
+  return result;
+}
+
+export const bftDefinition = {
+  description: "Run Deno type check",
+  fn: checkCommand,
+  aiSafe: true,
+} satisfies TaskDefinition;

--- a/infra/bft/tasks/ci.bft.ts
+++ b/infra/bft/tasks/ci.bft.ts
@@ -1,0 +1,136 @@
+import { getLogger } from "@bfmono/packages/logger/logger.ts";
+import { runShellCommandWithOutput } from "@bfmono/infra/bff/shellBase.ts";
+import { loggerGithub } from "@bfmono/infra/bff/githubLogger.ts";
+import { refreshAllSecrets } from "@bfmono/packages/get-configuration-var/get-configuration-var.ts";
+import type { TaskDefinition } from "@bfmono/infra/bft/bft.ts";
+import { buildCommand } from "./build.bft.ts";
+import { testCommand } from "./test.bft.ts";
+import { formatCommand } from "./format.bft.ts";
+import { lintCommand } from "./lint.bft.ts";
+import { e2eCommand } from "./e2e.bft.ts";
+import { checkCommand } from "./check.bft.ts";
+
+const logger = getLogger(import.meta);
+
+type GhMeta = {
+  file?: string;
+  line?: number;
+  col?: number;
+};
+
+// Quick helpers to unify normal logging & GH annotations
+const logCI = {
+  info: (msg: string) => {
+    logger.info(msg);
+  },
+  error: (msg: string, meta?: GhMeta) => {
+    if (meta) {
+      loggerGithub.error(msg, meta);
+    } else {
+      logger.error(msg);
+    }
+  },
+  warn: (msg: string, meta?: GhMeta) => {
+    if (meta) {
+      loggerGithub.warn(msg, meta);
+    } else {
+      logger.warn(msg);
+    }
+  },
+  debug: (msg: string, meta?: GhMeta) => {
+    if (meta) {
+      loggerGithub.warn(msg, meta);
+    } else {
+      logger.debug(msg);
+    }
+  },
+};
+
+async function runInstallStep(_useGithub: boolean): Promise<number> {
+  logger.info("Caching dependencies via deno install");
+  const { code } = await runShellCommandWithOutput(
+    ["deno", "install"],
+    {},
+    true,
+    false,
+  );
+  return code;
+}
+
+export async function ciCommand(options: Array<string>): Promise<number> {
+  await refreshAllSecrets();
+  logger.info("Running CI checks...");
+  const useGithub = options.includes("-g");
+
+  // 1) Install / "deno install"
+  const installResult = await runInstallStep(useGithub);
+  if (installResult !== 0) {
+    logCI.error("Install step failed");
+    return installResult;
+  }
+
+  // 2) Build step
+  const buildArgs = options.includes("--include-bolt-foundry")
+    ? ["--include-bolt-foundry"]
+    : [];
+  const buildResult = await buildCommand(buildArgs);
+  if (buildResult !== 0) {
+    logCI.error("Build step failed");
+    return buildResult;
+  }
+
+  // 3) Lint (with GitHub annotations if requested)
+  const lintArgs = useGithub ? ["-g"] : [];
+  const lintResult = await lintCommand(lintArgs);
+  if (lintResult !== 0) {
+    logCI.error("Lint step failed");
+    return lintResult;
+  }
+
+  // 4) Unit Tests
+  const testResult = await testCommand([]);
+  if (testResult !== 0) {
+    logCI.error("Test step failed");
+    return testResult;
+  }
+
+  // 5) E2E Tests
+  const e2eTestResult = await e2eCommand(["--build"]);
+  if (e2eTestResult !== 0) {
+    logCI.error("E2E test step failed");
+    return e2eTestResult;
+  }
+
+  // 6) Format check
+  const fmtResult = await formatCommand(["--check"]);
+  if (fmtResult !== 0) {
+    logCI.error("Format check failed");
+    return fmtResult;
+  }
+
+  // 7) Type check
+  const typecheckResult = await checkCommand([]);
+  if (typecheckResult !== 0) {
+    logCI.error("Type check failed");
+    return typecheckResult;
+  }
+
+  logger.info("\n📊 CI Checks Summary:");
+  logger.info(`Install:   ✅`);
+  logger.info(`Build:     ✅`);
+  logger.info(`Lint:      ✅`);
+  logger.info(`Test:      ✅`);
+  logger.info(`E2E Test:  ✅`);
+  logger.info(`Format:    ✅`);
+  logger.info(`TypeCheck: ✅`);
+
+  logger.info("All CI checks passed");
+  return 0;
+}
+
+export const bftDefinition = {
+  description:
+    "Run CI checks (lint, test, build, format). E.g. `bft ci -g` for GH annotations.",
+  fn: ciCommand,
+  aiSafe: true,
+} satisfies TaskDefinition;


### PR DESCRIPTION

Implement comprehensive CI pipeline command and standalone type checking to improve
development workflow and ensure code quality across the monorepo.

Changes:
- Add infra/bft/tasks/ci.bft.ts with full CI pipeline (install, build, lint, test, e2e, format, typecheck)
- Add infra/bft/tasks/check.bft.ts for standalone Deno type checking
- Update .github/workflows/ci.yml to use bft instead of bff command
- Update deno.jsonc to exclude additional directories and files from linting/type checking
- Add proper node_modules and .deno directory exclusions

Test plan:
1. Run the new CI command: bft ci
2. Test type checking: bft check
3. Verify GitHub Actions workflow uses correct command
4. Confirm excluded directories are properly ignored during linting

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
