### PR TITLE
Update Nix flake to latest nixpkgs-unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -36,17 +36,17 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1748649377,
-        "narHash": "sha256-h+xqzmUWhghq5kl57EPH2z3oL9fmO/pmZRa3+PoujTg=",
+        "lastModified": 1751450686,
+        "narHash": "sha256-hjTeWbhKAoH9wTzHrz/FOT51QxTzZgMBEUrnkRzBNG4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9276d3225945c544c6efab8210686bd7612a9115",
+        "rev": "1e968849c167dd400b51e2d87083d19242c1c315",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9276d3225945c544c6efab8210686bd7612a9115",
+        "rev": "1e968849c167dd400b51e2d87083d19242c1c315",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   inputs = {
     nixpkgs.url          = "github:NixOS/nixpkgs/26e168479fdc7a75fe55e457e713d8b5f794606a";
     flake-utils.url      = "github:numtide/flake-utils";
-    nixpkgs-unstable.url = "github:NixOS/nixpkgs/9276d3225945c544c6efab8210686bd7612a9115";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/1e968849c167dd400b51e2d87083d19242c1c315";
   };
 
   ########################


### PR DESCRIPTION

Update nixpkgs-unstable from 9276d32 to 1e96884 for latest package versions
and security updates in the development environment.

Changes:
- Update flake.nix nixpkgs-unstable URL to latest commit
- Update flake.lock with new package hashes and versions

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
