### PR TITLE
Streamline Claude post-update hook to remove linting step

### DIFF
--- a/.claude/post-update-hook.ts
+++ b/.claude/post-update-hook.ts
@@ -88,13 +88,11 @@ function isTargetFile(filePath: string): boolean {
 async function runBftCommands(filePath: string): Promise<void> {
   const commands = [
     { name: "format", args: ["bft", "format", filePath] },
-    { name: "lint", args: ["bft", "lint", filePath] },
     { name: "check", args: ["bft", "check", filePath] },
   ];
 
   const errors: Array<string> = [];
   let hasTypeErrors = false;
-  let hasLintErrors = false;
 
   for (const { name, args } of commands) {
     try {
@@ -121,9 +119,6 @@ async function runBftCommands(filePath: string): Promise<void> {
           if (typeErrorLines) {
             errors.push(`Type errors in ${filePath}:\n${typeErrorLines}`);
           }
-        } else if (name === "lint") {
-          hasLintErrors = true;
-          errors.push(`Lint issues in ${filePath}:\n${stderrText}`);
         } else {
           errors.push(`${name} failed for ${filePath}:\n${stderrText}`);
         }
@@ -145,14 +140,9 @@ async function runBftCommands(filePath: string): Promise<void> {
         `\n❌ Type checking failed - please fix the type errors above.`,
       );
     }
-    if (hasLintErrors) {
-      ui.output(
-        `\n⚠️  Linting issues detected - some may have been auto-fixed.`,
-      );
-    }
   } else {
     ui.output(
-      `\n✅ File ${filePath} passed all checks (format, lint, type check)`,
+      `\n✅ File ${filePath} passed all checks (format, type check)`,
     );
   }
 }


### PR DESCRIPTION

Remove lint checking from the automated post-update hook to improve performance
and reduce friction in the development workflow while maintaining essential
code quality checks.

Changes:
- Remove lint command from runBftCommands function
- Remove hasLintErrors tracking variable
- Remove lint error handling and messaging
- Update success message to reflect current checks (format, type check)

Test plan:
1. Make a code change and save a file
2. Verify the post-update hook runs format and type check only
3. Confirm no linting errors are reported
4. Verify success message shows correct checks performed

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/1360).
* #1361
* __->__ #1360