### PR TITLE
Replace BFT --help flags with centralized help command system

### DIFF
--- a/infra/bft/bft.ts
+++ b/infra/bft/bft.ts
@@ -10,30 +10,68 @@ export interface TaskDefinition {
   description: string;
   fn: (args: Array<string>) => number | Promise<number>;
   aiSafe?: boolean | ((args: Array<string>) => boolean);
+  helpText?: string;
 }
 
 export const taskMap = new Map<string, TaskDefinition>();
 
 // Built-in help task
 export const help: TaskDefinition = {
-  description: "Show available tasks",
+  description: "Show available tasks or detailed help for a specific task",
   aiSafe: true,
-  fn: (_args: Array<string>) => {
-    ui.output("Available tasks:\n");
+  fn: (args: Array<string>) => {
+    if (args.length === 0) {
+      // Show all available tasks
+      ui.output("Available tasks:\n");
 
-    const tasks = Array.from(taskMap.entries())
-      .sort(([a], [b]) => a.localeCompare(b));
+      const tasks = Array.from(taskMap.entries())
+        .sort(([a], [b]) => a.localeCompare(b));
 
-    for (const [name, task] of tasks) {
-      let aiSafeIndicator = "";
-      if (typeof task.aiSafe === "boolean") {
-        aiSafeIndicator = task.aiSafe ? " (AI-safe)" : "";
-      } else if (typeof task.aiSafe === "function") {
-        aiSafeIndicator = " (conditionally AI-safe)";
-      } else {
-        aiSafeIndicator = " (AI-safe)"; // default is safe
+      for (const [name, task] of tasks) {
+        let aiSafeIndicator = "";
+        if (typeof task.aiSafe === "boolean") {
+          aiSafeIndicator = task.aiSafe ? " (AI-safe)" : "";
+        } else if (typeof task.aiSafe === "function") {
+          aiSafeIndicator = " (conditionally AI-safe)";
+        } else {
+          aiSafeIndicator = " (AI-safe)"; // default is safe
+        }
+        ui.output(`  ${name.padEnd(20)} ${task.description}${aiSafeIndicator}`);
       }
-      ui.output(`  ${name.padEnd(20)} ${task.description}${aiSafeIndicator}`);
+
+      ui.output(
+        "\nUse 'bft help <command>' for detailed help on a specific command.",
+      );
+      return 0;
+    }
+
+    // Show help for specific command
+    const commandName = args[0];
+    const task = taskMap.get(commandName);
+
+    if (!task) {
+      ui.error(`Unknown command: ${commandName}`);
+      ui.output("Use 'bft help' to see all available commands.");
+      return 1;
+    }
+
+    ui.output(`Command: ${commandName}`);
+    ui.output(`Description: ${task.description}`);
+
+    let aiSafeIndicator = "";
+    if (typeof task.aiSafe === "boolean") {
+      aiSafeIndicator = task.aiSafe ? "AI-safe" : "Not AI-safe";
+    } else if (typeof task.aiSafe === "function") {
+      aiSafeIndicator = "Conditionally AI-safe";
+    } else {
+      aiSafeIndicator = "AI-safe"; // default is safe
+    }
+    ui.output(`AI Safety: ${aiSafeIndicator}`);
+
+    if (task.helpText) {
+      ui.output("\n" + task.helpText);
+    } else {
+      ui.output("\nNo additional help available for this command.");
     }
 
     return 0;

--- a/infra/bft/tasks/app.bft.ts
+++ b/infra/bft/tasks/app.bft.ts
@@ -27,32 +27,12 @@ async function app(args: Array<string>): Promise<number> {
 
   // Handle boltfoundry.com app
   const flags = parseArgs(appArgs, {
-    boolean: ["dev", "build", "no-open", "help"],
+    boolean: ["dev", "build", "no-open"],
     string: ["port"],
     default: {
       port: "3000",
     },
   });
-
-  if (flags.help) {
-    ui.output(`Usage: bft app boltfoundry-com [OPTIONS]
-
-Launch the Bolt Foundry landing page
-
-Options:
-  --dev              Run in development mode with Vite HMR
-  --build            Build assets without starting server
-  --port             Specify server port (default: 3000)
-  --no-open          Don't auto-open browser on startup
-  --help             Show this help message
-
-Examples:
-  bft app boltfoundry-com                   # Run production server
-  bft app boltfoundry-com --dev             # Run in development mode
-  bft app boltfoundry-com --build           # Build assets only
-  bft app boltfoundry-com --port 4000       # Run on port 4000`);
-    return 0;
-  }
 
   const port = parseInt(flags.port);
   if (isNaN(port)) {
@@ -222,6 +202,24 @@ export const bftDefinition = {
   description: "Launch web applications",
   aiSafe: true,
   fn: app,
+  helpText: `Usage: bft app <app-name> [OPTIONS]
+
+Launch web applications
+
+Available apps:
+  boltfoundry-com    Bolt Foundry landing page
+
+App-specific options for boltfoundry-com:
+  --dev              Run in development mode with Vite HMR
+  --build            Build assets without starting server
+  --port             Specify server port (default: 3000)
+  --no-open          Don't auto-open browser on startup
+
+Examples:
+  bft app boltfoundry-com                   # Run production server
+  bft app boltfoundry-com --dev             # Run in development mode
+  bft app boltfoundry-com --build           # Build assets only
+  bft app boltfoundry-com --port 4000       # Run on port 4000`,
 } satisfies TaskDefinition;
 
 // When run directly as a script

--- a/infra/bft/tasks/compile.bft.ts
+++ b/infra/bft/tasks/compile.bft.ts
@@ -2,61 +2,29 @@
 
 import type { TaskDefinition } from "../bft.ts";
 import { ui } from "@bfmono/packages/cli-ui/cli-ui.ts";
-import { parseArgs } from "@std/cli";
+import type { parseArgs } from "@std/cli";
 
 async function compile(args: Array<string>): Promise<number> {
-  // Check for global help flag
-  if (args.length === 1 && (args[0] === "--help" || args[0] === "-h")) {
-    ui.output(`Usage: bft compile <app-name> [OPTIONS]
-
-Compile applications to single executable binaries.
-
-Available apps:
-  boltfoundry.com    Bolt Foundry landing page
-
-Examples:
-  bft compile boltfoundry.com           # Compile boltfoundry.com to binary
-  bft compile boltfoundry.com --help    # Show app-specific help`);
-    return 0;
-  }
-
   if (args.length === 0) {
     ui.error("Usage: bft compile <app-name>");
     ui.output("Available apps:");
-    ui.output("  boltfoundry.com    Bolt Foundry landing page");
+    ui.output("  boltfoundry-com    Bolt Foundry landing page");
     return 1;
   }
 
   const appName = args[0];
   const compileArgs = args.slice(1);
 
-  if (appName !== "boltfoundry.com") {
+  if (appName !== "boltfoundry-com") {
     ui.error(`Unknown app: ${appName}`);
     ui.output("Available apps:");
-    ui.output("  boltfoundry.com    Bolt Foundry landing page");
+    ui.output("  boltfoundry-com    Bolt Foundry landing page");
     return 1;
   }
 
-  // Handle boltfoundry.com compilation
-  const flags = parseArgs(compileArgs, {
-    boolean: ["help"],
-  });
-
-  if (flags.help) {
-    ui.output(`Usage: bft compile boltfoundry.com
-
-Compile Bolt Foundry landing page to single executable binary.
-This will build frontend assets and compile the server into a standalone binary.
-
-The binary will be output to: ./build/boltfoundry-com
-
-Examples:
-  bft compile boltfoundry.com    # Build assets and compile to binary`);
-    return 0;
-  }
-
+  // Handle boltfoundry-com compilation
   const appPath =
-    new URL(import.meta.resolve("../../../apps/boltFoundry.com")).pathname;
+    new URL(import.meta.resolve("../../../apps/boltfoundry-com")).pathname;
   const buildDir = new URL(import.meta.resolve("../../../build")).pathname;
 
   // Ensure build directory exists
@@ -89,7 +57,7 @@ Examples:
 
     // Run the build command
     const buildCommand = new Deno.Command("bft", {
-      args: ["app", "boltfoundry.com", "--build"],
+      args: ["app", "boltfoundry-com", "--build"],
       stdout: "inherit",
       stderr: "inherit",
     });
@@ -112,7 +80,7 @@ Examples:
       "compile",
       "--allow-all",
       "--include",
-      "dist",
+      `${appPath}/dist`,
       "--output",
       binaryPath,
       serverPath,
@@ -144,6 +112,17 @@ export const bftDefinition = {
   description: "Compile applications to single binaries",
   aiSafe: true,
   fn: compile,
+  helpText: `Usage: bft compile <app-name>
+
+Compile applications to single executable binaries.
+
+Available apps:
+  boltfoundry-com    Bolt Foundry landing page
+
+The binary will be output to: ./build/boltfoundry-com
+
+Examples:
+  bft compile boltfoundry-com    # Build assets and compile to binary`,
 } satisfies TaskDefinition;
 
 // When run directly as a script

--- a/infra/bft/tasks/sl.bft.ts
+++ b/infra/bft/tasks/sl.bft.ts
@@ -329,4 +329,25 @@ export const bftDefinition = {
     "Sapling proxy with enhanced commit and amend (smart validation)",
   fn: slCommand,
   aiSafe: isSlCommandSafe,
+  helpText: `Usage: bft sl <subcommand> [arguments...]
+
+Sapling proxy with enhanced commit and amend functionality.
+
+Enhanced commands:
+  commit      Create commit with smart validation
+              Usage: bft sl commit -m "message" [--skip-precommit] [--no-submit] [files...]
+  amend       Amend commit with smart validation
+              Usage: bft sl amend [--skip-precommit] [args...]
+
+All other Sapling commands are passed through unchanged.
+
+Examples:
+  bft sl status                              # Show repository status
+  bft sl commit -m "Add feature"             # Create commit with validation
+  bft sl commit -m "Fix bug" --skip-precommit # Skip pre-commit validation
+  bft sl amend                               # Amend last commit with validation
+  bft sl diff                                # Show changes
+  bft sl log                                 # Show commit history
+
+For help on standard Sapling commands, use: bft sl <command> --help`,
 } satisfies TaskDefinition;


### PR DESCRIPTION

Standardize help functionality across all BFT commands by replacing individual --help flag handling with a unified "bft help <command>" system. This provides better consistency and centralizes help documentation in task definitions.

Changes:
- Add helpText field to TaskDefinition interface in infra/bft/bft.ts
- Enhance built-in help command to support "bft help <command>" syntax with detailed help display
- Remove --help flag parsing from app.bft.ts and move help content to task definition
- Remove --help flag parsing from compile.bft.ts and move help content to task definition
- Add comprehensive help text to sl.bft.ts task definition explaining enhanced commands
- Fix compile command path references from boltFoundry.com to boltfoundry-com for consistency

Test plan:
1. Test global help: bft help
2. Test command-specific help: bft help app, bft help compile, bft help sl
3. Verify commands work without --help flags: bft app, bft compile
4. Test error handling: bft help nonexistent-command

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
