### PR TITLE
Implement server-side rendering for boltfoundry-com app

### DIFF
--- a/apps/aibff/commands/gui.ts
+++ b/apps/aibff/commands/gui.ts
@@ -14,7 +14,7 @@ export const guiCommand: Command = {
       boolean: ["dev", "build", "no-open", "help"],
       string: ["port", "conversations-dir"],
       default: {
-        port: "3000",
+        port: "4000",
       },
     });
 

--- a/apps/aibff/gui/guiServer.ts
+++ b/apps/aibff/gui/guiServer.ts
@@ -79,7 +79,7 @@ async function generateInitialMessage(): Promise<string> {
 const flags = parseArgs(Deno.args, {
   string: ["port", "mode", "vite-port", "conversations-dir"],
   default: {
-    port: "3000",
+    port: "4000",
     mode: "production",
     "conversations-dir": undefined,
   },

--- a/apps/aibff/gui/src/components/GraderEditor.tsx
+++ b/apps/aibff/gui/src/components/GraderEditor.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { BfDsButton } from "@bfmono/apps/bfDs/components/BfDsButton.tsx";
+import { BfDsCallout } from "@bfmono/apps/bfDs/components/BfDsCallout.tsx";
 import { getLogger } from "@bolt-foundry/logger";
 import { useDebounced } from "../hooks/useDebounced.ts";
 
@@ -82,50 +83,28 @@ export function GraderEditor(
         <h2 style={{ margin: 0, fontSize: "1.25rem", color: "#fafaff" }}>
           Grader Definition
         </h2>
-        <div style={{ display: "flex", alignItems: "center", gap: "0.75rem" }}>
-          {/* Save status indicator */}
-          <div
-            style={{
-              fontSize: "0.75rem",
-              color: saveStatus === "saved"
-                ? "#4ade80"
-                : saveStatus === "saving"
-                ? "#fbbf24"
-                : "#f87171",
-              fontWeight: 500,
-              display: "flex",
-              alignItems: "center",
-              gap: "0.25rem",
-            }}
-          >
-            <div
-              style={{
-                width: "6px",
-                height: "6px",
-                borderRadius: "50%",
-                backgroundColor: saveStatus === "saved"
-                  ? "#4ade80"
-                  : saveStatus === "saving"
-                  ? "#fbbf24"
-                  : "#f87171",
-              }}
-            />
-            {saveStatus === "saved"
-              ? "Saved"
-              : saveStatus === "saving"
-              ? "Saving..."
-              : "Unsaved"}
-          </div>
-          <BfDsButton
-            onClick={handleSave}
-            variant="primary"
-            size="small"
-            disabled={saveStatus === "saving"}
-          >
-            Save Now
-          </BfDsButton>
-        </div>
+        <BfDsButton
+          onClick={handleSave}
+          variant="primary"
+          size="small"
+          disabled={saveStatus === "saving"}
+        >
+          Save Now
+        </BfDsButton>
       </div>
+
+      {/* Save status callout */}
+      <BfDsCallout
+        variant={saveStatus === "saved"
+          ? "success"
+          : saveStatus === "saving"
+          ? "info"
+          : "warning"}
+        visible={saveStatus !== "saved"}
+        autoDismiss={saveStatus === "saved" ? 3000 : 0}
+      >
+        {saveStatus === "saving" ? "Saving..." : "Unsaved changes"}
+      </BfDsCallout>
 
       {/* Editor */}
       <div

--- a/apps/aibff/memos/plans/2025-07-08-bfds-component-migration-plan.md
+++ b/apps/aibff/memos/plans/2025-07-08-bfds-component-migration-plan.md
@@ -1,0 +1,182 @@
+# AIBFF GUI - bfDs Component Migration Plan
+*Date: 2025-07-08*
+
+## Overview
+
+This plan outlines the migration of AIBFF GUI components to use the Bolt Foundry Design System (bfDs) components, replacing custom UI elements with standardized, accessible, and maintainable components.
+
+## Current State
+
+**bfDs Components Available:** 16 total components
+- Form: BfDsInput, BfDsTextArea, BfDsSelect, BfDsCheckbox, BfDsRadio, BfDsToggle, BfDsForm, BfDsFormSubmitButton
+- UI: BfDsButton, BfDsCallout, BfDsIcon, BfDsList/BfDsListItem, BfDsTabs, BfDsToast/BfDsToastProvider
+
+**Currently Used:** 2 components (13% adoption)
+- BfDsButton (20+ instances across 5 components)
+- BfDsCallout (recently added to GraderEditor)
+
+## Migration Strategy
+
+### Phase 1: Foundation Components
+**Priority: High Impact, Low Risk**
+
+#### 1.1 Replace WorkflowTextArea Component
+- **Target**: `/src/components/WorkflowTextArea.tsx`
+- **Replacement**: `BfDsTextArea`
+- **Impact**: 6 components immediately standardized
+- **Affected Components**:
+  - ActorDeckTab.tsx
+  - GraderDeckTab.tsx 
+  - GroundTruthTab.tsx
+  - InputSamplesTab.tsx
+  - NotesTab.tsx
+  - WorkflowPanel.tsx
+
+#### 1.2 Replace Custom TextAreas
+- **Target**: Custom textarea elements in:
+  - GraderEditor.tsx (lines 124-144)
+  - MessageInput.tsx (lines 60-83)
+- **Replacement**: `BfDsTextArea`
+- **Benefits**: Consistent validation states, accessibility
+
+### Phase 2: UI Enhancement
+**Priority: Medium Impact, Visual Improvement**
+
+#### 2.1 Replace Status Messages
+- **Target**: ChatWithIsograph.tsx
+  - Loading state (lines 372-386) → `BfDsCallout` variant="info"
+  - Error state (lines 388-432) → `BfDsCallout` variant="error"
+- **Target**: ConversationDisplay.tsx
+  - "No conversations" message → `BfDsCallout` variant="info"
+
+#### 2.2 Replace Custom Buttons
+- **Target**: Various custom styled buttons
+  - ChatWithIsograph header link → `BfDsButton` variant="secondary"
+  - WorkflowPanel accordion buttons → `BfDsButton` variant="ghost"
+- **Benefits**: Consistent styling, accessibility
+
+### Phase 3: Advanced Components
+**Priority: High Impact, Complex Changes**
+
+#### 3.1 Replace WorkflowPanel Accordion
+- **Target**: WorkflowPanel.tsx accordion system
+- **Replacement**: `BfDsTabs`
+- **Benefits**: Better UX, standardized interaction patterns
+- **Considerations**: May require UX review for behavior changes
+
+#### 3.2 Replace ConversationDisplay Lists
+- **Target**: ConversationDisplay.tsx custom `<ul>` elements
+- **Replacement**: `BfDsList` + `BfDsListItem`
+- **Benefits**: Consistent list styling, expandable content support
+
+### Phase 4: Form Integration
+**Priority: Medium Impact, Architecture Improvement**
+
+#### 4.1 Add Form Wrappers
+- **Target**: Components with multiple form fields
+- **Replacement**: Wrap with `BfDsForm`
+- **Benefits**: Centralized form state, better validation
+- **Candidates**:
+  - GraderEditor.tsx
+  - MessageInput.tsx
+  - WorkflowPanel.tsx sections
+
+#### 4.2 Replace WorkflowTabButton System
+- **Target**: WorkflowTabButton.tsx + custom tab logic
+- **Replacement**: `BfDsTabs` system
+- **Benefits**: Standardized tab behavior, accessibility
+
+### Phase 5: Polish & Icons
+**Priority: Low Impact, Visual Polish**
+
+#### 5.1 Add Icons
+- **Target**: Visual indicators throughout the app
+- **Replacement**: `BfDsIcon` from 50+ icon library
+- **Candidates**:
+  - Language indicators in CodeBlockWithAction
+  - Dropdown arrows in WorkflowPanel
+  - Status indicators
+
+#### 5.2 Add Toast Notifications
+- **Target**: Future enhancement
+- **Implementation**: `BfDsToastProvider` + `useBfDsToast` hook
+- **Benefits**: Consistent notification system
+
+## Technical Considerations
+
+### Dependencies
+- All bfDs components already available via `@bfmono/apps/bfDs/components/`
+- No additional dependencies required
+
+### Type Safety
+- All bfDs components include full TypeScript interfaces
+- Migration will improve type safety across the application
+
+### Styling
+- bfDs components use consistent theming
+- Custom styles will be reduced significantly
+- CSS custom properties for theming integration
+
+### Testing
+- Each phase should include component testing
+- Visual regression testing recommended
+- Accessibility testing with updated components
+
+### Performance
+- bfDs components are optimized for performance
+- Reduction in custom CSS will improve bundle size
+- Form state management improvements
+
+## Success Metrics
+
+### Quantitative
+- **Code Reduction**: ~85% reduction in custom UI code
+- **Component Usage**: From 13% to 80%+ bfDs adoption
+- **Consistency**: Standardized UI patterns across application
+
+### Qualitative
+- **Developer Experience**: Faster feature development
+- **Accessibility**: Improved keyboard navigation and screen reader support
+- **Maintainability**: Centralized component updates
+- **User Experience**: Consistent interaction patterns
+
+## Risk Assessment
+
+### Low Risk
+- Phase 1 (WorkflowTextArea replacement) - Direct API compatibility
+- Status message replacements - Additive changes
+
+### Medium Risk
+- WorkflowPanel accordion → BfDsTabs - Behavior changes
+- Form integration - State management changes
+
+### High Risk
+- WorkflowTabButton system replacement - Complex state logic
+
+## Implementation Notes
+
+### Code Standards
+- Follow existing import patterns: `import { BfDsButton } from "@bfmono/apps/bfDs/components/BfDsButton.tsx"`
+- Maintain TypeScript array syntax: `Array<T>` not `T[]`
+- Use `bft test` for testing throughout migration
+
+### Rollback Strategy
+- Each phase can be independently rolled back
+- Keep original components until migration is verified
+- Feature flags for gradual rollout if needed
+
+### Documentation
+- Update component documentation as migration progresses
+- Create migration guide for future similar projects
+- Document any custom styling requirements
+
+## Next Steps
+
+1. Begin Phase 1 with WorkflowTextArea replacement
+2. Establish visual regression testing
+3. Verify all bfDs components work in aibff context
+4. Review Phase 3 changes with design team
+
+## Conclusion
+
+This migration will significantly improve the AIBFF GUI's consistency, accessibility, and maintainability while reducing custom code by ~85%. The phased approach minimizes risk while delivering incremental value throughout the process.

--- a/apps/aibff/memos/plans/2025-07-aibff-gui-right-panel-redesign.md
+++ b/apps/aibff/memos/plans/2025-07-aibff-gui-right-panel-redesign.md
@@ -11,6 +11,9 @@
 The existing `TabbedEditor` component has been replaced with the new
 `WorkflowPanel` accordion.
 
+🔄 **UPDATE**: The accordion workflow will be restructured into a cleaner 4-tab
+interface based on user feedback and workflow optimization.
+
 ## Implementation Completed (July 2025)
 
 ### New WorkflowPanel Accordion ✅
@@ -60,21 +63,58 @@ WorkflowPanel (radio-style accordion)
 - **State management**: Each section has independent state hooks for content
   persistence
 
-## Technical Implementation Plan
+## Updated Technical Implementation Plan
 
-### 1. New Component Architecture
+### 1. New Four-Tab Component Architecture
 
 ```
-WorkflowPanel (new root component)
-├── WorkflowTabs (tab navigation)
-├── InputSamplesTab (existing functionality)
-├── SystemPromptTab (renamed from Actor Deck)
-├── OutputSamplesTab (new JSONL editor)
-├── EvalPromptTab (renamed from Grader Deck)
-├── EvalOutputTab (new results display)
-├── FixTab (new AI feedback UI)
-└── EditTab (new file browser)
+WorkflowPanel (updated root component)
+├── BfDs Tab Navigation (using BfDs tab components)
+├── SystemPromptTab (consolidates system prompt, input variables, test conversation)
+├── CalibrateTab (saved results → ground truth grading workflow)
+├── EvalTab (grader creation and execution per dimension)
+└── FixTab (outlier analysis and grader/prompt refinement)
 ```
+
+### 2. Detailed Tab Workflow Structure
+
+#### Tab 1: System Prompt
+
+**Purpose**: Core prompt development and testing **Content**: Consolidates first
+3 accordion sections:
+
+- System Prompt editor
+- Input Variables (JSONL format)
+- Test Conversation (ephemeral chat interface)
+- Saved Results (conversation save/load)
+- Ground Truth (graded samples with explanations)
+
+#### Tab 2: Calibrate
+
+**Purpose**: Sample grading and ground truth generation **Content**:
+
+- Display saved conversation results
+- Grading interface (+3 to -3 scale)
+- Description field for grading rationale
+- Move graded samples to ground truth collection
+
+#### Tab 3: Eval
+
+**Purpose**: Grader creation and execution **Content**:
+
+- Multiple grader management (one per dimension)
+- Grader editor for each dimension
+- Execution interface against ground truth data
+- Results display and metrics
+
+#### Tab 4: Fix
+
+**Purpose**: Iterative improvement based on results **Content**:
+
+- Evaluation results analysis
+- Outlier identification and filtering
+- Grader refinement interface
+- System prompt adjustment tools
 
 ### 2. Tab-Specific Implementation Details
 
@@ -212,15 +252,19 @@ input ConversationUpdateInput {
       Conversation, Saved Results, Calibration, Eval Prompt, Run Eval, Files
 - [x] **State management** - Each section has independent content state
 
-### Phase 2: Tool Call Enhancement (CURRENT PRIORITY)
+### Phase 2: Four-Tab Restructure (CURRENT PRIORITY)
 
-- [ ] **Implement placeholder tool functions** - Connect to actual file
-      operations
-- [ ] **Enhanced tool call integration** - System Prompt and Input Variables
-      tool calls
-- [ ] **Test Conversation functionality** - Ephemeral chat interface for prompt
-      testing
-- [ ] **Saved Results implementation** - Save/load conversation outputs as JSONL
+- [ ] **Implement BfDs tab navigation** - Replace accordion with proper tab
+      interface
+- [ ] **Restructure SystemPromptTab** - Consolidate system prompt, input
+      variables, test conversation, saved results, and ground truth into single
+      tab
+- [ ] **Create CalibrateTab** - Grading interface for saved results with +3 to
+      -3 scale and descriptions
+- [ ] **Enhance EvalTab** - Multiple grader management and execution against
+      ground truth
+- [ ] **Implement FixTab** - Outlier analysis and iterative improvement
+      interface
 
 ### Phase 3: File Integration (NEXT)
 
@@ -322,14 +366,18 @@ getConversationFiles() -> Array<{name: string, size: number, modified: string}>
    persistence
 5. **E2E Testing**: ✅ Screenshot-based verification of accordion functionality
 
-### Phase 2 Goals (Tool Call Enhancement)
+### Phase 2 Goals (Four-Tab Restructure)
 
-1. **Tool Call Implementation**: Implement placeholder tool functions for real
-   workflow integration
-2. **Test Conversation**: Build ephemeral chat interface within accordion
-   section
-3. **Saved Results**: JSONL save/load functionality for conversation outputs
-4. **File Operations**: Connect accordion sections to actual file persistence
+1. **BfDs Tab Integration**: Replace accordion with proper tab navigation using
+   BfDs components
+2. **SystemPromptTab Enhancement**: Consolidate 5 accordion sections into
+   cohesive single-tab workflow
+3. **CalibrateTab Implementation**: Build grading interface with +3 to -3 scale
+   and ground truth generation
+4. **EvalTab Multi-Grader Support**: Support multiple graders per dimension with
+   execution capabilities
+5. **FixTab Outlier Analysis**: Results analysis and iterative improvement
+   interface
 
 ### Future Goals
 

--- a/apps/boltfoundry-com/ClientRoot.tsx
+++ b/apps/boltfoundry-com/ClientRoot.tsx
@@ -1,0 +1,30 @@
+import { hydrateRoot } from "react-dom/client";
+import App from "./src/App.tsx";
+import "./src/index.css";
+
+export interface ClientRootProps {
+  environment: Record<string, unknown>;
+}
+
+export function ClientRoot({ environment: _environment }: ClientRootProps) {
+  return <App />;
+}
+
+export function rehydrate(environment: Record<string, unknown>) {
+  const root = document.querySelector("#root");
+  if (root) {
+    hydrateRoot(
+      root,
+      <ClientRoot environment={environment} />,
+    );
+  }
+}
+
+// @ts-expect-error Not typed on the window yet
+if (globalThis.__ENVIRONMENT__) {
+  // @ts-expect-error Not typed on the window yet
+  rehydrate(globalThis.__ENVIRONMENT__);
+} else {
+  // @ts-expect-error Not typed on the window yet
+  globalThis.__REHYDRATE__ = rehydrate;
+}

--- a/apps/boltfoundry-com/__tests__/e2e/ssr.test.e2e.ts
+++ b/apps/boltfoundry-com/__tests__/e2e/ssr.test.e2e.ts
@@ -1,0 +1,228 @@
+import { assert, assertEquals } from "@std/assert";
+import {
+  navigateTo,
+  teardownE2ETest,
+} from "@bfmono/infra/testing/e2e/setup.ts";
+import { getLogger } from "@bfmono/packages/logger/logger.ts";
+import { setupBoltFoundryComTest } from "../helpers.ts";
+
+const logger = getLogger(import.meta);
+
+Deno.test("SSR landing page loads and hydrates correctly", async () => {
+  const context = await setupBoltFoundryComTest();
+
+  try {
+    // Navigate to the home page
+    await navigateTo(context, "/");
+
+    // Take screenshot after initial page load
+    await context.takeScreenshot("ssr-landing-page-initial");
+
+    // Wait for content to ensure page loaded
+    const title = await context.page.title();
+    logger.info(`Page title: ${title}`);
+
+    // Verify the page title is correct
+    assertEquals(title, "Bolt Foundry", "Page title should be 'Bolt Foundry'");
+
+    // Check if the page contains expected server-rendered content
+    const bodyText = await context.page.evaluate(() =>
+      document.body.textContent
+    );
+
+    // Verify core landing page content is present
+    assert(
+      bodyText?.includes("Bolt Foundry"),
+      "Page should contain 'Bolt Foundry' heading",
+    );
+
+    assert(
+      bodyText?.includes("Coming Soon"),
+      "Page should contain 'Coming Soon' text",
+    );
+
+    assert(
+      bodyText?.includes("Phase 1 implementation"),
+      "Page should contain Phase 1 implementation text",
+    );
+
+    assert(
+      bodyText?.includes("Architecture foundation established"),
+      "Page should contain architecture foundation text",
+    );
+
+    assert(
+      bodyText?.includes("© 2025 Bolt Foundry. All rights reserved."),
+      "Page should contain copyright footer",
+    );
+
+    // Verify SSR-specific elements are present
+    const rootElement = await context.page.$("#root");
+    assert(rootElement, "Page should have #root element for React hydration");
+
+    // Check that the server rendered the initial HTML structure
+    const appElement = await context.page.$(".app");
+    assert(appElement, "Page should have .app element from server rendering");
+
+    // Verify that the client bundle script is loaded
+    const clientScript = await context.page.evaluate(() => {
+      const script = document.querySelector(
+        'script[src="/static/build/ClientRoot.js"]',
+      );
+      return script !== null;
+    });
+    assert(clientScript, "Page should include ClientRoot.js script");
+
+    // Verify that the __ENVIRONMENT__ global is set up for rehydration
+    const hasEnvironment = await context.page.evaluate(() => {
+      // @ts-expect-error - Testing runtime global
+      return typeof globalThis.__ENVIRONMENT__ === "object";
+    });
+    assert(
+      hasEnvironment,
+      "Page should have __ENVIRONMENT__ global for rehydration",
+    );
+
+    // Verify the environment contains expected data
+    const environment = await context.page.evaluate(() => {
+      // @ts-expect-error - Testing runtime global
+      return globalThis.__ENVIRONMENT__;
+    });
+    assert(environment?.mode, "Environment should contain mode");
+    assert(environment?.port, "Environment should contain port");
+
+    // Verify that CSS styles are applied correctly
+    const headerStyles = await context.page.evaluate(() => {
+      const header = document.querySelector(".app-header");
+      if (!header) return null;
+      const styles = globalThis.getComputedStyle(header);
+      return {
+        background: styles.background,
+        color: styles.color,
+        textAlign: styles.textAlign,
+      };
+    });
+
+    assert(
+      headerStyles?.textAlign === "center",
+      "Header should be center-aligned",
+    );
+    assert(
+      headerStyles?.color.includes("255, 255, 255") ||
+        headerStyles?.color === "white",
+      "Header text should be white",
+    );
+
+    // Test that the page is interactive (hydration worked)
+    await new Promise((resolve) => setTimeout(resolve, 1000)); // Give time for hydration
+
+    // Take screenshot after hydration
+    await context.takeScreenshot("ssr-landing-page-hydrated");
+
+    logger.info("SSR landing page test completed successfully");
+  } catch (error) {
+    // Take screenshot on test failure
+    await context.takeScreenshot("ssr-landing-page-error");
+    logger.error("SSR test failed:", error);
+    throw error;
+  } finally {
+    await teardownE2ETest(context);
+  }
+});
+
+Deno.test("SSR serves correct response headers", async () => {
+  const context = await setupBoltFoundryComTest();
+
+  try {
+    // Make request and check response headers
+    const response = await context.page.goto("/");
+
+    // Verify response is successful
+    assertEquals(response?.status(), 200, "Response should be 200 OK");
+
+    // Verify content type is HTML
+    const contentType = response?.headers()["content-type"];
+    assert(
+      contentType?.includes("text/html"),
+      "Response should have HTML content type",
+    );
+
+    // Get the raw HTML to verify server-side rendering
+    const html = await response?.text();
+
+    // Verify that the HTML contains server-rendered content
+    assert(
+      html?.includes('<div class="app">'),
+      "HTML should contain server-rendered app structure",
+    );
+
+    assert(
+      html?.includes("Bolt Foundry"),
+      "HTML should contain server-rendered heading",
+    );
+
+    assert(
+      html?.includes("Coming Soon"),
+      "HTML should contain server-rendered subtitle",
+    );
+
+    // Verify that the rehydration script is included
+    assert(
+      html?.includes("globalThis.__ENVIRONMENT__"),
+      "HTML should include environment setup for rehydration",
+    );
+
+    logger.info("SSR response headers test completed successfully");
+  } catch (error) {
+    await context.takeScreenshot("ssr-headers-test-error");
+    logger.error("SSR headers test failed:", error);
+    throw error;
+  } finally {
+    await teardownE2ETest(context);
+  }
+});
+
+Deno.test("SSR handles static assets correctly", async () => {
+  const context = await setupBoltFoundryComTest();
+
+  try {
+    // Navigate to the home page first
+    await navigateTo(context, "/");
+
+    // Test that CSS is loaded correctly
+    const cssResponse = await context.page.goto("/static/index.css");
+    assertEquals(
+      cssResponse?.status(),
+      200,
+      "CSS should be served successfully",
+    );
+
+    const cssContentType = cssResponse?.headers()["content-type"];
+    assert(
+      cssContentType?.includes("text/css"),
+      "CSS should have correct content type",
+    );
+
+    // Test that JavaScript is loaded correctly
+    const jsResponse = await context.page.goto("/static/build/ClientRoot.js");
+    assertEquals(
+      jsResponse?.status(),
+      200,
+      "JavaScript should be served successfully",
+    );
+
+    const jsContentType = jsResponse?.headers()["content-type"];
+    assert(
+      jsContentType?.includes("javascript"),
+      "JavaScript should have correct content type",
+    );
+
+    logger.info("SSR static assets test completed successfully");
+  } catch (error) {
+    await context.takeScreenshot("ssr-assets-test-error");
+    logger.error("SSR static assets test failed:", error);
+    throw error;
+  } finally {
+    await teardownE2ETest(context);
+  }
+});

--- a/apps/boltfoundry-com/__tests__/helpers.ts
+++ b/apps/boltfoundry-com/__tests__/helpers.ts
@@ -1,0 +1,13 @@
+import {
+  type E2ETestContext,
+  setupE2ETest,
+} from "@bfmono/infra/testing/e2e/setup.ts";
+import { getConfigurationVariable } from "@bolt-foundry/get-configuration-var";
+
+/**
+ * Sets up e2e test for boltfoundry-com with automatic server startup
+ */
+export async function setupBoltFoundryComTest(): Promise<E2ETestContext> {
+  const baseUrl = getConfigurationVariable("BF_E2E_BOLTFOUNDRY_COM_URL");
+  return await setupE2ETest({ baseUrl });
+}

--- a/apps/boltfoundry-com/deno.json
+++ b/apps/boltfoundry-com/deno.json
@@ -15,5 +15,6 @@
     "react": "npm:react@^19.1.0",
     "react-dom": "npm:react-dom@^19.1.0",
     "react/jsx-runtime": "npm:react/jsx-runtime"
-  }
+  },
+  "exclude": ["static/build/"]
 }

--- a/apps/boltfoundry-com/server.tsx
+++ b/apps/boltfoundry-com/server.tsx
@@ -2,6 +2,9 @@
 
 import { parseArgs } from "@std/cli";
 import { getLogger } from "@bolt-foundry/logger";
+import { renderToReadableStream } from "react-dom/server";
+import { ServerRenderedPage } from "./server/components/ServerRenderedPage.tsx";
+import App from "./src/App.tsx";
 
 const logger = getLogger(import.meta);
 
@@ -90,61 +93,67 @@ const handler = async (request: Request): Promise<Response> => {
     }
   }
 
-  // In production mode, serve static assets
-  const distPath = new URL(import.meta.resolve("./dist")).pathname;
+  // Handle static assets first
+  if (url.pathname.startsWith("/static/")) {
+    const staticPath = new URL(import.meta.resolve("./static")).pathname;
+    const filePath = url.pathname.replace("/static/", "");
+    const fullPath = `${staticPath}/${filePath}`;
+
+    try {
+      const file = await Deno.open(fullPath);
+      const stat = await file.stat();
+
+      // Determine content type
+      let contentType = "application/octet-stream";
+      if (filePath.endsWith(".html")) contentType = "text/html";
+      else if (filePath.endsWith(".js")) {
+        contentType = "application/javascript";
+      } else if (filePath.endsWith(".css")) contentType = "text/css";
+      else if (filePath.endsWith(".json")) contentType = "application/json";
+      else if (filePath.endsWith(".svg")) contentType = "image/svg+xml";
+      else if (filePath.endsWith(".png")) contentType = "image/png";
+      else if (filePath.endsWith(".ico")) contentType = "image/x-icon";
+
+      return new Response(file.readable, {
+        headers: {
+          "Content-Type": contentType,
+          "Content-Length": stat.size.toString(),
+        },
+      });
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return new Response("Not Found", { status: 404 });
+      }
+      throw error;
+    }
+  }
 
   // API routes should return 404 if not found
   if (url.pathname.startsWith("/api/")) {
     return new Response("Not Found", { status: 404 });
   }
 
-  // Default to index.html for root
-  let filePath = url.pathname;
-  if (filePath === "/") {
-    filePath = "/index.html";
-  }
+  // For all other routes, render the React app with SSR
+  const environment = {
+    mode: isDev ? "development" : "production",
+    port: port,
+  };
 
-  const fullPath = `${distPath}${filePath}`;
+  const element = (
+    <ServerRenderedPage environment={environment}>
+      <App />
+    </ServerRenderedPage>
+  );
 
   try {
-    const file = await Deno.open(fullPath);
-    const stat = await file.stat();
-
-    // Determine content type
-    let contentType = "application/octet-stream";
-    if (filePath.endsWith(".html")) contentType = "text/html";
-    else if (filePath.endsWith(".js")) {
-      contentType = "application/javascript";
-    } else if (filePath.endsWith(".css")) contentType = "text/css";
-    else if (filePath.endsWith(".json")) contentType = "application/json";
-    else if (filePath.endsWith(".svg")) contentType = "image/svg+xml";
-    else if (filePath.endsWith(".png")) contentType = "image/png";
-    else if (filePath.endsWith(".ico")) contentType = "image/x-icon";
-
-    return new Response(file.readable, {
-      headers: {
-        "Content-Type": contentType,
-        "Content-Length": stat.size.toString(),
-      },
+    const stream = await renderToReadableStream(element);
+    return new Response(stream, {
+      headers: { "content-type": "text/html; charset=utf-8" },
     });
   } catch (error) {
-    if (error instanceof Deno.errors.NotFound) {
-      // For client-side routes (not containing a file extension)
-      if (!url.pathname.includes(".")) {
-        try {
-          const indexPath = `${distPath}/index.html`;
-          const file = await Deno.open(indexPath);
-          return new Response(file.readable, {
-            headers: { "Content-Type": "text/html" },
-          });
-        } catch {
-          // Fall through to 404
-        }
-      }
-    }
+    logger.error("Error rendering React app:", error);
+    return new Response("Internal Server Error", { status: 500 });
   }
-
-  return new Response("Not Found", { status: 404 });
 };
 
 // Start the server

--- a/apps/boltfoundry-com/server/components/ServerRenderedPage.tsx
+++ b/apps/boltfoundry-com/server/components/ServerRenderedPage.tsx
@@ -1,0 +1,45 @@
+import type React from "react";
+
+type Props = React.PropsWithChildren<{
+  environment: Record<string, unknown>;
+}>;
+
+/*
+ * This only runs on the server!!!! It should never run on the client.
+ */
+export function ServerRenderedPage({ children, environment }: Props) {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Bolt Foundry</title>
+        <link rel="stylesheet" href="/static/index.css" />
+        <script type="module" src="/static/build/ClientRoot.js" />
+      </head>
+      <body>
+        <div id="root">
+          {children}
+        </div>
+        <script
+          type="module"
+          defer
+          dangerouslySetInnerHTML={{
+            __html: `globalThis.__ENVIRONMENT__ = ${
+              JSON.stringify(environment ?? {})
+            };
+
+          if (globalThis.__REHYDRATE__) {
+            console.debug("Trying to rehydrate");
+            await globalThis.__REHYDRATE__(globalThis.__ENVIRONMENT__);
+          } else {
+            // can't rehydrate yet.
+            console.warn("Rehydration fail");
+          }
+          `,
+          }}
+        />
+      </body>
+    </html>
+  );
+}

--- a/apps/boltfoundry-com/src/App.tsx
+++ b/apps/boltfoundry-com/src/App.tsx
@@ -1,5 +1,3 @@
-import "./App.css";
-
 function App() {
   return (
     <div className="app">

--- a/apps/boltfoundry-com/static/build/ClientRoot.js
+++ b/apps/boltfoundry-com/static/build/ClientRoot.js
@@ -1,0 +1,11334 @@
+import { setImmediate } from "node:timers";
+import process from "node:process";
+var $c = { exports: {} }, me = {}; /**
+ * @license React
+ * react-jsx-runtime.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+var wv;
+function D1() {
+  if (wv) return me;
+  wv = 1;
+  var D = Symbol.for("react.transitional.element"),
+    sl = Symbol.for("react.fragment");
+  function ll(S, vl, ml) {
+    var Al = null;
+    if (
+      ml !== void 0 && (Al = "" + ml),
+        vl.key !== void 0 && (Al = "" + vl.key),
+        "key" in vl
+    ) {
+      ml = {};
+      for (var ql in vl) ql !== "key" && (ml[ql] = vl[ql]);
+    } else ml = vl;
+    return vl = ml.ref, {
+      $$typeof: D,
+      type: S,
+      key: Al,
+      ref: vl !== void 0 ? vl : null,
+      props: ml,
+    };
+  }
+  return me.Fragment = sl, me.jsx = ll, me.jsxs = ll, me;
+}
+var Wv;
+function U1() {
+  return Wv || (Wv = 1, $c.exports = D1()), $c.exports;
+}
+var tt = U1(), kc = { exports: {} }, Se = {}, Fc = { exports: {} }, Ic = {}; /**
+ * @license React
+ * scheduler.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+var $v;
+function R1() {
+  return $v || ($v = 1,
+    function (D) {
+      function sl(r, _) {
+        var B = r.length;
+        r.push(_);
+        l: for (; 0 < B;) {
+          var I = B - 1 >>> 1, s = r[I];
+          if (0 < vl(s, _)) r[I] = _, r[B] = s, B = I;
+          else break l;
+        }
+      }
+      function ll(r) {
+        return r.length === 0 ? null : r[0];
+      }
+      function S(r) {
+        if (r.length === 0) return null;
+        var _ = r[0], B = r.pop();
+        if (B !== _) {
+          r[0] = B;
+          l: for (var I = 0, s = r.length, E = s >>> 1; I < E;) {
+            var O = 2 * (I + 1) - 1, z = r[O], N = O + 1, L = r[N];
+            if (0 > vl(z, B)) {
+              N < s && 0 > vl(L, z)
+                ? (r[I] = L, r[N] = B, I = N)
+                : (r[I] = z, r[O] = B, I = O);
+            } else if (N < s && 0 > vl(L, B)) r[I] = L, r[N] = B, I = N;
+            else break l;
+          }
+        }
+        return _;
+      }
+      function vl(r, _) {
+        var B = r.sortIndex - _.sortIndex;
+        return B !== 0 ? B : r.id - _.id;
+      }
+      if (
+        D.unstable_now = void 0,
+          typeof performance == "object" && typeof performance.now == "function"
+      ) {
+        var ml = performance;
+        D.unstable_now = function () {
+          return ml.now();
+        };
+      } else {
+        var Al = Date, ql = Al.now();
+        D.unstable_now = function () {
+          return Al.now() - ql;
+        };
+      }
+      var H = [],
+        A = [],
+        R = 1,
+        al = null,
+        tl = 3,
+        Yl = !1,
+        Bl = !1,
+        yt = !1,
+        Gl = !1,
+        yu = typeof setTimeout == "function" ? setTimeout : null,
+        zt = typeof clearTimeout == "function" ? clearTimeout : null,
+        Ml = typeof setImmediate < "u" ? setImmediate : null;
+      function dt(r) {
+        for (var _ = ll(A); _ !== null;) {
+          if (_.callback === null) S(A);
+          else if (_.startTime <= r) {
+            S(A), _.sortIndex = _.expirationTime, sl(H, _);
+          } else break;
+          _ = ll(A);
+        }
+      }
+      function V(r) {
+        if (yt = !1, dt(r), !Bl) {
+          if (ll(H) !== null) Bl = !0, Cl || (Cl = !0, Dl());
+          else {
+            var _ = ll(A);
+            _ !== null && Ul(V, _.startTime - r);
+          }
+        }
+      }
+      var Cl = !1, Vl = -1, Ll = 5, St = -1;
+      function qu() {
+        return Gl ? !0 : !(D.unstable_now() - St < Ll);
+      }
+      function _t() {
+        if (Gl = !1, Cl) {
+          var r = D.unstable_now();
+          St = r;
+          var _ = !0;
+          try {
+            l: {
+              Bl = !1, yt && (yt = !1, zt(Vl), Vl = -1), Yl = !0;
+              var B = tl;
+              try {
+                t: {
+                  for (
+                    dt(r), al = ll(H);
+                    al !== null && !(al.expirationTime > r && qu());
+                  ) {
+                    var I = al.callback;
+                    if (typeof I == "function") {
+                      al.callback = null, tl = al.priorityLevel;
+                      var s = I(al.expirationTime <= r);
+                      if (r = D.unstable_now(), typeof s == "function") {
+                        al.callback = s, dt(r), _ = !0;
+                        break t;
+                      }
+                      al === ll(H) && S(H), dt(r);
+                    } else S(H);
+                    al = ll(H);
+                  }
+                  if (al !== null) _ = !0;
+                  else {
+                    var E = ll(A);
+                    E !== null && Ul(V, E.startTime - r), _ = !1;
+                  }
+                }
+                break l;
+              } finally {
+                al = null, tl = B, Yl = !1;
+              }
+              _ = void 0;
+            }
+          } finally {
+            _ ? Dl() : Cl = !1;
+          }
+        }
+      }
+      var Dl;
+      if (typeof Ml == "function") {
+        Dl = function () {
+          Ml(_t);
+        };
+      } else if (typeof MessageChannel < "u") {
+        var du = new MessageChannel(), hu = du.port2;
+        du.port1.onmessage = _t,
+          Dl = function () {
+            hu.postMessage(null);
+          };
+      } else {Dl = function () {
+          yu(_t, 0);
+        };}
+      function Ul(r, _) {
+        Vl = yu(function () {
+          r(D.unstable_now());
+        }, _);
+      }
+      D.unstable_IdlePriority = 5,
+        D.unstable_ImmediatePriority = 1,
+        D.unstable_LowPriority = 4,
+        D.unstable_NormalPriority = 3,
+        D.unstable_Profiling = null,
+        D.unstable_UserBlockingPriority = 2,
+        D.unstable_cancelCallback = function (r) {
+          r.callback = null;
+        },
+        D.unstable_forceFrameRate = function (r) {
+          0 > r || 125 < r
+            ? console.error(
+              "forceFrameRate takes a positive int between 0 and 125, forcing frame rates higher than 125 fps is not supported",
+            )
+            : Ll = 0 < r ? Math.floor(1e3 / r) : 5;
+        },
+        D.unstable_getCurrentPriorityLevel = function () {
+          return tl;
+        },
+        D.unstable_next = function (r) {
+          switch (tl) {
+            case 1:
+            case 2:
+            case 3:
+              var _ = 3;
+              break;
+            default:
+              _ = tl;
+          }
+          var B = tl;
+          tl = _;
+          try {
+            return r();
+          } finally {
+            tl = B;
+          }
+        },
+        D.unstable_requestPaint = function () {
+          Gl = !0;
+        },
+        D.unstable_runWithPriority = function (r, _) {
+          switch (r) {
+            case 1:
+            case 2:
+            case 3:
+            case 4:
+            case 5:
+              break;
+            default:
+              r = 3;
+          }
+          var B = tl;
+          tl = r;
+          try {
+            return _();
+          } finally {
+            tl = B;
+          }
+        },
+        D.unstable_scheduleCallback = function (r, _, B) {
+          var I = D.unstable_now();
+          switch (
+            typeof B == "object" && B !== null
+              ? (B = B.delay, B = typeof B == "number" && 0 < B ? I + B : I)
+              : B = I, r
+          ) {
+            case 1:
+              var s = -1;
+              break;
+            case 2:
+              s = 250;
+              break;
+            case 5:
+              s = 1073741823;
+              break;
+            case 4:
+              s = 1e4;
+              break;
+            default:
+              s = 5e3;
+          }
+          return s = B + s,
+            r = {
+              id: R++,
+              callback: _,
+              priorityLevel: r,
+              startTime: B,
+              expirationTime: s,
+              sortIndex: -1,
+            },
+            B > I
+              ? (r.sortIndex = B,
+                sl(A, r),
+                ll(H) === null && r === ll(A) &&
+                (yt ? (zt(Vl), Vl = -1) : yt = !0, Ul(V, B - I)))
+              : (r.sortIndex = s,
+                sl(H, r),
+                Bl || Yl || (Bl = !0, Cl || (Cl = !0, Dl()))),
+            r;
+        },
+        D.unstable_shouldYield = qu,
+        D.unstable_wrapCallback = function (r) {
+          var _ = tl;
+          return function () {
+            var B = tl;
+            tl = _;
+            try {
+              return r.apply(this, arguments);
+            } finally {
+              tl = B;
+            }
+          };
+        };
+    }(Ic)),
+    Ic;
+}
+var kv;
+function H1() {
+  return kv || (kv = 1, Fc.exports = R1()), Fc.exports;
+}
+var Pc = { exports: {} }, X = {}; /**
+ * @license React
+ * react.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+var Fv;
+function N1() {
+  if (Fv) return X;
+  Fv = 1;
+  var D = Symbol.for("react.transitional.element"),
+    sl = Symbol.for("react.portal"),
+    ll = Symbol.for("react.fragment"),
+    S = Symbol.for("react.strict_mode"),
+    vl = Symbol.for("react.profiler"),
+    ml = Symbol.for("react.consumer"),
+    Al = Symbol.for("react.context"),
+    ql = Symbol.for("react.forward_ref"),
+    H = Symbol.for("react.suspense"),
+    A = Symbol.for("react.memo"),
+    R = Symbol.for("react.lazy"),
+    al = Symbol.iterator;
+  function tl(s) {
+    return s === null || typeof s != "object"
+      ? null
+      : (s = al && s[al] || s["@@iterator"], typeof s == "function" ? s : null);
+  }
+  var Yl = {
+      isMounted: function () {
+        return !1;
+      },
+      enqueueForceUpdate: function () {},
+      enqueueReplaceState: function () {},
+      enqueueSetState: function () {},
+    },
+    Bl = Object.assign,
+    yt = {};
+  function Gl(s, E, O) {
+    this.props = s, this.context = E, this.refs = yt, this.updater = O || Yl;
+  }
+  Gl.prototype.isReactComponent = {},
+    Gl.prototype.setState = function (s, E) {
+      if (typeof s != "object" && typeof s != "function" && s != null) {
+        throw Error(
+          "takes an object of state variables to update or a function which returns an object of state variables.",
+        );
+      }
+      this.updater.enqueueSetState(this, s, E, "setState");
+    },
+    Gl.prototype.forceUpdate = function (s) {
+      this.updater.enqueueForceUpdate(this, s, "forceUpdate");
+    };
+  function yu() {}
+  yu.prototype = Gl.prototype;
+  function zt(s, E, O) {
+    this.props = s, this.context = E, this.refs = yt, this.updater = O || Yl;
+  }
+  var Ml = zt.prototype = new yu();
+  Ml.constructor = zt, Bl(Ml, Gl.prototype), Ml.isPureReactComponent = !0;
+  var dt = Array.isArray,
+    V = { H: null, A: null, T: null, S: null, V: null },
+    Cl = Object.prototype.hasOwnProperty;
+  function Vl(s, E, O, z, N, L) {
+    return O = L.ref,
+      { $$typeof: D, type: s, key: E, ref: O !== void 0 ? O : null, props: L };
+  }
+  function Ll(s, E) {
+    return Vl(s.type, E, void 0, void 0, void 0, s.props);
+  }
+  function St(s) {
+    return typeof s == "object" && s !== null && s.$$typeof === D;
+  }
+  function qu(s) {
+    var E = { "=": "=0", ":": "=2" };
+    return "$" + s.replace(/[=:]/g, function (O) {
+      return E[O];
+    });
+  }
+  var _t = /\/+/g;
+  function Dl(s, E) {
+    return typeof s == "object" && s !== null && s.key != null
+      ? qu("" + s.key)
+      : E.toString(36);
+  }
+  function du() {}
+  function hu(s) {
+    switch (s.status) {
+      case "fulfilled":
+        return s.value;
+      case "rejected":
+        throw s.reason;
+      default:
+        switch (
+          typeof s.status == "string"
+            ? s.then(du, du)
+            : (s.status = "pending",
+              s.then(function (E) {
+                s.status === "pending" && (s.status = "fulfilled", s.value = E);
+              }, function (E) {
+                s.status === "pending" && (s.status = "rejected", s.reason = E);
+              })), s.status
+        ) {
+          case "fulfilled":
+            return s.value;
+          case "rejected":
+            throw s.reason;
+        }
+    }
+    throw s;
+  }
+  function Ul(s, E, O, z, N) {
+    var L = typeof s;
+    (L === "undefined" || L === "boolean") && (s = null);
+    var G = !1;
+    if (s === null) G = !0;
+    else {switch (L) {
+        case "bigint":
+        case "string":
+        case "number":
+          G = !0;
+          break;
+        case "object":
+          switch (s.$$typeof) {
+            case D:
+            case sl:
+              G = !0;
+              break;
+            case R:
+              return G = s._init, Ul(G(s._payload), E, O, z, N);
+          }
+      }}
+    if (G) {
+      return N = N(s),
+        G = z === "" ? "." + Dl(s, 0) : z,
+        dt(N)
+          ? (O = "",
+            G != null && (O = G.replace(_t, "$&/") + "/"),
+            Ul(N, E, O, "", function (Zt) {
+              return Zt;
+            }))
+          : N != null &&
+            (St(N) && (N = Ll(
+              N,
+              O + (N.key == null || s && s.key === N.key
+                ? ""
+                : ("" + N.key).replace(_t, "$&/") + "/") +
+                G,
+            )),
+              E.push(N)),
+        1;
+    }
+    G = 0;
+    var Kl = z === "" ? "." : z + ":";
+    if (dt(s)) {
+      for (var el = 0; el < s.length; el++) {
+        z = s[el], L = Kl + Dl(z, el), G += Ul(z, E, O, L, N);
+      }
+    } else if (el = tl(s), typeof el == "function") {
+      for (s = el.call(s), el = 0; !(z = s.next()).done;) {
+        z = z.value, L = Kl + Dl(z, el++), G += Ul(z, E, O, L, N);
+      }
+    } else if (L === "object") {
+      if (typeof s.then == "function") return Ul(hu(s), E, O, z, N);
+      throw E = String(s),
+        Error(
+          "Objects are not valid as a React child (found: " +
+            (E === "[object Object]"
+              ? "object with keys {" + Object.keys(s).join(", ") + "}"
+              : E) +
+            "). If you meant to render a collection of children, use an array instead.",
+        );
+    }
+    return G;
+  }
+  function r(s, E, O) {
+    if (s == null) return s;
+    var z = [], N = 0;
+    return Ul(s, z, "", "", function (L) {
+      return E.call(O, L, N++);
+    }),
+      z;
+  }
+  function _(s) {
+    if (s._status === -1) {
+      var E = s._result;
+      E = E(),
+        E.then(function (O) {
+          (s._status === 0 || s._status === -1) &&
+            (s._status = 1, s._result = O);
+        }, function (O) {
+          (s._status === 0 || s._status === -1) &&
+            (s._status = 2, s._result = O);
+        }),
+        s._status === -1 && (s._status = 0, s._result = E);
+    }
+    if (s._status === 1) return s._result.default;
+    throw s._result;
+  }
+  var B = typeof reportError == "function" ? reportError : function (s) {
+    if (typeof window == "object" && typeof globalThis.ErrorEvent == "function") {
+      var E = new globalThis.ErrorEvent("error", {
+        bubbles: !0,
+        cancelable: !0,
+        message:
+          typeof s == "object" && s !== null && typeof s.message == "string"
+            ? String(s.message)
+            : String(s),
+        error: s,
+      });
+      if (!globalThis.dispatchEvent(E)) return;
+    } else if (
+      typeof process == "object" && typeof process.emit == "function"
+    ) {
+      process.emit("uncaughtException", s);
+      return;
+    }
+    console.error(s);
+  };
+  function I() {}
+  return X.Children = {
+    map: r,
+    forEach: function (s, E, O) {
+      r(s, function () {
+        E.apply(this, arguments);
+      }, O);
+    },
+    count: function (s) {
+      var E = 0;
+      return r(s, function () {
+        E++;
+      }),
+        E;
+    },
+    toArray: function (s) {
+      return r(s, function (E) {
+        return E;
+      }) || [];
+    },
+    only: function (s) {
+      if (!St(s)) {
+        throw Error(
+          "React.Children.only expected to receive a single React element child.",
+        );
+      }
+      return s;
+    },
+  },
+    X.Component = Gl,
+    X.Fragment = ll,
+    X.Profiler = vl,
+    X.PureComponent = zt,
+    X.StrictMode = S,
+    X.Suspense = H,
+    X.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE = V,
+    X.__COMPILER_RUNTIME = {
+      __proto__: null,
+      c: function (s) {
+        return V.H.useMemoCache(s);
+      },
+    },
+    X.cache = function (s) {
+      return function () {
+        return s.apply(null, arguments);
+      };
+    },
+    X.cloneElement = function (s, E, O) {
+      if (s == null) {
+        throw Error(
+          "The argument must be a React element, but you passed " + s + ".",
+        );
+      }
+      var z = Bl({}, s.props), N = s.key, L = void 0;
+      if (E != null) {
+        for (
+          G in E.ref !== void 0 && (L = void 0),
+            E.key !== void 0 && (N = "" + E.key),
+            E
+        ) {
+          !Cl.call(E, G) || G === "key" || G === "__self" || G === "__source" ||
+            G === "ref" && E.ref === void 0 || (z[G] = E[G]);
+        }
+      }
+      var G = arguments.length - 2;
+      if (G === 1) z.children = O;
+      else if (1 < G) {
+        for (var Kl = Array(G), el = 0; el < G; el++) {
+          Kl[el] = arguments[el + 2];
+        }
+        z.children = Kl;
+      }
+      return Vl(s.type, N, void 0, void 0, L, z);
+    },
+    X.createContext = function (s) {
+      return s = {
+        $$typeof: Al,
+        _currentValue: s,
+        _currentValue2: s,
+        _threadCount: 0,
+        Provider: null,
+        Consumer: null,
+      },
+        s.Provider = s,
+        s.Consumer = { $$typeof: ml, _context: s },
+        s;
+    },
+    X.createElement = function (s, E, O) {
+      var z, N = {}, L = null;
+      if (E != null) {
+        for (z in E.key !== void 0 && (L = "" + E.key), E) {
+          Cl.call(E, z) && z !== "key" && z !== "__self" && z !== "__source" &&
+            (N[z] = E[z]);
+        }
+      }
+      var G = arguments.length - 2;
+      if (G === 1) N.children = O;
+      else if (1 < G) {
+        for (var Kl = Array(G), el = 0; el < G; el++) {
+          Kl[el] = arguments[el + 2];
+        }
+        N.children = Kl;
+      }
+      if (s && s.defaultProps) {
+        for (z in G = s.defaultProps, G) N[z] === void 0 && (N[z] = G[z]);
+      }
+      return Vl(s, L, void 0, void 0, null, N);
+    },
+    X.createRef = function () {
+      return { current: null };
+    },
+    X.forwardRef = function (s) {
+      return { $$typeof: ql, render: s };
+    },
+    X.isValidElement = St,
+    X.lazy = function (s) {
+      return { $$typeof: R, _payload: { _status: -1, _result: s }, _init: _ };
+    },
+    X.memo = function (s, E) {
+      return { $$typeof: A, type: s, compare: E === void 0 ? null : E };
+    },
+    X.startTransition = function (s) {
+      var E = V.T, O = {};
+      V.T = O;
+      try {
+        var z = s(), N = V.S;
+        N !== null && N(O, z),
+          typeof z == "object" && z !== null && typeof z.then == "function" &&
+          z.then(I, B);
+      } catch (L) {
+        B(L);
+      } finally {
+        V.T = E;
+      }
+    },
+    X.unstable_useCacheRefresh = function () {
+      return V.H.useCacheRefresh();
+    },
+    X.use = function (s) {
+      return V.H.use(s);
+    },
+    X.useActionState = function (s, E, O) {
+      return V.H.useActionState(s, E, O);
+    },
+    X.useCallback = function (s, E) {
+      return V.H.useCallback(s, E);
+    },
+    X.useContext = function (s) {
+      return V.H.useContext(s);
+    },
+    X.useDebugValue = function () {},
+    X.useDeferredValue = function (s, E) {
+      return V.H.useDeferredValue(s, E);
+    },
+    X.useEffect = function (s, E, O) {
+      var z = V.H;
+      if (typeof O == "function") {
+        throw Error(
+          "useEffect CRUD overload is not enabled in this build of React.",
+        );
+      }
+      return z.useEffect(s, E);
+    },
+    X.useId = function () {
+      return V.H.useId();
+    },
+    X.useImperativeHandle = function (s, E, O) {
+      return V.H.useImperativeHandle(s, E, O);
+    },
+    X.useInsertionEffect = function (s, E) {
+      return V.H.useInsertionEffect(s, E);
+    },
+    X.useLayoutEffect = function (s, E) {
+      return V.H.useLayoutEffect(s, E);
+    },
+    X.useMemo = function (s, E) {
+      return V.H.useMemo(s, E);
+    },
+    X.useOptimistic = function (s, E) {
+      return V.H.useOptimistic(s, E);
+    },
+    X.useReducer = function (s, E, O) {
+      return V.H.useReducer(s, E, O);
+    },
+    X.useRef = function (s) {
+      return V.H.useRef(s);
+    },
+    X.useState = function (s) {
+      return V.H.useState(s);
+    },
+    X.useSyncExternalStore = function (s, E, O) {
+      return V.H.useSyncExternalStore(s, E, O);
+    },
+    X.useTransition = function () {
+      return V.H.useTransition();
+    },
+    X.version = "19.1.0",
+    X;
+}
+var Iv;
+function ey() {
+  return Iv || (Iv = 1, Pc.exports = N1()), Pc.exports;
+}
+var li = { exports: {} }, Nl = {}; /**
+ * @license React
+ * react-dom.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+var Pv;
+function q1() {
+  if (Pv) return Nl;
+  Pv = 1;
+  var D = ey();
+  function sl(H) {
+    var A = "https://react.dev/errors/" + H;
+    if (1 < arguments.length) {
+      A += "?args[]=" + encodeURIComponent(arguments[1]);
+      for (var R = 2; R < arguments.length; R++) {
+        A += "&args[]=" + encodeURIComponent(arguments[R]);
+      }
+    }
+    return "Minified React error #" + H + "; visit " + A +
+      " for the full message or use the non-minified dev environment for full errors and additional helpful warnings.";
+  }
+  function ll() {}
+  var S = {
+      d: {
+        f: ll,
+        r: function () {
+          throw Error(sl(522));
+        },
+        D: ll,
+        C: ll,
+        L: ll,
+        m: ll,
+        X: ll,
+        S: ll,
+        M: ll,
+      },
+      p: 0,
+      findDOMNode: null,
+    },
+    vl = Symbol.for("react.portal");
+  function ml(H, A, R) {
+    var al = 3 < arguments.length && arguments[3] !== void 0
+      ? arguments[3]
+      : null;
+    return {
+      $$typeof: vl,
+      key: al == null ? null : "" + al,
+      children: H,
+      containerInfo: A,
+      implementation: R,
+    };
+  }
+  var Al = D.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;
+  function ql(H, A) {
+    if (H === "font") return "";
+    if (typeof A == "string") return A === "use-credentials" ? A : "";
+  }
+  return Nl.__DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE = S,
+    Nl.createPortal = function (H, A) {
+      var R = 2 < arguments.length && arguments[2] !== void 0
+        ? arguments[2]
+        : null;
+      if (!A || A.nodeType !== 1 && A.nodeType !== 9 && A.nodeType !== 11) {
+        throw Error(sl(299));
+      }
+      return ml(H, A, null, R);
+    },
+    Nl.flushSync = function (H) {
+      var A = Al.T, R = S.p;
+      try {
+        if (Al.T = null, S.p = 2, H) return H();
+      } finally {
+        Al.T = A, S.p = R, S.d.f();
+      }
+    },
+    Nl.preconnect = function (H, A) {
+      typeof H == "string" &&
+        (A
+          ? (A = A.crossOrigin,
+            A = typeof A == "string"
+              ? A === "use-credentials" ? A : ""
+              : void 0)
+          : A = null,
+          S.d.C(H, A));
+    },
+    Nl.prefetchDNS = function (H) {
+      typeof H == "string" && S.d.D(H);
+    },
+    Nl.preinit = function (H, A) {
+      if (typeof H == "string" && A && typeof A.as == "string") {
+        var R = A.as,
+          al = ql(R, A.crossOrigin),
+          tl = typeof A.integrity == "string" ? A.integrity : void 0,
+          Yl = typeof A.fetchPriority == "string" ? A.fetchPriority : void 0;
+        R === "style"
+          ? S.d.S(H, typeof A.precedence == "string" ? A.precedence : void 0, {
+            crossOrigin: al,
+            integrity: tl,
+            fetchPriority: Yl,
+          })
+          : R === "script" &&
+            S.d.X(H, {
+              crossOrigin: al,
+              integrity: tl,
+              fetchPriority: Yl,
+              nonce: typeof A.nonce == "string" ? A.nonce : void 0,
+            });
+      }
+    },
+    Nl.preinitModule = function (H, A) {
+      if (typeof H == "string") {
+        if (typeof A == "object" && A !== null) {
+          if (A.as == null || A.as === "script") {
+            var R = ql(A.as, A.crossOrigin);
+            S.d.M(H, {
+              crossOrigin: R,
+              integrity: typeof A.integrity == "string" ? A.integrity : void 0,
+              nonce: typeof A.nonce == "string" ? A.nonce : void 0,
+            });
+          }
+        } else A == null && S.d.M(H);
+      }
+    },
+    Nl.preload = function (H, A) {
+      if (
+        typeof H == "string" && typeof A == "object" && A !== null &&
+        typeof A.as == "string"
+      ) {
+        var R = A.as, al = ql(R, A.crossOrigin);
+        S.d.L(H, R, {
+          crossOrigin: al,
+          integrity: typeof A.integrity == "string" ? A.integrity : void 0,
+          nonce: typeof A.nonce == "string" ? A.nonce : void 0,
+          type: typeof A.type == "string" ? A.type : void 0,
+          fetchPriority: typeof A.fetchPriority == "string"
+            ? A.fetchPriority
+            : void 0,
+          referrerPolicy: typeof A.referrerPolicy == "string"
+            ? A.referrerPolicy
+            : void 0,
+          imageSrcSet: typeof A.imageSrcSet == "string"
+            ? A.imageSrcSet
+            : void 0,
+          imageSizes: typeof A.imageSizes == "string" ? A.imageSizes : void 0,
+          media: typeof A.media == "string" ? A.media : void 0,
+        });
+      }
+    },
+    Nl.preloadModule = function (H, A) {
+      if (typeof H == "string") {
+        if (A) {
+          var R = ql(A.as, A.crossOrigin);
+          S.d.m(H, {
+            as: typeof A.as == "string" && A.as !== "script" ? A.as : void 0,
+            crossOrigin: R,
+            integrity: typeof A.integrity == "string" ? A.integrity : void 0,
+          });
+        } else S.d.m(H);
+      }
+    },
+    Nl.requestFormReset = function (H) {
+      S.d.r(H);
+    },
+    Nl.unstable_batchedUpdates = function (H, A) {
+      return H(A);
+    },
+    Nl.useFormState = function (H, A, R) {
+      return Al.H.useFormState(H, A, R);
+    },
+    Nl.useFormStatus = function () {
+      return Al.H.useHostTransitionStatus();
+    },
+    Nl.version = "19.1.0",
+    Nl;
+}
+var ly;
+function Y1() {
+  if (ly) return li.exports;
+  ly = 1;
+  function D() {
+    if (
+      !(typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ > "u" ||
+        typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE != "function")
+    ) {
+      try {
+        __REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE(D);
+      } catch (sl) {
+        console.error(sl);
+      }
+    }
+  }
+  return D(), li.exports = q1(), li.exports;
+} /**
+ * @license React
+ * react-dom-client.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+var ty;
+function B1() {
+  if (ty) return Se;
+  ty = 1;
+  var D = H1(), sl = ey(), ll = Y1();
+  function S(l) {
+    var t = "https://react.dev/errors/" + l;
+    if (1 < arguments.length) {
+      t += "?args[]=" + encodeURIComponent(arguments[1]);
+      for (var u = 2; u < arguments.length; u++) {
+        t += "&args[]=" + encodeURIComponent(arguments[u]);
+      }
+    }
+    return "Minified React error #" + l + "; visit " + t +
+      " for the full message or use the non-minified dev environment for full errors and additional helpful warnings.";
+  }
+  function vl(l) {
+    return !(!l || l.nodeType !== 1 && l.nodeType !== 9 && l.nodeType !== 11);
+  }
+  function ml(l) {
+    var t = l, u = l;
+    if (l.alternate) { for (; t.return;) t = t.return; }
+    else {
+      l = t;
+      do t = l, (t.flags & 4098) !== 0 && (u = t.return), l = t.return; while (
+        l
+      );
+    }
+    return t.tag === 3 ? u : null;
+  }
+  function Al(l) {
+    if (l.tag === 13) {
+      var t = l.memoizedState;
+      if (
+        t === null && (l = l.alternate, l !== null && (t = l.memoizedState)),
+          t !== null
+      ) return t.dehydrated;
+    }
+    return null;
+  }
+  function ql(l) {
+    if (ml(l) !== l) throw Error(S(188));
+  }
+  function H(l) {
+    var t = l.alternate;
+    if (!t) {
+      if (t = ml(l), t === null) throw Error(S(188));
+      return t !== l ? null : l;
+    }
+    for (var u = l, a = t;;) {
+      var e = u.return;
+      if (e === null) break;
+      var n = e.alternate;
+      if (n === null) {
+        if (a = e.return, a !== null) {
+          u = a;
+          continue;
+        }
+        break;
+      }
+      if (e.child === n.child) {
+        for (n = e.child; n;) {
+          if (n === u) return ql(e), l;
+          if (n === a) return ql(e), t;
+          n = n.sibling;
+        }
+        throw Error(S(188));
+      }
+      if (u.return !== a.return) u = e, a = n;
+      else {
+        for (var f = !1, c = e.child; c;) {
+          if (c === u) {
+            f = !0, u = e, a = n;
+            break;
+          }
+          if (c === a) {
+            f = !0, a = e, u = n;
+            break;
+          }
+          c = c.sibling;
+        }
+        if (!f) {
+          for (c = n.child; c;) {
+            if (c === u) {
+              f = !0, u = n, a = e;
+              break;
+            }
+            if (c === a) {
+              f = !0, a = n, u = e;
+              break;
+            }
+            c = c.sibling;
+          }
+          if (!f) throw Error(S(189));
+        }
+      }
+      if (u.alternate !== a) throw Error(S(190));
+    }
+    if (u.tag !== 3) throw Error(S(188));
+    return u.stateNode.current === u ? l : t;
+  }
+  function A(l) {
+    var t = l.tag;
+    if (t === 5 || t === 26 || t === 27 || t === 6) return l;
+    for (l = l.child; l !== null;) {
+      if (t = A(l), t !== null) return t;
+      l = l.sibling;
+    }
+    return null;
+  }
+  var R = Object.assign,
+    al = Symbol.for("react.element"),
+    tl = Symbol.for("react.transitional.element"),
+    Yl = Symbol.for("react.portal"),
+    Bl = Symbol.for("react.fragment"),
+    yt = Symbol.for("react.strict_mode"),
+    Gl = Symbol.for("react.profiler"),
+    yu = Symbol.for("react.provider"),
+    zt = Symbol.for("react.consumer"),
+    Ml = Symbol.for("react.context"),
+    dt = Symbol.for("react.forward_ref"),
+    V = Symbol.for("react.suspense"),
+    Cl = Symbol.for("react.suspense_list"),
+    Vl = Symbol.for("react.memo"),
+    Ll = Symbol.for("react.lazy"),
+    St = Symbol.for("react.activity"),
+    qu = Symbol.for("react.memo_cache_sentinel"),
+    _t = Symbol.iterator;
+  function Dl(l) {
+    return l === null || typeof l != "object"
+      ? null
+      : (l = _t && l[_t] || l["@@iterator"], typeof l == "function" ? l : null);
+  }
+  var du = Symbol.for("react.client.reference");
+  function hu(l) {
+    if (l == null) return null;
+    if (typeof l == "function") {
+      return l.$$typeof === du ? null : l.displayName || l.name || null;
+    }
+    if (typeof l == "string") return l;
+    switch (l) {
+      case Bl:
+        return "Fragment";
+      case Gl:
+        return "Profiler";
+      case yt:
+        return "StrictMode";
+      case V:
+        return "Suspense";
+      case Cl:
+        return "SuspenseList";
+      case St:
+        return "Activity";
+    }
+    if (typeof l == "object") {
+      switch (l.$$typeof) {
+        case Yl:
+          return "Portal";
+        case Ml:
+          return (l.displayName || "Context") + ".Provider";
+        case zt:
+          return (l._context.displayName || "Context") + ".Consumer";
+        case dt:
+          var t = l.render;
+          return l = l.displayName,
+            l ||
+            (l = t.displayName || t.name || "",
+              l = l !== "" ? "ForwardRef(" + l + ")" : "ForwardRef"),
+            l;
+        case Vl:
+          return t = l.displayName || null,
+            t !== null ? t : hu(l.type) || "Memo";
+        case Ll:
+          t = l._payload, l = l._init;
+          try {
+            return hu(l(t));
+          } catch {}
+      }
+    }
+    return null;
+  }
+  var Ul = Array.isArray,
+    r = sl.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE,
+    _ = ll.__DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE,
+    B = { pending: !1, data: null, method: null, action: null },
+    I = [],
+    s = -1;
+  function E(l) {
+    return { current: l };
+  }
+  function O(l) {
+    0 > s || (l.current = I[s], I[s] = null, s--);
+  }
+  function z(l, t) {
+    s++, I[s] = l.current, l.current = t;
+  }
+  var N = E(null), L = E(null), G = E(null), Kl = E(null);
+  function el(l, t) {
+    switch (z(G, t), z(L, l), z(N, null), t.nodeType) {
+      case 9:
+      case 11:
+        l = (l = t.documentElement) && (l = l.namespaceURI) ? Ev(l) : 0;
+        break;
+      default:
+        if (l = t.tagName, t = t.namespaceURI) t = Ev(t), l = Av(t, l);
+        else {switch (l) {
+            case "svg":
+              l = 1;
+              break;
+            case "math":
+              l = 2;
+              break;
+            default:
+              l = 0;
+          }}
+    }
+    O(N), z(N, l);
+  }
+  function Zt() {
+    O(N), O(L), O(G);
+  }
+  function Yn(l) {
+    l.memoizedState !== null && z(Kl, l);
+    var t = N.current, u = Av(t, l.type);
+    t !== u && (z(L, l), z(N, u));
+  }
+  function ge(l) {
+    L.current === l && (O(N), O(L)),
+      Kl.current === l && (O(Kl), ve._currentValue = B);
+  }
+  var Bn = Object.prototype.hasOwnProperty,
+    pn = D.unstable_scheduleCallback,
+    Gn = D.unstable_cancelCallback,
+    ny = D.unstable_shouldYield,
+    fy = D.unstable_requestPaint,
+    gt = D.unstable_now,
+    cy = D.unstable_getCurrentPriorityLevel,
+    ti = D.unstable_ImmediatePriority,
+    ui = D.unstable_UserBlockingPriority,
+    re = D.unstable_NormalPriority,
+    iy = D.unstable_LowPriority,
+    ai = D.unstable_IdlePriority,
+    sy = D.log,
+    vy = D.unstable_setDisableYieldValue,
+    ra = null,
+    Jl = null;
+  function jt(l) {
+    if (
+      typeof sy == "function" && vy(l),
+        Jl && typeof Jl.setStrictMode == "function"
+    ) {
+      try {
+        Jl.setStrictMode(ra, l);
+      } catch {}
+    }
+  }
+  var wl = Math.clz32 ? Math.clz32 : hy, yy = Math.log, dy = Math.LN2;
+  function hy(l) {
+    return l >>>= 0, l === 0 ? 32 : 31 - (yy(l) / dy | 0) | 0;
+  }
+  var be = 256, Te = 4194304;
+  function ou(l) {
+    var t = l & 42;
+    if (t !== 0) return t;
+    switch (l & -l) {
+      case 1:
+        return 1;
+      case 2:
+        return 2;
+      case 4:
+        return 4;
+      case 8:
+        return 8;
+      case 16:
+        return 16;
+      case 32:
+        return 32;
+      case 64:
+        return 64;
+      case 128:
+        return 128;
+      case 256:
+      case 512:
+      case 1024:
+      case 2048:
+      case 4096:
+      case 8192:
+      case 16384:
+      case 32768:
+      case 65536:
+      case 131072:
+      case 262144:
+      case 524288:
+      case 1048576:
+      case 2097152:
+        return l & 4194048;
+      case 4194304:
+      case 8388608:
+      case 16777216:
+      case 33554432:
+        return l & 62914560;
+      case 67108864:
+        return 67108864;
+      case 134217728:
+        return 134217728;
+      case 268435456:
+        return 268435456;
+      case 536870912:
+        return 536870912;
+      case 1073741824:
+        return 0;
+      default:
+        return l;
+    }
+  }
+  function Ee(l, t, u) {
+    var a = l.pendingLanes;
+    if (a === 0) return 0;
+    var e = 0, n = l.suspendedLanes, f = l.pingedLanes;
+    l = l.warmLanes;
+    var c = a & 134217727;
+    return c !== 0
+      ? (a = c & ~n,
+        a !== 0
+          ? e = ou(a)
+          : (f &= c,
+            f !== 0 ? e = ou(f) : u || (u = c & ~l, u !== 0 && (e = ou(u)))))
+      : (c = a & ~n,
+        c !== 0
+          ? e = ou(c)
+          : f !== 0
+          ? e = ou(f)
+          : u || (u = a & ~l, u !== 0 && (e = ou(u)))),
+      e === 0 ? 0 : t !== 0 && t !== e && (t & n) === 0 &&
+          (n = e & -e, u = t & -t, n >= u || n === 32 && (u & 4194048) !== 0)
+        ? t
+        : e;
+  }
+  function ba(l, t) {
+    return (l.pendingLanes & ~(l.suspendedLanes & ~l.pingedLanes) & t) === 0;
+  }
+  function oy(l, t) {
+    switch (l) {
+      case 1:
+      case 2:
+      case 4:
+      case 8:
+      case 64:
+        return t + 250;
+      case 16:
+      case 32:
+      case 128:
+      case 256:
+      case 512:
+      case 1024:
+      case 2048:
+      case 4096:
+      case 8192:
+      case 16384:
+      case 32768:
+      case 65536:
+      case 131072:
+      case 262144:
+      case 524288:
+      case 1048576:
+      case 2097152:
+        return t + 5e3;
+      case 4194304:
+      case 8388608:
+      case 16777216:
+      case 33554432:
+        return -1;
+      case 67108864:
+      case 134217728:
+      case 268435456:
+      case 536870912:
+      case 1073741824:
+        return -1;
+      default:
+        return -1;
+    }
+  }
+  function ei() {
+    var l = be;
+    return be <<= 1, (be & 4194048) === 0 && (be = 256), l;
+  }
+  function ni() {
+    var l = Te;
+    return Te <<= 1, (Te & 62914560) === 0 && (Te = 4194304), l;
+  }
+  function Xn(l) {
+    for (var t = [], u = 0; 31 > u; u++) t.push(l);
+    return t;
+  }
+  function Ta(l, t) {
+    l.pendingLanes |= t,
+      t !== 268435456 &&
+      (l.suspendedLanes = 0, l.pingedLanes = 0, l.warmLanes = 0);
+  }
+  function my(l, t, u, a, e, n) {
+    var f = l.pendingLanes;
+    l.pendingLanes = u,
+      l.suspendedLanes = 0,
+      l.pingedLanes = 0,
+      l.warmLanes = 0,
+      l.expiredLanes &= u,
+      l.entangledLanes &= u,
+      l.errorRecoveryDisabledLanes &= u,
+      l.shellSuspendCounter = 0;
+    var c = l.entanglements, i = l.expirationTimes, h = l.hiddenUpdates;
+    for (u = f & ~u; 0 < u;) {
+      var g = 31 - wl(u), T = 1 << g;
+      c[g] = 0, i[g] = -1;
+      var o = h[g];
+      if (o !== null) {
+        for (h[g] = null, g = 0; g < o.length; g++) {
+          var m = o[g];
+          m !== null && (m.lane &= -536870913);
+        }
+      }
+      u &= ~T;
+    }
+    a !== 0 && fi(l, a, 0),
+      n !== 0 && e === 0 && l.tag !== 0 && (l.suspendedLanes |= n & ~(f & ~t));
+  }
+  function fi(l, t, u) {
+    l.pendingLanes |= t, l.suspendedLanes &= ~t;
+    var a = 31 - wl(t);
+    l.entangledLanes |= t,
+      l.entanglements[a] = l.entanglements[a] | 1073741824 | u & 4194090;
+  }
+  function ci(l, t) {
+    var u = l.entangledLanes |= t;
+    for (l = l.entanglements; u;) {
+      var a = 31 - wl(u), e = 1 << a;
+      e & t | l[a] & t && (l[a] |= t), u &= ~e;
+    }
+  }
+  function Qn(l) {
+    switch (l) {
+      case 2:
+        l = 1;
+        break;
+      case 8:
+        l = 4;
+        break;
+      case 32:
+        l = 16;
+        break;
+      case 256:
+      case 512:
+      case 1024:
+      case 2048:
+      case 4096:
+      case 8192:
+      case 16384:
+      case 32768:
+      case 65536:
+      case 131072:
+      case 262144:
+      case 524288:
+      case 1048576:
+      case 2097152:
+      case 4194304:
+      case 8388608:
+      case 16777216:
+      case 33554432:
+        l = 128;
+        break;
+      case 268435456:
+        l = 134217728;
+        break;
+      default:
+        l = 0;
+    }
+    return l;
+  }
+  function xn(l) {
+    return l &= -l,
+      2 < l ? 8 < l ? (l & 134217727) !== 0 ? 32 : 268435456 : 8 : 2;
+  }
+  function ii() {
+    var l = _.p;
+    return l !== 0 ? l : (l = globalThis.event, l === void 0 ? 32 : jv(l.type));
+  }
+  function Sy(l, t) {
+    var u = _.p;
+    try {
+      return _.p = l, t();
+    } finally {
+      _.p = u;
+    }
+  }
+  var Ct = Math.random().toString(36).slice(2),
+    Rl = "__reactFiber$" + Ct,
+    Xl = "__reactProps$" + Ct,
+    Yu = "__reactContainer$" + Ct,
+    Zn = "__reactEvents$" + Ct,
+    gy = "__reactListeners$" + Ct,
+    ry = "__reactHandles$" + Ct,
+    si = "__reactResources$" + Ct,
+    Ea = "__reactMarker$" + Ct;
+  function jn(l) {
+    delete l[Rl], delete l[Xl], delete l[Zn], delete l[gy], delete l[ry];
+  }
+  function Bu(l) {
+    var t = l[Rl];
+    if (t) return t;
+    for (var u = l.parentNode; u;) {
+      if (t = u[Yu] || u[Rl]) {
+        if (
+          u = t.alternate, t.child !== null || u !== null && u.child !== null
+        ) {
+          for (l = Mv(l); l !== null;) {
+            if (u = l[Rl]) return u;
+            l = Mv(l);
+          }
+        }
+        return t;
+      }
+      l = u, u = l.parentNode;
+    }
+    return null;
+  }
+  function pu(l) {
+    if (l = l[Rl] || l[Yu]) {
+      var t = l.tag;
+      if (t === 5 || t === 6 || t === 13 || t === 26 || t === 27 || t === 3) {
+        return l;
+      }
+    }
+    return null;
+  }
+  function Aa(l) {
+    var t = l.tag;
+    if (t === 5 || t === 26 || t === 27 || t === 6) return l.stateNode;
+    throw Error(S(33));
+  }
+  function Gu(l) {
+    var t = l[si];
+    return t ||
+      (t = l[si] = { hoistableStyles: new Map(), hoistableScripts: new Map() }),
+      t;
+  }
+  function rl(l) {
+    l[Ea] = !0;
+  }
+  var vi = new Set(), yi = {};
+  function mu(l, t) {
+    Xu(l, t), Xu(l + "Capture", t);
+  }
+  function Xu(l, t) {
+    for (yi[l] = t, l = 0; l < t.length; l++) vi.add(t[l]);
+  }
+  var by = RegExp(
+      "^[:A-Z_a-z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD][:A-Z_a-z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD\\-.0-9\\u00B7\\u0300-\\u036F\\u203F-\\u2040]*$",
+    ),
+    di = {},
+    hi = {};
+  function Ty(l) {
+    return Bn.call(hi, l)
+      ? !0
+      : Bn.call(di, l)
+      ? !1
+      : by.test(l)
+      ? hi[l] = !0
+      : (di[l] = !0, !1);
+  }
+  function Ae(l, t, u) {
+    if (Ty(t)) {
+      if (u === null) l.removeAttribute(t);
+      else {
+        switch (typeof u) {
+          case "undefined":
+          case "function":
+          case "symbol":
+            l.removeAttribute(t);
+            return;
+          case "boolean":
+            var a = t.toLowerCase().slice(0, 5);
+            if (a !== "data-" && a !== "aria-") {
+              l.removeAttribute(t);
+              return;
+            }
+        }
+        l.setAttribute(t, "" + u);
+      }
+    }
+  }
+  function ze(l, t, u) {
+    if (u === null) l.removeAttribute(t);
+    else {
+      switch (typeof u) {
+        case "undefined":
+        case "function":
+        case "symbol":
+        case "boolean":
+          l.removeAttribute(t);
+          return;
+      }
+      l.setAttribute(t, "" + u);
+    }
+  }
+  function Ot(l, t, u, a) {
+    if (a === null) l.removeAttribute(u);
+    else {
+      switch (typeof a) {
+        case "undefined":
+        case "function":
+        case "symbol":
+        case "boolean":
+          l.removeAttribute(u);
+          return;
+      }
+      l.setAttributeNS(t, u, "" + a);
+    }
+  }
+  var Cn, oi;
+  function Qu(l) {
+    if (Cn === void 0) {
+      try {
+        throw Error();
+      } catch (u) {
+        var t = u.stack.trim().match(/\n( *(at )?)/);
+        Cn = t && t[1] || "",
+          oi = -1 < u.stack.indexOf(`
+    at`)
+            ? " (<anonymous>)"
+            : -1 < u.stack.indexOf("@")
+            ? "@unknown:0:0"
+            : "";
+      }
+    }
+    return `
+` + Cn + l + oi;
+  }
+  var Vn = !1;
+  function Ln(l, t) {
+    if (!l || Vn) return "";
+    Vn = !0;
+    var u = Error.prepareStackTrace;
+    Error.prepareStackTrace = void 0;
+    try {
+      var a = {
+        DetermineComponentFrameRoot: function () {
+          try {
+            if (t) {
+              var T = function () {
+                throw Error();
+              };
+              if (
+                Object.defineProperty(T.prototype, "props", {
+                  set: function () {
+                    throw Error();
+                  },
+                }), typeof Reflect == "object" && Reflect.construct
+              ) {
+                try {
+                  Reflect.construct(T, []);
+                } catch (m) {
+                  var o = m;
+                }
+                Reflect.construct(l, [], T);
+              } else {
+                try {
+                  T.call();
+                } catch (m) {
+                  o = m;
+                }
+                l.call(T.prototype);
+              }
+            } else {
+              try {
+                throw Error();
+              } catch (m) {
+                o = m;
+              }
+              (T = l()) && typeof T.catch == "function" &&
+                T.catch(function () {});
+            }
+          } catch (m) {
+            if (m && o && typeof m.stack == "string") return [m.stack, o.stack];
+          }
+          return [null, null];
+        },
+      };
+      a.DetermineComponentFrameRoot.displayName = "DetermineComponentFrameRoot";
+      var e = Object.getOwnPropertyDescriptor(
+        a.DetermineComponentFrameRoot,
+        "name",
+      );
+      e && e.configurable &&
+        Object.defineProperty(a.DetermineComponentFrameRoot, "name", {
+          value: "DetermineComponentFrameRoot",
+        });
+      var n = a.DetermineComponentFrameRoot(), f = n[0], c = n[1];
+      if (f && c) {
+        var i = f.split(`
+`),
+          h = c.split(`
+`);
+        for (
+          e = a = 0;
+          a < i.length && !i[a].includes("DetermineComponentFrameRoot");
+        ) a++;
+        for (; e < h.length && !h[e].includes("DetermineComponentFrameRoot");) {
+          e++;
+        }
+        if (a === i.length || e === h.length) {
+          for (
+            a = i.length - 1, e = h.length - 1;
+            1 <= a && 0 <= e && i[a] !== h[e];
+          ) e--;
+        }
+        for (; 1 <= a && 0 <= e; a--, e--) {
+          if (i[a] !== h[e]) {
+            if (a !== 1 || e !== 1) {
+              do if (a--, e--, 0 > e || i[a] !== h[e]) {
+                var g = `
+` + i[a].replace(" at new ", " at ");
+                return l.displayName && g.includes("<anonymous>") &&
+                  (g = g.replace("<anonymous>", l.displayName)),
+                  g;
+              } while (1 <= a && 0 <= e);
+            }
+            break;
+          }
+        }
+      }
+    } finally {
+      Vn = !1, Error.prepareStackTrace = u;
+    }
+    return (u = l ? l.displayName || l.name : "") ? Qu(u) : "";
+  }
+  function Ey(l) {
+    switch (l.tag) {
+      case 26:
+      case 27:
+      case 5:
+        return Qu(l.type);
+      case 16:
+        return Qu("Lazy");
+      case 13:
+        return Qu("Suspense");
+      case 19:
+        return Qu("SuspenseList");
+      case 0:
+      case 15:
+        return Ln(l.type, !1);
+      case 11:
+        return Ln(l.type.render, !1);
+      case 1:
+        return Ln(l.type, !0);
+      case 31:
+        return Qu("Activity");
+      default:
+        return "";
+    }
+  }
+  function mi(l) {
+    try {
+      var t = "";
+      do t += Ey(l), l = l.return; while (l);
+      return t;
+    } catch (u) {
+      return `
+Error generating stack: ` + u.message + `
+` + u.stack;
+    }
+  }
+  function ut(l) {
+    switch (typeof l) {
+      case "bigint":
+      case "boolean":
+      case "number":
+      case "string":
+      case "undefined":
+        return l;
+      case "object":
+        return l;
+      default:
+        return "";
+    }
+  }
+  function Si(l) {
+    var t = l.type;
+    return (l = l.nodeName) && l.toLowerCase() === "input" &&
+      (t === "checkbox" || t === "radio");
+  }
+  function Ay(l) {
+    var t = Si(l) ? "checked" : "value",
+      u = Object.getOwnPropertyDescriptor(l.constructor.prototype, t),
+      a = "" + l[t];
+    if (
+      !l.hasOwnProperty(t) && typeof u < "u" && typeof u.get == "function" &&
+      typeof u.set == "function"
+    ) {
+      var e = u.get, n = u.set;
+      return Object.defineProperty(l, t, {
+        configurable: !0,
+        get: function () {
+          return e.call(this);
+        },
+        set: function (f) {
+          a = "" + f, n.call(this, f);
+        },
+      }),
+        Object.defineProperty(l, t, { enumerable: u.enumerable }),
+        {
+          getValue: function () {
+            return a;
+          },
+          setValue: function (f) {
+            a = "" + f;
+          },
+          stopTracking: function () {
+            l._valueTracker = null, delete l[t];
+          },
+        };
+    }
+  }
+  function _e(l) {
+    l._valueTracker || (l._valueTracker = Ay(l));
+  }
+  function gi(l) {
+    if (!l) return !1;
+    var t = l._valueTracker;
+    if (!t) return !0;
+    var u = t.getValue(), a = "";
+    return l && (a = Si(l) ? l.checked ? "true" : "false" : l.value),
+      l = a,
+      l !== u ? (t.setValue(l), !0) : !1;
+  }
+  function Oe(l) {
+    if (l = l || (typeof document < "u" ? document : void 0), typeof l > "u") {
+      return null;
+    }
+    try {
+      return l.activeElement || l.body;
+    } catch {
+      return l.body;
+    }
+  }
+  var zy = /[\n"\\]/g;
+  function at(l) {
+    return l.replace(zy, function (t) {
+      return "\\" + t.charCodeAt(0).toString(16) + " ";
+    });
+  }
+  function Kn(l, t, u, a, e, n, f, c) {
+    l.name = "",
+      f != null && typeof f != "function" && typeof f != "symbol" &&
+        typeof f != "boolean"
+        ? l.type = f
+        : l.removeAttribute("type"),
+      t != null
+        ? f === "number"
+          ? (t === 0 && l.value === "" || l.value != t) &&
+            (l.value = "" + ut(t))
+          : l.value !== "" + ut(t) && (l.value = "" + ut(t))
+        : f !== "submit" && f !== "reset" || l.removeAttribute("value"),
+      t != null
+        ? Jn(l, f, ut(t))
+        : u != null
+        ? Jn(l, f, ut(u))
+        : a != null && l.removeAttribute("value"),
+      e == null && n != null && (l.defaultChecked = !!n),
+      e != null &&
+      (l.checked = e && typeof e != "function" && typeof e != "symbol"),
+      c != null && typeof c != "function" && typeof c != "symbol" &&
+        typeof c != "boolean"
+        ? l.name = "" + ut(c)
+        : l.removeAttribute("name");
+  }
+  function ri(l, t, u, a, e, n, f, c) {
+    if (
+      n != null && typeof n != "function" && typeof n != "symbol" &&
+      typeof n != "boolean" && (l.type = n), t != null || u != null
+    ) {
+      if (!(n !== "submit" && n !== "reset" || t != null)) return;
+      u = u != null ? "" + ut(u) : "",
+        t = t != null ? "" + ut(t) : u,
+        c || t === l.value || (l.value = t),
+        l.defaultValue = t;
+    }
+    a = a ?? e,
+      a = typeof a != "function" && typeof a != "symbol" && !!a,
+      l.checked = c ? l.checked : !!a,
+      l.defaultChecked = !!a,
+      f != null && typeof f != "function" && typeof f != "symbol" &&
+      typeof f != "boolean" && (l.name = f);
+  }
+  function Jn(l, t, u) {
+    t === "number" && Oe(l.ownerDocument) === l || l.defaultValue === "" + u ||
+      (l.defaultValue = "" + u);
+  }
+  function xu(l, t, u, a) {
+    if (l = l.options, t) {
+      t = {};
+      for (var e = 0; e < u.length; e++) t["$" + u[e]] = !0;
+      for (u = 0; u < l.length; u++) {
+        e = t.hasOwnProperty("$" + l[u].value),
+          l[u].selected !== e && (l[u].selected = e),
+          e && a && (l[u].defaultSelected = !0);
+      }
+    } else {
+      for (u = "" + ut(u), t = null, e = 0; e < l.length; e++) {
+        if (l[e].value === u) {
+          l[e].selected = !0, a && (l[e].defaultSelected = !0);
+          return;
+        }
+        t !== null || l[e].disabled || (t = l[e]);
+      }
+      t !== null && (t.selected = !0);
+    }
+  }
+  function bi(l, t, u) {
+    if (
+      t != null && (t = "" + ut(t), t !== l.value && (l.value = t), u == null)
+    ) {
+      l.defaultValue !== t && (l.defaultValue = t);
+      return;
+    }
+    l.defaultValue = u != null ? "" + ut(u) : "";
+  }
+  function Ti(l, t, u, a) {
+    if (t == null) {
+      if (a != null) {
+        if (u != null) throw Error(S(92));
+        if (Ul(a)) {
+          if (1 < a.length) throw Error(S(93));
+          a = a[0];
+        }
+        u = a;
+      }
+      u == null && (u = ""), t = u;
+    }
+    u = ut(t),
+      l.defaultValue = u,
+      a = l.textContent,
+      a === u && a !== "" && a !== null && (l.value = a);
+  }
+  function Zu(l, t) {
+    if (t) {
+      var u = l.firstChild;
+      if (u && u === l.lastChild && u.nodeType === 3) {
+        u.nodeValue = t;
+        return;
+      }
+    }
+    l.textContent = t;
+  }
+  var _y = new Set(
+    "animationIterationCount aspectRatio borderImageOutset borderImageSlice borderImageWidth boxFlex boxFlexGroup boxOrdinalGroup columnCount columns flex flexGrow flexPositive flexShrink flexNegative flexOrder gridArea gridRow gridRowEnd gridRowSpan gridRowStart gridColumn gridColumnEnd gridColumnSpan gridColumnStart fontWeight lineClamp lineHeight opacity order orphans scale tabSize widows zIndex zoom fillOpacity floodOpacity stopOpacity strokeDasharray strokeDashoffset strokeMiterlimit strokeOpacity strokeWidth MozAnimationIterationCount MozBoxFlex MozBoxFlexGroup MozLineClamp msAnimationIterationCount msFlex msZoom msFlexGrow msFlexNegative msFlexOrder msFlexPositive msFlexShrink msGridColumn msGridColumnSpan msGridRow msGridRowSpan WebkitAnimationIterationCount WebkitBoxFlex WebKitBoxFlexGroup WebkitBoxOrdinalGroup WebkitColumnCount WebkitColumns WebkitFlex WebkitFlexGrow WebkitFlexPositive WebkitFlexShrink WebkitLineClamp"
+      .split(" "),
+  );
+  function Ei(l, t, u) {
+    var a = t.indexOf("--") === 0;
+    u == null || typeof u == "boolean" || u === ""
+      ? a ? l.setProperty(t, "") : t === "float" ? l.cssFloat = "" : l[t] = ""
+      : a
+      ? l.setProperty(t, u)
+      : typeof u != "number" || u === 0 || _y.has(t)
+      ? t === "float" ? l.cssFloat = u : l[t] = ("" + u).trim()
+      : l[t] = u + "px";
+  }
+  function Ai(l, t, u) {
+    if (t != null && typeof t != "object") throw Error(S(62));
+    if (l = l.style, u != null) {
+      for (var a in u) {
+        !u.hasOwnProperty(a) || t != null && t.hasOwnProperty(a) ||
+          (a.indexOf("--") === 0
+            ? l.setProperty(a, "")
+            : a === "float"
+            ? l.cssFloat = ""
+            : l[a] = "");
+      }
+      for (var e in t) {
+        a = t[e], t.hasOwnProperty(e) && u[e] !== a && Ei(l, e, a);
+      }
+    } else for (var n in t) t.hasOwnProperty(n) && Ei(l, n, t[n]);
+  }
+  function wn(l) {
+    if (l.indexOf("-") === -1) return !1;
+    switch (l) {
+      case "annotation-xml":
+      case "color-profile":
+      case "font-face":
+      case "font-face-src":
+      case "font-face-uri":
+      case "font-face-format":
+      case "font-face-name":
+      case "missing-glyph":
+        return !1;
+      default:
+        return !0;
+    }
+  }
+  var Oy = new Map([
+      ["acceptCharset", "accept-charset"],
+      ["htmlFor", "for"],
+      ["httpEquiv", "http-equiv"],
+      ["crossOrigin", "crossorigin"],
+      ["accentHeight", "accent-height"],
+      ["alignmentBaseline", "alignment-baseline"],
+      ["arabicForm", "arabic-form"],
+      ["baselineShift", "baseline-shift"],
+      ["capHeight", "cap-height"],
+      ["clipPath", "clip-path"],
+      ["clipRule", "clip-rule"],
+      ["colorInterpolation", "color-interpolation"],
+      ["colorInterpolationFilters", "color-interpolation-filters"],
+      ["colorProfile", "color-profile"],
+      ["colorRendering", "color-rendering"],
+      ["dominantBaseline", "dominant-baseline"],
+      ["enableBackground", "enable-background"],
+      ["fillOpacity", "fill-opacity"],
+      ["fillRule", "fill-rule"],
+      ["floodColor", "flood-color"],
+      ["floodOpacity", "flood-opacity"],
+      ["fontFamily", "font-family"],
+      ["fontSize", "font-size"],
+      ["fontSizeAdjust", "font-size-adjust"],
+      ["fontStretch", "font-stretch"],
+      ["fontStyle", "font-style"],
+      ["fontVariant", "font-variant"],
+      ["fontWeight", "font-weight"],
+      ["glyphName", "glyph-name"],
+      ["glyphOrientationHorizontal", "glyph-orientation-horizontal"],
+      ["glyphOrientationVertical", "glyph-orientation-vertical"],
+      ["horizAdvX", "horiz-adv-x"],
+      ["horizOriginX", "horiz-origin-x"],
+      ["imageRendering", "image-rendering"],
+      ["letterSpacing", "letter-spacing"],
+      ["lightingColor", "lighting-color"],
+      ["markerEnd", "marker-end"],
+      ["markerMid", "marker-mid"],
+      ["markerStart", "marker-start"],
+      ["overlinePosition", "overline-position"],
+      ["overlineThickness", "overline-thickness"],
+      ["paintOrder", "paint-order"],
+      ["panose-1", "panose-1"],
+      ["pointerEvents", "pointer-events"],
+      ["renderingIntent", "rendering-intent"],
+      ["shapeRendering", "shape-rendering"],
+      ["stopColor", "stop-color"],
+      ["stopOpacity", "stop-opacity"],
+      ["strikethroughPosition", "strikethrough-position"],
+      ["strikethroughThickness", "strikethrough-thickness"],
+      ["strokeDasharray", "stroke-dasharray"],
+      ["strokeDashoffset", "stroke-dashoffset"],
+      ["strokeLinecap", "stroke-linecap"],
+      ["strokeLinejoin", "stroke-linejoin"],
+      ["strokeMiterlimit", "stroke-miterlimit"],
+      ["strokeOpacity", "stroke-opacity"],
+      ["strokeWidth", "stroke-width"],
+      ["textAnchor", "text-anchor"],
+      ["textDecoration", "text-decoration"],
+      ["textRendering", "text-rendering"],
+      ["transformOrigin", "transform-origin"],
+      ["underlinePosition", "underline-position"],
+      ["underlineThickness", "underline-thickness"],
+      ["unicodeBidi", "unicode-bidi"],
+      ["unicodeRange", "unicode-range"],
+      ["unitsPerEm", "units-per-em"],
+      ["vAlphabetic", "v-alphabetic"],
+      ["vHanging", "v-hanging"],
+      ["vIdeographic", "v-ideographic"],
+      ["vMathematical", "v-mathematical"],
+      ["vectorEffect", "vector-effect"],
+      ["vertAdvY", "vert-adv-y"],
+      ["vertOriginX", "vert-origin-x"],
+      ["vertOriginY", "vert-origin-y"],
+      ["wordSpacing", "word-spacing"],
+      ["writingMode", "writing-mode"],
+      ["xmlnsXlink", "xmlns:xlink"],
+      ["xHeight", "x-height"],
+    ]),
+    My =
+      /^[\u0000-\u001F ]*j[\r\n\t]*a[\r\n\t]*v[\r\n\t]*a[\r\n\t]*s[\r\n\t]*c[\r\n\t]*r[\r\n\t]*i[\r\n\t]*p[\r\n\t]*t[\r\n\t]*:/i;
+  function Me(l) {
+    return My.test("" + l)
+      ? "javascript:throw new Error('React has blocked a javascript: URL as a security precaution.')"
+      : l;
+  }
+  var Wn = null;
+  function $n(l) {
+    return l = l.target || l.srcElement || window,
+      l.correspondingUseElement && (l = l.correspondingUseElement),
+      l.nodeType === 3 ? l.parentNode : l;
+  }
+  var ju = null, Cu = null;
+  function zi(l) {
+    var t = pu(l);
+    if (t && (l = t.stateNode)) {
+      var u = l[Xl] || null;
+      l: switch (l = t.stateNode, t.type) {
+        case "input":
+          if (
+            Kn(
+              l,
+              u.value,
+              u.defaultValue,
+              u.defaultValue,
+              u.checked,
+              u.defaultChecked,
+              u.type,
+              u.name,
+            ),
+              t = u.name,
+              u.type === "radio" && t != null
+          ) {
+            for (u = l; u.parentNode;) u = u.parentNode;
+            for (
+              u = u.querySelectorAll(
+                'input[name="' + at("" + t) + '"][type="radio"]',
+              ), t = 0;
+              t < u.length;
+              t++
+            ) {
+              var a = u[t];
+              if (a !== l && a.form === l.form) {
+                var e = a[Xl] || null;
+                if (!e) throw Error(S(90));
+                Kn(
+                  a,
+                  e.value,
+                  e.defaultValue,
+                  e.defaultValue,
+                  e.checked,
+                  e.defaultChecked,
+                  e.type,
+                  e.name,
+                );
+              }
+            }
+            for (t = 0; t < u.length; t++) a = u[t], a.form === l.form && gi(a);
+          }
+          break l;
+        case "textarea":
+          bi(l, u.value, u.defaultValue);
+          break l;
+        case "select":
+          t = u.value, t != null && xu(l, !!u.multiple, t, !1);
+      }
+    }
+  }
+  var kn = !1;
+  function _i(l, t, u) {
+    if (kn) return l(t, u);
+    kn = !0;
+    try {
+      var a = l(t);
+      return a;
+    } finally {
+      if (
+        kn = !1,
+          (ju !== null || Cu !== null) &&
+          (dn(), ju && (t = ju, l = Cu, Cu = ju = null, zi(t), l))
+      ) { for (t = 0; t < l.length; t++) zi(l[t]); }
+    }
+  }
+  function za(l, t) {
+    var u = l.stateNode;
+    if (u === null) return null;
+    var a = u[Xl] || null;
+    if (a === null) return null;
+    u = a[t];
+    l: switch (t) {
+      case "onClick":
+      case "onClickCapture":
+      case "onDoubleClick":
+      case "onDoubleClickCapture":
+      case "onMouseDown":
+      case "onMouseDownCapture":
+      case "onMouseMove":
+      case "onMouseMoveCapture":
+      case "onMouseUp":
+      case "onMouseUpCapture":
+      case "onMouseEnter":
+        (a = !a.disabled) ||
+        (l = l.type,
+          a = !(l === "button" || l === "input" || l === "select" ||
+            l === "textarea")), l = !a;
+        break l;
+      default:
+        l = !1;
+    }
+    if (l) return null;
+    if (u && typeof u != "function") throw Error(S(231, t, typeof u));
+    return u;
+  }
+  var Mt = !(typeof window > "u" || typeof globalThis.document > "u" ||
+      typeof globalThis.document.createElement > "u"),
+    Fn = !1;
+  if (Mt) {
+    try {
+      var _a = {};
+      Object.defineProperty(_a, "passive", {
+        get: function () {
+          Fn = !0;
+        },
+      }),
+        globalThis.addEventListener("test", _a, _a),
+        globalThis.removeEventListener("test", _a, _a);
+    } catch {
+      Fn = !1;
+    }
+  }
+  var Vt = null, In = null, De = null;
+  function Oi() {
+    if (De) return De;
+    var l,
+      t = In,
+      u = t.length,
+      a,
+      e = "value" in Vt ? Vt.value : Vt.textContent,
+      n = e.length;
+    for (l = 0; l < u && t[l] === e[l]; l++);
+    var f = u - l;
+    for (a = 1; a <= f && t[u - a] === e[n - a]; a++);
+    return De = e.slice(l, 1 < a ? 1 - a : void 0);
+  }
+  function Ue(l) {
+    var t = l.keyCode;
+    return "charCode" in l
+      ? (l = l.charCode, l === 0 && t === 13 && (l = 13))
+      : l = t,
+      l === 10 && (l = 13),
+      32 <= l || l === 13 ? l : 0;
+  }
+  function Re() {
+    return !0;
+  }
+  function Mi() {
+    return !1;
+  }
+  function Ql(l) {
+    function t(u, a, e, n, f) {
+      this._reactName = u,
+        this._targetInst = e,
+        this.type = a,
+        this.nativeEvent = n,
+        this.target = f,
+        this.currentTarget = null;
+      for (var c in l) {
+        l.hasOwnProperty(c) && (u = l[c], this[c] = u ? u(n) : n[c]);
+      }
+      return this.isDefaultPrevented =
+        (n.defaultPrevented != null ? n.defaultPrevented : n.returnValue === !1)
+          ? Re
+          : Mi,
+        this.isPropagationStopped = Mi,
+        this;
+    }
+    return R(t.prototype, {
+      preventDefault: function () {
+        this.defaultPrevented = !0;
+        var u = this.nativeEvent;
+        u &&
+          (u.preventDefault
+            ? u.preventDefault()
+            : typeof u.returnValue != "unknown" && (u.returnValue = !1),
+            this.isDefaultPrevented = Re);
+      },
+      stopPropagation: function () {
+        var u = this.nativeEvent;
+        u &&
+          (u.stopPropagation
+            ? u.stopPropagation()
+            : typeof u.cancelBubble != "unknown" && (u.cancelBubble = !0),
+            this.isPropagationStopped = Re);
+      },
+      persist: function () {},
+      isPersistent: Re,
+    }),
+      t;
+  }
+  var Su = {
+      eventPhase: 0,
+      bubbles: 0,
+      cancelable: 0,
+      timeStamp: function (l) {
+        return l.timeStamp || Date.now();
+      },
+      defaultPrevented: 0,
+      isTrusted: 0,
+    },
+    He = Ql(Su),
+    Oa = R({}, Su, { view: 0, detail: 0 }),
+    Dy = Ql(Oa),
+    Pn,
+    lf,
+    Ma,
+    Ne = R({}, Oa, {
+      screenX: 0,
+      screenY: 0,
+      clientX: 0,
+      clientY: 0,
+      pageX: 0,
+      pageY: 0,
+      ctrlKey: 0,
+      shiftKey: 0,
+      altKey: 0,
+      metaKey: 0,
+      getModifierState: uf,
+      button: 0,
+      buttons: 0,
+      relatedTarget: function (l) {
+        return l.relatedTarget === void 0
+          ? l.fromElement === l.srcElement ? l.toElement : l.fromElement
+          : l.relatedTarget;
+      },
+      movementX: function (l) {
+        return "movementX" in l
+          ? l.movementX
+          : (l !== Ma && (Ma && l.type === "mousemove"
+            ? (Pn = l.screenX - Ma.screenX, lf = l.screenY - Ma.screenY)
+            : lf = Pn = 0,
+            Ma = l),
+            Pn);
+      },
+      movementY: function (l) {
+        return "movementY" in l ? l.movementY : lf;
+      },
+    }),
+    Di = Ql(Ne),
+    Uy = R({}, Ne, { dataTransfer: 0 }),
+    Ry = Ql(Uy),
+    Hy = R({}, Oa, { relatedTarget: 0 }),
+    tf = Ql(Hy),
+    Ny = R({}, Su, { animationName: 0, elapsedTime: 0, pseudoElement: 0 }),
+    qy = Ql(Ny),
+    Yy = R({}, Su, {
+      clipboardData: function (l) {
+        return "clipboardData" in l ? l.clipboardData : globalThis.clipboardData;
+      },
+    }),
+    By = Ql(Yy),
+    py = R({}, Su, { data: 0 }),
+    Ui = Ql(py),
+    Gy = {
+      Esc: "Escape",
+      Spacebar: " ",
+      Left: "ArrowLeft",
+      Up: "ArrowUp",
+      Right: "ArrowRight",
+      Down: "ArrowDown",
+      Del: "Delete",
+      Win: "OS",
+      Menu: "ContextMenu",
+      Apps: "ContextMenu",
+      Scroll: "ScrollLock",
+      MozPrintableKey: "Unidentified",
+    },
+    Xy = {
+      8: "Backspace",
+      9: "Tab",
+      12: "Clear",
+      13: "Enter",
+      16: "Shift",
+      17: "Control",
+      18: "Alt",
+      19: "Pause",
+      20: "CapsLock",
+      27: "Escape",
+      32: " ",
+      33: "PageUp",
+      34: "PageDown",
+      35: "End",
+      36: "Home",
+      37: "ArrowLeft",
+      38: "ArrowUp",
+      39: "ArrowRight",
+      40: "ArrowDown",
+      45: "Insert",
+      46: "Delete",
+      112: "F1",
+      113: "F2",
+      114: "F3",
+      115: "F4",
+      116: "F5",
+      117: "F6",
+      118: "F7",
+      119: "F8",
+      120: "F9",
+      121: "F10",
+      122: "F11",
+      123: "F12",
+      144: "NumLock",
+      145: "ScrollLock",
+      224: "Meta",
+    },
+    Qy = {
+      Alt: "altKey",
+      Control: "ctrlKey",
+      Meta: "metaKey",
+      Shift: "shiftKey",
+    };
+  function xy(l) {
+    var t = this.nativeEvent;
+    return t.getModifierState
+      ? t.getModifierState(l)
+      : (l = Qy[l])
+      ? !!t[l]
+      : !1;
+  }
+  function uf() {
+    return xy;
+  }
+  var Zy = R({}, Oa, {
+      key: function (l) {
+        if (l.key) {
+          var t = Gy[l.key] || l.key;
+          if (t !== "Unidentified") return t;
+        }
+        return l.type === "keypress"
+          ? (l = Ue(l), l === 13 ? "Enter" : String.fromCharCode(l))
+          : l.type === "keydown" || l.type === "keyup"
+          ? Xy[l.keyCode] || "Unidentified"
+          : "";
+      },
+      code: 0,
+      location: 0,
+      ctrlKey: 0,
+      shiftKey: 0,
+      altKey: 0,
+      metaKey: 0,
+      repeat: 0,
+      locale: 0,
+      getModifierState: uf,
+      charCode: function (l) {
+        return l.type === "keypress" ? Ue(l) : 0;
+      },
+      keyCode: function (l) {
+        return l.type === "keydown" || l.type === "keyup" ? l.keyCode : 0;
+      },
+      which: function (l) {
+        return l.type === "keypress"
+          ? Ue(l)
+          : l.type === "keydown" || l.type === "keyup"
+          ? l.keyCode
+          : 0;
+      },
+    }),
+    jy = Ql(Zy),
+    Cy = R({}, Ne, {
+      pointerId: 0,
+      width: 0,
+      height: 0,
+      pressure: 0,
+      tangentialPressure: 0,
+      tiltX: 0,
+      tiltY: 0,
+      twist: 0,
+      pointerType: 0,
+      isPrimary: 0,
+    }),
+    Ri = Ql(Cy),
+    Vy = R({}, Oa, {
+      touches: 0,
+      targetTouches: 0,
+      changedTouches: 0,
+      altKey: 0,
+      metaKey: 0,
+      ctrlKey: 0,
+      shiftKey: 0,
+      getModifierState: uf,
+    }),
+    Ly = Ql(Vy),
+    Ky = R({}, Su, { propertyName: 0, elapsedTime: 0, pseudoElement: 0 }),
+    Jy = Ql(Ky),
+    wy = R({}, Ne, {
+      deltaX: function (l) {
+        return "deltaX" in l
+          ? l.deltaX
+          : "wheelDeltaX" in l
+          ? -l.wheelDeltaX
+          : 0;
+      },
+      deltaY: function (l) {
+        return "deltaY" in l
+          ? l.deltaY
+          : "wheelDeltaY" in l
+          ? -l.wheelDeltaY
+          : "wheelDelta" in l
+          ? -l.wheelDelta
+          : 0;
+      },
+      deltaZ: 0,
+      deltaMode: 0,
+    }),
+    Wy = Ql(wy),
+    $y = R({}, Su, { newState: 0, oldState: 0 }),
+    ky = Ql($y),
+    Fy = [9, 13, 27, 32],
+    af = Mt && "CompositionEvent" in window,
+    Da = null;
+  Mt && "documentMode" in document && (Da = document.documentMode);
+  var Iy = Mt && "TextEvent" in window && !Da,
+    Hi = Mt && (!af || Da && 8 < Da && 11 >= Da),
+    Ni = " ",
+    qi = !1;
+  function Yi(l, t) {
+    switch (l) {
+      case "keyup":
+        return Fy.indexOf(t.keyCode) !== -1;
+      case "keydown":
+        return t.keyCode !== 229;
+      case "keypress":
+      case "mousedown":
+      case "focusout":
+        return !0;
+      default:
+        return !1;
+    }
+  }
+  function Bi(l) {
+    return l = l.detail, typeof l == "object" && "data" in l ? l.data : null;
+  }
+  var Vu = !1;
+  function Py(l, t) {
+    switch (l) {
+      case "compositionend":
+        return Bi(t);
+      case "keypress":
+        return t.which !== 32 ? null : (qi = !0, Ni);
+      case "textInput":
+        return l = t.data, l === Ni && qi ? null : l;
+      default:
+        return null;
+    }
+  }
+  function ld(l, t) {
+    if (Vu) {
+      return l === "compositionend" || !af && Yi(l, t)
+        ? (l = Oi(), De = In = Vt = null, Vu = !1, l)
+        : null;
+    }
+    switch (l) {
+      case "paste":
+        return null;
+      case "keypress":
+        if (!(t.ctrlKey || t.altKey || t.metaKey) || t.ctrlKey && t.altKey) {
+          if (t.char && 1 < t.char.length) return t.char;
+          if (t.which) return String.fromCharCode(t.which);
+        }
+        return null;
+      case "compositionend":
+        return Hi && t.locale !== "ko" ? null : t.data;
+      default:
+        return null;
+    }
+  }
+  var td = {
+    color: !0,
+    date: !0,
+    datetime: !0,
+    "datetime-local": !0,
+    email: !0,
+    month: !0,
+    number: !0,
+    password: !0,
+    range: !0,
+    search: !0,
+    tel: !0,
+    text: !0,
+    time: !0,
+    url: !0,
+    week: !0,
+  };
+  function pi(l) {
+    var t = l && l.nodeName && l.nodeName.toLowerCase();
+    return t === "input" ? !!td[l.type] : t === "textarea";
+  }
+  function Gi(l, t, u, a) {
+    ju ? Cu ? Cu.push(a) : Cu = [a] : ju = a,
+      t = rn(t, "onChange"),
+      0 < t.length &&
+      (u = new He("onChange", "change", null, u, a),
+        l.push({ event: u, listeners: t }));
+  }
+  var Ua = null, Ra = null;
+  function ud(l) {
+    Sv(l, 0);
+  }
+  function qe(l) {
+    var t = Aa(l);
+    if (gi(t)) return l;
+  }
+  function Xi(l, t) {
+    if (l === "change") return t;
+  }
+  var Qi = !1;
+  if (Mt) {
+    var ef;
+    if (Mt) {
+      var nf = "oninput" in document;
+      if (!nf) {
+        var xi = document.createElement("div");
+        xi.setAttribute("oninput", "return;"),
+          nf = typeof xi.oninput == "function";
+      }
+      ef = nf;
+    } else ef = !1;
+    Qi = ef && (!document.documentMode || 9 < document.documentMode);
+  }
+  function Zi() {
+    Ua && (Ua.detachEvent("onpropertychange", ji), Ra = Ua = null);
+  }
+  function ji(l) {
+    if (l.propertyName === "value" && qe(Ra)) {
+      var t = [];
+      Gi(t, Ra, l, $n(l)), _i(ud, t);
+    }
+  }
+  function ad(l, t, u) {
+    l === "focusin"
+      ? (Zi(), Ua = t, Ra = u, Ua.attachEvent("onpropertychange", ji))
+      : l === "focusout" && Zi();
+  }
+  function ed(l) {
+    if (l === "selectionchange" || l === "keyup" || l === "keydown") {
+      return qe(Ra);
+    }
+  }
+  function nd(l, t) {
+    if (l === "click") return qe(t);
+  }
+  function fd(l, t) {
+    if (l === "input" || l === "change") return qe(t);
+  }
+  function cd(l, t) {
+    return l === t && (l !== 0 || 1 / l === 1 / t) || l !== l && t !== t;
+  }
+  var Wl = typeof Object.is == "function" ? Object.is : cd;
+  function Ha(l, t) {
+    if (Wl(l, t)) return !0;
+    if (
+      typeof l != "object" || l === null || typeof t != "object" || t === null
+    ) return !1;
+    var u = Object.keys(l), a = Object.keys(t);
+    if (u.length !== a.length) return !1;
+    for (a = 0; a < u.length; a++) {
+      var e = u[a];
+      if (!Bn.call(t, e) || !Wl(l[e], t[e])) return !1;
+    }
+    return !0;
+  }
+  function Ci(l) {
+    for (; l && l.firstChild;) l = l.firstChild;
+    return l;
+  }
+  function Vi(l, t) {
+    var u = Ci(l);
+    l = 0;
+    for (var a; u;) {
+      if (u.nodeType === 3) {
+        if (a = l + u.textContent.length, l <= t && a >= t) {
+          return { node: u, offset: t - l };
+        }
+        l = a;
+      }
+      l: {
+        for (; u;) {
+          if (u.nextSibling) {
+            u = u.nextSibling;
+            break l;
+          }
+          u = u.parentNode;
+        }
+        u = void 0;
+      }
+      u = Ci(u);
+    }
+  }
+  function Li(l, t) {
+    return l && t
+      ? l === t
+        ? !0
+        : l && l.nodeType === 3
+        ? !1
+        : t && t.nodeType === 3
+        ? Li(l, t.parentNode)
+        : "contains" in l
+        ? l.contains(t)
+        : l.compareDocumentPosition
+        ? !!(l.compareDocumentPosition(t) & 16)
+        : !1
+      : !1;
+  }
+  function Ki(l) {
+    l = l != null && l.ownerDocument != null &&
+        l.ownerDocument.defaultView != null
+      ? l.ownerDocument.defaultView
+      : window;
+    for (var t = Oe(l.document); t instanceof l.HTMLIFrameElement;) {
+      try {
+        var u = typeof t.contentWindow.location.href == "string";
+      } catch {
+        u = !1;
+      }
+      if (u) l = t.contentWindow;
+      else break;
+      t = Oe(l.document);
+    }
+    return t;
+  }
+  function ff(l) {
+    var t = l && l.nodeName && l.nodeName.toLowerCase();
+    return t &&
+      (t === "input" &&
+          (l.type === "text" || l.type === "search" || l.type === "tel" ||
+            l.type === "url" || l.type === "password") ||
+        t === "textarea" || l.contentEditable === "true");
+  }
+  var id = Mt && "documentMode" in document && 11 >= document.documentMode,
+    Lu = null,
+    cf = null,
+    Na = null,
+    sf = !1;
+  function Ji(l, t, u) {
+    var a = u.window === u
+      ? u.document
+      : u.nodeType === 9
+      ? u
+      : u.ownerDocument;
+    sf || Lu == null || Lu !== Oe(a) ||
+      (a = Lu,
+        "selectionStart" in a && ff(a)
+          ? a = { start: a.selectionStart, end: a.selectionEnd }
+          : (a = (a.ownerDocument && a.ownerDocument.defaultView || window)
+            .getSelection(),
+            a = {
+              anchorNode: a.anchorNode,
+              anchorOffset: a.anchorOffset,
+              focusNode: a.focusNode,
+              focusOffset: a.focusOffset,
+            }),
+        Na && Ha(Na, a) ||
+        (Na = a,
+          a = rn(cf, "onSelect"),
+          0 < a.length &&
+          (t = new He("onSelect", "select", null, t, u),
+            l.push({ event: t, listeners: a }),
+            t.target = Lu)));
+  }
+  function gu(l, t) {
+    var u = {};
+    return u[l.toLowerCase()] = t.toLowerCase(),
+      u["Webkit" + l] = "webkit" + t,
+      u["Moz" + l] = "moz" + t,
+      u;
+  }
+  var Ku = {
+      animationend: gu("Animation", "AnimationEnd"),
+      animationiteration: gu("Animation", "AnimationIteration"),
+      animationstart: gu("Animation", "AnimationStart"),
+      transitionrun: gu("Transition", "TransitionRun"),
+      transitionstart: gu("Transition", "TransitionStart"),
+      transitioncancel: gu("Transition", "TransitionCancel"),
+      transitionend: gu("Transition", "TransitionEnd"),
+    },
+    vf = {},
+    wi = {};
+  Mt && (wi = document.createElement("div").style,
+    "AnimationEvent" in window ||
+    (delete Ku.animationend.animation,
+      delete Ku.animationiteration.animation,
+      delete Ku.animationstart.animation),
+    "TransitionEvent" in window || delete Ku.transitionend.transition);
+  function ru(l) {
+    if (vf[l]) return vf[l];
+    if (!Ku[l]) return l;
+    var t = Ku[l], u;
+    for (u in t) if (t.hasOwnProperty(u) && u in wi) return vf[l] = t[u];
+    return l;
+  }
+  var Wi = ru("animationend"),
+    $i = ru("animationiteration"),
+    ki = ru("animationstart"),
+    sd = ru("transitionrun"),
+    vd = ru("transitionstart"),
+    yd = ru("transitioncancel"),
+    Fi = ru("transitionend"),
+    Ii = new Map(),
+    yf =
+      "abort auxClick beforeToggle cancel canPlay canPlayThrough click close contextMenu copy cut drag dragEnd dragEnter dragExit dragLeave dragOver dragStart drop durationChange emptied encrypted ended error gotPointerCapture input invalid keyDown keyPress keyUp load loadedData loadedMetadata loadStart lostPointerCapture mouseDown mouseMove mouseOut mouseOver mouseUp paste pause play playing pointerCancel pointerDown pointerMove pointerOut pointerOver pointerUp progress rateChange reset resize seeked seeking stalled submit suspend timeUpdate touchCancel touchEnd touchStart volumeChange scroll toggle touchMove waiting wheel"
+        .split(" ");
+  yf.push("scrollEnd");
+  function ht(l, t) {
+    Ii.set(l, t), mu(t, [l]);
+  }
+  var Pi = new WeakMap();
+  function et(l, t) {
+    if (typeof l == "object" && l !== null) {
+      var u = Pi.get(l);
+      return u !== void 0
+        ? u
+        : (t = { value: l, source: t, stack: mi(t) }, Pi.set(l, t), t);
+    }
+    return { value: l, source: t, stack: mi(t) };
+  }
+  var nt = [], Ju = 0, df = 0;
+  function Ye() {
+    for (var l = Ju, t = df = Ju = 0; t < l;) {
+      var u = nt[t];
+      nt[t++] = null;
+      var a = nt[t];
+      nt[t++] = null;
+      var e = nt[t];
+      nt[t++] = null;
+      var n = nt[t];
+      if (nt[t++] = null, a !== null && e !== null) {
+        var f = a.pending;
+        f === null ? e.next = e : (e.next = f.next, f.next = e), a.pending = e;
+      }
+      n !== 0 && l0(u, e, n);
+    }
+  }
+  function Be(l, t, u, a) {
+    nt[Ju++] = l,
+      nt[Ju++] = t,
+      nt[Ju++] = u,
+      nt[Ju++] = a,
+      df |= a,
+      l.lanes |= a,
+      l = l.alternate,
+      l !== null && (l.lanes |= a);
+  }
+  function hf(l, t, u, a) {
+    return Be(l, t, u, a), pe(l);
+  }
+  function wu(l, t) {
+    return Be(l, null, null, t), pe(l);
+  }
+  function l0(l, t, u) {
+    l.lanes |= u;
+    var a = l.alternate;
+    a !== null && (a.lanes |= u);
+    for (var e = !1, n = l.return; n !== null;) {
+      n.childLanes |= u,
+        a = n.alternate,
+        a !== null && (a.childLanes |= u),
+        n.tag === 22 &&
+        (l = n.stateNode, l === null || l._visibility & 1 || (e = !0)),
+        l = n,
+        n = n.return;
+    }
+    return l.tag === 3
+      ? (n = l.stateNode,
+        e && t !== null &&
+        (e = 31 - wl(u),
+          l = n.hiddenUpdates,
+          a = l[e],
+          a === null ? l[e] = [t] : a.push(t),
+          t.lane = u | 536870912),
+        n)
+      : null;
+  }
+  function pe(l) {
+    if (50 < ue) throw ue = 0, bc = null, Error(S(185));
+    for (var t = l.return; t !== null;) l = t, t = l.return;
+    return l.tag === 3 ? l.stateNode : null;
+  }
+  var Wu = {};
+  function dd(l, t, u, a) {
+    this.tag = l,
+      this.key = u,
+      this.sibling =
+        this.child =
+        this.return =
+        this.stateNode =
+        this.type =
+        this.elementType =
+          null,
+      this.index = 0,
+      this.refCleanup = this.ref = null,
+      this.pendingProps = t,
+      this.dependencies =
+        this.memoizedState =
+        this.updateQueue =
+        this.memoizedProps =
+          null,
+      this.mode = a,
+      this.subtreeFlags = this.flags = 0,
+      this.deletions = null,
+      this.childLanes = this.lanes = 0,
+      this.alternate = null;
+  }
+  function $l(l, t, u, a) {
+    return new dd(l, t, u, a);
+  }
+  function of(l) {
+    return l = l.prototype, !(!l || !l.isReactComponent);
+  }
+  function Dt(l, t) {
+    var u = l.alternate;
+    return u === null
+      ? (u = $l(l.tag, t, l.key, l.mode),
+        u.elementType = l.elementType,
+        u.type = l.type,
+        u.stateNode = l.stateNode,
+        u.alternate = l,
+        l.alternate = u)
+      : (u.pendingProps = t,
+        u.type = l.type,
+        u.flags = 0,
+        u.subtreeFlags = 0,
+        u.deletions = null),
+      u.flags = l.flags & 65011712,
+      u.childLanes = l.childLanes,
+      u.lanes = l.lanes,
+      u.child = l.child,
+      u.memoizedProps = l.memoizedProps,
+      u.memoizedState = l.memoizedState,
+      u.updateQueue = l.updateQueue,
+      t = l.dependencies,
+      u.dependencies = t === null
+        ? null
+        : { lanes: t.lanes, firstContext: t.firstContext },
+      u.sibling = l.sibling,
+      u.index = l.index,
+      u.ref = l.ref,
+      u.refCleanup = l.refCleanup,
+      u;
+  }
+  function t0(l, t) {
+    l.flags &= 65011714;
+    var u = l.alternate;
+    return u === null
+      ? (l.childLanes = 0,
+        l.lanes = t,
+        l.child = null,
+        l.subtreeFlags = 0,
+        l.memoizedProps = null,
+        l.memoizedState = null,
+        l.updateQueue = null,
+        l.dependencies = null,
+        l.stateNode = null)
+      : (l.childLanes = u.childLanes,
+        l.lanes = u.lanes,
+        l.child = u.child,
+        l.subtreeFlags = 0,
+        l.deletions = null,
+        l.memoizedProps = u.memoizedProps,
+        l.memoizedState = u.memoizedState,
+        l.updateQueue = u.updateQueue,
+        l.type = u.type,
+        t = u.dependencies,
+        l.dependencies = t === null
+          ? null
+          : { lanes: t.lanes, firstContext: t.firstContext }),
+      l;
+  }
+  function Ge(l, t, u, a, e, n) {
+    var f = 0;
+    if (a = l, typeof l == "function") of(l) && (f = 1);
+    else if (typeof l == "string") {
+      f = o1(l, u, N.current)
+        ? 26
+        : l === "html" || l === "head" || l === "body"
+        ? 27
+        : 5;
+    } else {l: switch (l) {
+        case St:
+          return l = $l(31, u, t, e), l.elementType = St, l.lanes = n, l;
+        case Bl:
+          return bu(u.children, e, n, t);
+        case yt:
+          f = 8, e |= 24;
+          break;
+        case Gl:
+          return l = $l(12, u, t, e | 2), l.elementType = Gl, l.lanes = n, l;
+        case V:
+          return l = $l(13, u, t, e), l.elementType = V, l.lanes = n, l;
+        case Cl:
+          return l = $l(19, u, t, e), l.elementType = Cl, l.lanes = n, l;
+        default:
+          if (typeof l == "object" && l !== null) {
+            switch (l.$$typeof) {
+              case yu:
+              case Ml:
+                f = 10;
+                break l;
+              case zt:
+                f = 9;
+                break l;
+              case dt:
+                f = 11;
+                break l;
+              case Vl:
+                f = 14;
+                break l;
+              case Ll:
+                f = 16, a = null;
+                break l;
+            }
+          }
+          f = 29,
+            u = Error(S(130, l === null ? "null" : typeof l, "")),
+            a = null;
+      }}
+    return t = $l(f, u, t, e), t.elementType = l, t.type = a, t.lanes = n, t;
+  }
+  function bu(l, t, u, a) {
+    return l = $l(7, l, a, t), l.lanes = u, l;
+  }
+  function mf(l, t, u) {
+    return l = $l(6, l, null, t), l.lanes = u, l;
+  }
+  function Sf(l, t, u) {
+    return t = $l(4, l.children !== null ? l.children : [], l.key, t),
+      t.lanes = u,
+      t.stateNode = {
+        containerInfo: l.containerInfo,
+        pendingChildren: null,
+        implementation: l.implementation,
+      },
+      t;
+  }
+  var $u = [],
+    ku = 0,
+    Xe = null,
+    Qe = 0,
+    ft = [],
+    ct = 0,
+    Tu = null,
+    Ut = 1,
+    Rt = "";
+  function Eu(l, t) {
+    $u[ku++] = Qe, $u[ku++] = Xe, Xe = l, Qe = t;
+  }
+  function u0(l, t, u) {
+    ft[ct++] = Ut, ft[ct++] = Rt, ft[ct++] = Tu, Tu = l;
+    var a = Ut;
+    l = Rt;
+    var e = 32 - wl(a) - 1;
+    a &= ~(1 << e), u += 1;
+    var n = 32 - wl(t) + e;
+    if (30 < n) {
+      var f = e - e % 5;
+      n = (a & (1 << f) - 1).toString(32),
+        a >>= f,
+        e -= f,
+        Ut = 1 << 32 - wl(t) + e | u << e | a,
+        Rt = n + l;
+    } else Ut = 1 << n | u << e | a, Rt = l;
+  }
+  function gf(l) {
+    l.return !== null && (Eu(l, 1), u0(l, 1, 0));
+  }
+  function rf(l) {
+    for (; l === Xe;) {
+      Xe = $u[--ku], $u[ku] = null, Qe = $u[--ku], $u[ku] = null;
+    }
+    for (; l === Tu;) {
+      Tu = ft[--ct],
+        ft[ct] = null,
+        Rt = ft[--ct],
+        ft[ct] = null,
+        Ut = ft[--ct],
+        ft[ct] = null;
+    }
+  }
+  var pl = null, cl = null, J = !1, Au = null, rt = !1, bf = Error(S(519));
+  function zu(l) {
+    var t = Error(S(418, ""));
+    throw Ba(et(t, l)), bf;
+  }
+  function a0(l) {
+    var t = l.stateNode, u = l.type, a = l.memoizedProps;
+    switch (t[Rl] = l, t[Xl] = a, u) {
+      case "dialog":
+        j("cancel", t), j("close", t);
+        break;
+      case "iframe":
+      case "object":
+      case "embed":
+        j("load", t);
+        break;
+      case "video":
+      case "audio":
+        for (u = 0; u < ee.length; u++) j(ee[u], t);
+        break;
+      case "source":
+        j("error", t);
+        break;
+      case "img":
+      case "image":
+      case "link":
+        j("error", t), j("load", t);
+        break;
+      case "details":
+        j("toggle", t);
+        break;
+      case "input":
+        j("invalid", t),
+          ri(
+            t,
+            a.value,
+            a.defaultValue,
+            a.checked,
+            a.defaultChecked,
+            a.type,
+            a.name,
+            !0,
+          ),
+          _e(t);
+        break;
+      case "select":
+        j("invalid", t);
+        break;
+      case "textarea":
+        j("invalid", t), Ti(t, a.value, a.defaultValue, a.children), _e(t);
+    }
+    u = a.children,
+      typeof u != "string" && typeof u != "number" && typeof u != "bigint" ||
+        t.textContent === "" + u || a.suppressHydrationWarning === !0 ||
+        Tv(t.textContent, u)
+        ? (a.popover != null && (j("beforetoggle", t), j("toggle", t)),
+          a.onScroll != null && j("scroll", t),
+          a.onScrollEnd != null && j("scrollend", t),
+          a.onClick != null && (t.onclick = bn),
+          t = !0)
+        : t = !1,
+      t || zu(l);
+  }
+  function e0(l) {
+    for (pl = l.return; pl;) {
+      switch (pl.tag) {
+        case 5:
+        case 13:
+          rt = !1;
+          return;
+        case 27:
+        case 3:
+          rt = !0;
+          return;
+        default:
+          pl = pl.return;
+      }
+    }
+  }
+  function qa(l) {
+    if (l !== pl) return !1;
+    if (!J) return e0(l), J = !0, !1;
+    var t = l.tag, u;
+    if (
+      (u = t !== 3 && t !== 27) &&
+      ((u = t === 5) &&
+        (u = l.type,
+          u = !(u !== "form" && u !== "button") || pc(l.type, l.memoizedProps)),
+        u = !u),
+        u && cl && zu(l),
+        e0(l),
+        t === 13
+    ) {
+      if (l = l.memoizedState, l = l !== null ? l.dehydrated : null, !l) {
+        throw Error(S(317));
+      }
+      l: {
+        for (l = l.nextSibling, t = 0; l;) {
+          if (l.nodeType === 8) {
+            if (u = l.data, u === "/$") {
+              if (t === 0) {
+                cl = mt(l.nextSibling);
+                break l;
+              }
+              t--;
+            } else u !== "$" && u !== "$!" && u !== "$?" || t++;
+          }
+          l = l.nextSibling;
+        }
+        cl = null;
+      }
+    } else {t === 27
+        ? (t = cl, nu(l.type) ? (l = xc, xc = null, cl = l) : cl = t)
+        : cl = pl ? mt(l.stateNode.nextSibling) : null;}
+    return !0;
+  }
+  function Ya() {
+    cl = pl = null, J = !1;
+  }
+  function n0() {
+    var l = Au;
+    return l !== null &&
+      (jl === null ? jl = l : jl.push.apply(jl, l), Au = null),
+      l;
+  }
+  function Ba(l) {
+    Au === null ? Au = [l] : Au.push(l);
+  }
+  var Tf = E(null), _u = null, Ht = null;
+  function Lt(l, t, u) {
+    z(Tf, t._currentValue), t._currentValue = u;
+  }
+  function Nt(l) {
+    l._currentValue = Tf.current, O(Tf);
+  }
+  function Ef(l, t, u) {
+    for (; l !== null;) {
+      var a = l.alternate;
+      if (
+        (l.childLanes & t) !== t
+          ? (l.childLanes |= t, a !== null && (a.childLanes |= t))
+          : a !== null && (a.childLanes & t) !== t && (a.childLanes |= t),
+          l === u
+      ) break;
+      l = l.return;
+    }
+  }
+  function Af(l, t, u, a) {
+    var e = l.child;
+    for (e !== null && (e.return = l); e !== null;) {
+      var n = e.dependencies;
+      if (n !== null) {
+        var f = e.child;
+        n = n.firstContext;
+        l: for (; n !== null;) {
+          var c = n;
+          n = e;
+          for (var i = 0; i < t.length; i++) {
+            if (c.context === t[i]) {
+              n.lanes |= u,
+                c = n.alternate,
+                c !== null && (c.lanes |= u),
+                Ef(n.return, u, l),
+                a || (f = null);
+              break l;
+            }
+          }
+          n = c.next;
+        }
+      } else if (e.tag === 18) {
+        if (f = e.return, f === null) throw Error(S(341));
+        f.lanes |= u,
+          n = f.alternate,
+          n !== null && (n.lanes |= u),
+          Ef(f, u, l),
+          f = null;
+      } else f = e.child;
+      if (f !== null) f.return = e;
+      else {for (f = e; f !== null;) {
+          if (f === l) {
+            f = null;
+            break;
+          }
+          if (e = f.sibling, e !== null) {
+            e.return = f.return, f = e;
+            break;
+          }
+          f = f.return;
+        }}
+      e = f;
+    }
+  }
+  function pa(l, t, u, a) {
+    l = null;
+    for (var e = t, n = !1; e !== null;) {
+      if (!n) {
+        if ((e.flags & 524288) !== 0) n = !0;
+        else if ((e.flags & 262144) !== 0) break;
+      }
+      if (e.tag === 10) {
+        var f = e.alternate;
+        if (f === null) throw Error(S(387));
+        if (f = f.memoizedProps, f !== null) {
+          var c = e.type;
+          Wl(e.pendingProps.value, f.value) ||
+            (l !== null ? l.push(c) : l = [c]);
+        }
+      } else if (e === Kl.current) {
+        if (f = e.alternate, f === null) throw Error(S(387));
+        f.memoizedState.memoizedState !== e.memoizedState.memoizedState &&
+          (l !== null ? l.push(ve) : l = [ve]);
+      }
+      e = e.return;
+    }
+    l !== null && Af(t, l, u, a), t.flags |= 262144;
+  }
+  function xe(l) {
+    for (l = l.firstContext; l !== null;) {
+      if (!Wl(l.context._currentValue, l.memoizedValue)) return !0;
+      l = l.next;
+    }
+    return !1;
+  }
+  function Ou(l) {
+    _u = l,
+      Ht = null,
+      l = l.dependencies,
+      l !== null && (l.firstContext = null);
+  }
+  function Hl(l) {
+    return f0(_u, l);
+  }
+  function Ze(l, t) {
+    return _u === null && Ou(l), f0(l, t);
+  }
+  function f0(l, t) {
+    var u = t._currentValue;
+    if (t = { context: t, memoizedValue: u, next: null }, Ht === null) {
+      if (l === null) throw Error(S(308));
+      Ht = t, l.dependencies = { lanes: 0, firstContext: t }, l.flags |= 524288;
+    } else Ht = Ht.next = t;
+    return u;
+  }
+  var hd = typeof AbortController < "u" ? AbortController : function () {
+      var l = [],
+        t = this.signal = {
+          aborted: !1,
+          addEventListener: function (u, a) {
+            l.push(a);
+          },
+        };
+      this.abort = function () {
+        t.aborted = !0,
+          l.forEach(function (u) {
+            return u();
+          });
+      };
+    },
+    od = D.unstable_scheduleCallback,
+    md = D.unstable_NormalPriority,
+    Sl = {
+      $$typeof: Ml,
+      Consumer: null,
+      Provider: null,
+      _currentValue: null,
+      _currentValue2: null,
+      _threadCount: 0,
+    };
+  function zf() {
+    return { controller: new hd(), data: new Map(), refCount: 0 };
+  }
+  function Ga(l) {
+    l.refCount--,
+      l.refCount === 0 && od(md, function () {
+        l.controller.abort();
+      });
+  }
+  var Xa = null, _f = 0, Fu = 0, Iu = null;
+  function Sd(l, t) {
+    if (Xa === null) {
+      var u = Xa = [];
+      _f = 0,
+        Fu = Mc(),
+        Iu = {
+          status: "pending",
+          value: void 0,
+          then: function (a) {
+            u.push(a);
+          },
+        };
+    }
+    return _f++, t.then(c0, c0), t;
+  }
+  function c0() {
+    if (--_f === 0 && Xa !== null) {
+      Iu !== null && (Iu.status = "fulfilled");
+      var l = Xa;
+      Xa = null, Fu = 0, Iu = null;
+      for (var t = 0; t < l.length; t++) (0, l[t])();
+    }
+  }
+  function gd(l, t) {
+    var u = [],
+      a = {
+        status: "pending",
+        value: null,
+        reason: null,
+        then: function (e) {
+          u.push(e);
+        },
+      };
+    return l.then(function () {
+      a.status = "fulfilled", a.value = t;
+      for (var e = 0; e < u.length; e++) (0, u[e])(t);
+    }, function (e) {
+      for (a.status = "rejected", a.reason = e, e = 0; e < u.length; e++) {
+        (0, u[e])(void 0);
+      }
+    }),
+      a;
+  }
+  var i0 = r.S;
+  r.S = function (l, t) {
+    typeof t == "object" && t !== null && typeof t.then == "function" &&
+    Sd(l, t), i0 !== null && i0(l, t);
+  };
+  var Mu = E(null);
+  function Of() {
+    var l = Mu.current;
+    return l !== null ? l : ul.pooledCache;
+  }
+  function je(l, t) {
+    t === null ? z(Mu, Mu.current) : z(Mu, t.pool);
+  }
+  function s0() {
+    var l = Of();
+    return l === null ? null : { parent: Sl._currentValue, pool: l };
+  }
+  var Qa = Error(S(460)),
+    v0 = Error(S(474)),
+    Ce = Error(S(542)),
+    Mf = { then: function () {} };
+  function y0(l) {
+    return l = l.status, l === "fulfilled" || l === "rejected";
+  }
+  function Ve() {}
+  function d0(l, t, u) {
+    switch (
+      u = l[u],
+        u === void 0 ? l.push(t) : u !== t && (t.then(Ve, Ve), t = u),
+        t.status
+    ) {
+      case "fulfilled":
+        return t.value;
+      case "rejected":
+        throw l = t.reason, o0(l), l;
+      default:
+        if (typeof t.status == "string") t.then(Ve, Ve);
+        else {
+          if (l = ul, l !== null && 100 < l.shellSuspendCounter) {
+            throw Error(S(482));
+          }
+          l = t,
+            l.status = "pending",
+            l.then(function (a) {
+              if (t.status === "pending") {
+                var e = t;
+                e.status = "fulfilled", e.value = a;
+              }
+            }, function (a) {
+              if (t.status === "pending") {
+                var e = t;
+                e.status = "rejected", e.reason = a;
+              }
+            });
+        }
+        switch (t.status) {
+          case "fulfilled":
+            return t.value;
+          case "rejected":
+            throw l = t.reason, o0(l), l;
+        }
+        throw xa = t, Qa;
+    }
+  }
+  var xa = null;
+  function h0() {
+    if (xa === null) throw Error(S(459));
+    var l = xa;
+    return xa = null, l;
+  }
+  function o0(l) {
+    if (l === Qa || l === Ce) throw Error(S(483));
+  }
+  var Kt = !1;
+  function Df(l) {
+    l.updateQueue = {
+      baseState: l.memoizedState,
+      firstBaseUpdate: null,
+      lastBaseUpdate: null,
+      shared: { pending: null, lanes: 0, hiddenCallbacks: null },
+      callbacks: null,
+    };
+  }
+  function Uf(l, t) {
+    l = l.updateQueue,
+      t.updateQueue === l &&
+      (t.updateQueue = {
+        baseState: l.baseState,
+        firstBaseUpdate: l.firstBaseUpdate,
+        lastBaseUpdate: l.lastBaseUpdate,
+        shared: l.shared,
+        callbacks: null,
+      });
+  }
+  function Jt(l) {
+    return { lane: l, tag: 0, payload: null, callback: null, next: null };
+  }
+  function wt(l, t, u) {
+    var a = l.updateQueue;
+    if (a === null) return null;
+    if (a = a.shared, (w & 2) !== 0) {
+      var e = a.pending;
+      return e === null ? t.next = t : (t.next = e.next, e.next = t),
+        a.pending = t,
+        t = pe(l),
+        l0(l, null, u),
+        t;
+    }
+    return Be(l, a, t, u), pe(l);
+  }
+  function Za(l, t, u) {
+    if (t = t.updateQueue, t !== null && (t = t.shared, (u & 4194048) !== 0)) {
+      var a = t.lanes;
+      a &= l.pendingLanes, u |= a, t.lanes = u, ci(l, u);
+    }
+  }
+  function Rf(l, t) {
+    var u = l.updateQueue, a = l.alternate;
+    if (a !== null && (a = a.updateQueue, u === a)) {
+      var e = null, n = null;
+      if (u = u.firstBaseUpdate, u !== null) {
+        do {
+          var f = {
+            lane: u.lane,
+            tag: u.tag,
+            payload: u.payload,
+            callback: null,
+            next: null,
+          };
+          n === null ? e = n = f : n = n.next = f, u = u.next;
+        } while (u !== null);
+        n === null ? e = n = t : n = n.next = t;
+      } else e = n = t;
+      u = {
+        baseState: a.baseState,
+        firstBaseUpdate: e,
+        lastBaseUpdate: n,
+        shared: a.shared,
+        callbacks: a.callbacks,
+      }, l.updateQueue = u;
+      return;
+    }
+    l = u.lastBaseUpdate,
+      l === null ? u.firstBaseUpdate = t : l.next = t,
+      u.lastBaseUpdate = t;
+  }
+  var Hf = !1;
+  function ja() {
+    if (Hf) {
+      var l = Iu;
+      if (l !== null) throw l;
+    }
+  }
+  function Ca(l, t, u, a) {
+    Hf = !1;
+    var e = l.updateQueue;
+    Kt = !1;
+    var n = e.firstBaseUpdate, f = e.lastBaseUpdate, c = e.shared.pending;
+    if (c !== null) {
+      e.shared.pending = null;
+      var i = c, h = i.next;
+      i.next = null, f === null ? n = h : f.next = h, f = i;
+      var g = l.alternate;
+      g !== null &&
+        (g = g.updateQueue,
+          c = g.lastBaseUpdate,
+          c !== f &&
+          (c === null ? g.firstBaseUpdate = h : c.next = h,
+            g.lastBaseUpdate = i));
+    }
+    if (n !== null) {
+      var T = e.baseState;
+      f = 0, g = h = i = null, c = n;
+      do {
+        var o = c.lane & -536870913, m = o !== c.lane;
+        if (m ? (C & o) === o : (a & o) === o) {
+          o !== 0 && o === Fu && (Hf = !0),
+            g !== null &&
+            (g = g.next = {
+              lane: 0,
+              tag: c.tag,
+              payload: c.payload,
+              callback: null,
+              next: null,
+            });
+          l: {
+            var p = l, q = c;
+            o = t;
+            var F = u;
+            switch (q.tag) {
+              case 1:
+                if (p = q.payload, typeof p == "function") {
+                  T = p.call(F, T, o);
+                  break l;
+                }
+                T = p;
+                break l;
+              case 3:
+                p.flags = p.flags & -65537 | 128;
+              case 0:
+                if (
+                  p = q.payload,
+                    o = typeof p == "function" ? p.call(F, T, o) : p,
+                    o == null
+                ) break l;
+                T = R({}, T, o);
+                break l;
+              case 2:
+                Kt = !0;
+            }
+          }
+          o = c.callback,
+            o !== null &&
+            (l.flags |= 64,
+              m && (l.flags |= 8192),
+              m = e.callbacks,
+              m === null ? e.callbacks = [o] : m.push(o));
+        } else {m = {
+            lane: o,
+            tag: c.tag,
+            payload: c.payload,
+            callback: c.callback,
+            next: null,
+          },
+            g === null ? (h = g = m, i = T) : g = g.next = m,
+            f |= o;}
+        if (c = c.next, c === null) {
+          if (c = e.shared.pending, c === null) break;
+          m = c,
+            c = m.next,
+            m.next = null,
+            e.lastBaseUpdate = m,
+            e.shared.pending = null;
+        }
+      } while (!0);
+      g === null && (i = T),
+        e.baseState = i,
+        e.firstBaseUpdate = h,
+        e.lastBaseUpdate = g,
+        n === null && (e.shared.lanes = 0),
+        tu |= f,
+        l.lanes = f,
+        l.memoizedState = T;
+    }
+  }
+  function m0(l, t) {
+    if (typeof l != "function") throw Error(S(191, l));
+    l.call(t);
+  }
+  function S0(l, t) {
+    var u = l.callbacks;
+    if (u !== null) {
+      for (l.callbacks = null, l = 0; l < u.length; l++) m0(u[l], t);
+    }
+  }
+  var Pu = E(null), Le = E(0);
+  function g0(l, t) {
+    l = Qt, z(Le, l), z(Pu, t), Qt = l | t.baseLanes;
+  }
+  function Nf() {
+    z(Le, Qt), z(Pu, Pu.current);
+  }
+  function qf() {
+    Qt = Le.current, O(Pu), O(Le);
+  }
+  var Wt = 0,
+    Q = null,
+    $ = null,
+    hl = null,
+    Ke = !1,
+    la = !1,
+    Du = !1,
+    Je = 0,
+    Va = 0,
+    ta = null,
+    rd = 0;
+  function yl() {
+    throw Error(S(321));
+  }
+  function Yf(l, t) {
+    if (t === null) return !1;
+    for (var u = 0; u < t.length && u < l.length; u++) {
+      if (!Wl(l[u], t[u])) return !1;
+    }
+    return !0;
+  }
+  function Bf(l, t, u, a, e, n) {
+    return Wt = n,
+      Q = t,
+      t.memoizedState = null,
+      t.updateQueue = null,
+      t.lanes = 0,
+      r.H = l === null || l.memoizedState === null ? ls : ts,
+      Du = !1,
+      n = u(a, e),
+      Du = !1,
+      la && (n = b0(t, u, a, e)),
+      r0(l),
+      n;
+  }
+  function r0(l) {
+    r.H = Ie;
+    var t = $ !== null && $.next !== null;
+    if (Wt = 0, hl = $ = Q = null, Ke = !1, Va = 0, ta = null, t) {
+      throw Error(S(300));
+    }
+    l === null || bl || (l = l.dependencies, l !== null && xe(l) && (bl = !0));
+  }
+  function b0(l, t, u, a) {
+    Q = l;
+    var e = 0;
+    do {
+      if (la && (ta = null), Va = 0, la = !1, 25 <= e) throw Error(S(301));
+      if (e += 1, hl = $ = null, l.updateQueue != null) {
+        var n = l.updateQueue;
+        n.lastEffect = null,
+          n.events = null,
+          n.stores = null,
+          n.memoCache != null && (n.memoCache.index = 0);
+      }
+      r.H = Od, n = t(u, a);
+    } while (la);
+    return n;
+  }
+  function bd() {
+    var l = r.H, t = l.useState()[0];
+    return t = typeof t.then == "function" ? La(t) : t,
+      l = l.useState()[0],
+      ($ !== null ? $.memoizedState : null) !== l && (Q.flags |= 1024),
+      t;
+  }
+  function pf() {
+    var l = Je !== 0;
+    return Je = 0, l;
+  }
+  function Gf(l, t, u) {
+    t.updateQueue = l.updateQueue, t.flags &= -2053, l.lanes &= ~u;
+  }
+  function Xf(l) {
+    if (Ke) {
+      for (l = l.memoizedState; l !== null;) {
+        var t = l.queue;
+        t !== null && (t.pending = null), l = l.next;
+      }
+      Ke = !1;
+    }
+    Wt = 0, hl = $ = Q = null, la = !1, Va = Je = 0, ta = null;
+  }
+  function xl() {
+    var l = {
+      memoizedState: null,
+      baseState: null,
+      baseQueue: null,
+      queue: null,
+      next: null,
+    };
+    return hl === null ? Q.memoizedState = hl = l : hl = hl.next = l, hl;
+  }
+  function ol() {
+    if ($ === null) {
+      var l = Q.alternate;
+      l = l !== null ? l.memoizedState : null;
+    } else l = $.next;
+    var t = hl === null ? Q.memoizedState : hl.next;
+    if (t !== null) hl = t, $ = l;
+    else {
+      if (l === null) {
+        throw Q.alternate === null ? Error(S(467)) : Error(S(310));
+      }
+      $ = l,
+        l = {
+          memoizedState: $.memoizedState,
+          baseState: $.baseState,
+          baseQueue: $.baseQueue,
+          queue: $.queue,
+          next: null,
+        },
+        hl === null ? Q.memoizedState = hl = l : hl = hl.next = l;
+    }
+    return hl;
+  }
+  function Qf() {
+    return { lastEffect: null, events: null, stores: null, memoCache: null };
+  }
+  function La(l) {
+    var t = Va;
+    return Va += 1,
+      ta === null && (ta = []),
+      l = d0(ta, l, t),
+      t = Q,
+      (hl === null ? t.memoizedState : hl.next) === null &&
+      (t = t.alternate, r.H = t === null || t.memoizedState === null ? ls : ts),
+      l;
+  }
+  function we(l) {
+    if (l !== null && typeof l == "object") {
+      if (typeof l.then == "function") return La(l);
+      if (l.$$typeof === Ml) return Hl(l);
+    }
+    throw Error(S(438, String(l)));
+  }
+  function xf(l) {
+    var t = null, u = Q.updateQueue;
+    if (u !== null && (t = u.memoCache), t == null) {
+      var a = Q.alternate;
+      a !== null &&
+        (a = a.updateQueue,
+          a !== null &&
+          (a = a.memoCache,
+            a != null && (t = {
+              data: a.data.map(function (e) {
+                return e.slice();
+              }),
+              index: 0,
+            })));
+    }
+    if (
+      t == null && (t = { data: [], index: 0 }),
+        u === null && (u = Qf(), Q.updateQueue = u),
+        u.memoCache = t,
+        u = t.data[t.index],
+        u === void 0
+    ) { for (u = t.data[t.index] = Array(l), a = 0; a < l; a++) u[a] = qu; }
+    return t.index++, u;
+  }
+  function qt(l, t) {
+    return typeof t == "function" ? t(l) : t;
+  }
+  function We(l) {
+    var t = ol();
+    return Zf(t, $, l);
+  }
+  function Zf(l, t, u) {
+    var a = l.queue;
+    if (a === null) throw Error(S(311));
+    a.lastRenderedReducer = u;
+    var e = l.baseQueue, n = a.pending;
+    if (n !== null) {
+      if (e !== null) {
+        var f = e.next;
+        e.next = n.next, n.next = f;
+      }
+      t.baseQueue = e = n, a.pending = null;
+    }
+    if (n = l.baseState, e === null) l.memoizedState = n;
+    else {
+      t = e.next;
+      var c = f = null, i = null, h = t, g = !1;
+      do {
+        var T = h.lane & -536870913;
+        if (T !== h.lane ? (C & T) === T : (Wt & T) === T) {
+          var o = h.revertLane;
+          if (o === 0) {
+            i !== null &&
+            (i = i.next = {
+              lane: 0,
+              revertLane: 0,
+              action: h.action,
+              hasEagerState: h.hasEagerState,
+              eagerState: h.eagerState,
+              next: null,
+            }), T === Fu && (g = !0);
+          } else if ((Wt & o) === o) {
+            h = h.next, o === Fu && (g = !0);
+            continue;
+          } else {T = {
+              lane: 0,
+              revertLane: h.revertLane,
+              action: h.action,
+              hasEagerState: h.hasEagerState,
+              eagerState: h.eagerState,
+              next: null,
+            },
+              i === null ? (c = i = T, f = n) : i = i.next = T,
+              Q.lanes |= o,
+              tu |= o;}
+          T = h.action,
+            Du && u(n, T),
+            n = h.hasEagerState ? h.eagerState : u(n, T);
+        } else {o = {
+            lane: T,
+            revertLane: h.revertLane,
+            action: h.action,
+            hasEagerState: h.hasEagerState,
+            eagerState: h.eagerState,
+            next: null,
+          },
+            i === null ? (c = i = o, f = n) : i = i.next = o,
+            Q.lanes |= T,
+            tu |= T;}
+        h = h.next;
+      } while (h !== null && h !== t);
+      if (
+        i === null ? f = n : i.next = c,
+          !Wl(n, l.memoizedState) && (bl = !0, g && (u = Iu, u !== null))
+      ) throw u;
+      l.memoizedState = n,
+        l.baseState = f,
+        l.baseQueue = i,
+        a.lastRenderedState = n;
+    }
+    return e === null && (a.lanes = 0), [l.memoizedState, a.dispatch];
+  }
+  function jf(l) {
+    var t = ol(), u = t.queue;
+    if (u === null) throw Error(S(311));
+    u.lastRenderedReducer = l;
+    var a = u.dispatch, e = u.pending, n = t.memoizedState;
+    if (e !== null) {
+      u.pending = null;
+      var f = e = e.next;
+      do n = l(n, f.action), f = f.next; while (f !== e);
+      Wl(n, t.memoizedState) || (bl = !0),
+        t.memoizedState = n,
+        t.baseQueue === null && (t.baseState = n),
+        u.lastRenderedState = n;
+    }
+    return [n, a];
+  }
+  function T0(l, t, u) {
+    var a = Q, e = ol(), n = J;
+    if (n) {
+      if (u === void 0) throw Error(S(407));
+      u = u();
+    } else u = t();
+    var f = !Wl(($ || e).memoizedState, u);
+    f && (e.memoizedState = u, bl = !0), e = e.queue;
+    var c = z0.bind(null, a, e, l);
+    if (
+      Ka(2048, 8, c, [l]),
+        e.getSnapshot !== t || f || hl !== null && hl.memoizedState.tag & 1
+    ) {
+      if (
+        a.flags |= 2048,
+          ua(9, $e(), A0.bind(null, a, e, u, t), null),
+          ul === null
+      ) throw Error(S(349));
+      n || (Wt & 124) !== 0 || E0(a, t, u);
+    }
+    return u;
+  }
+  function E0(l, t, u) {
+    l.flags |= 16384,
+      l = { getSnapshot: t, value: u },
+      t = Q.updateQueue,
+      t === null
+        ? (t = Qf(), Q.updateQueue = t, t.stores = [l])
+        : (u = t.stores, u === null ? t.stores = [l] : u.push(l));
+  }
+  function A0(l, t, u, a) {
+    t.value = u, t.getSnapshot = a, _0(t) && O0(l);
+  }
+  function z0(l, t, u) {
+    return u(function () {
+      _0(t) && O0(l);
+    });
+  }
+  function _0(l) {
+    var t = l.getSnapshot;
+    l = l.value;
+    try {
+      var u = t();
+      return !Wl(l, u);
+    } catch {
+      return !0;
+    }
+  }
+  function O0(l) {
+    var t = wu(l, 2);
+    t !== null && lt(t, l, 2);
+  }
+  function Cf(l) {
+    var t = xl();
+    if (typeof l == "function") {
+      var u = l;
+      if (l = u(), Du) {
+        jt(!0);
+        try {
+          u();
+        } finally {
+          jt(!1);
+        }
+      }
+    }
+    return t.memoizedState = t.baseState = l,
+      t.queue = {
+        pending: null,
+        lanes: 0,
+        dispatch: null,
+        lastRenderedReducer: qt,
+        lastRenderedState: l,
+      },
+      t;
+  }
+  function M0(l, t, u, a) {
+    return l.baseState = u, Zf(l, $, typeof a == "function" ? a : qt);
+  }
+  function Td(l, t, u, a, e) {
+    if (Fe(l)) throw Error(S(485));
+    if (l = t.action, l !== null) {
+      var n = {
+        payload: e,
+        action: l,
+        next: null,
+        isTransition: !0,
+        status: "pending",
+        value: null,
+        reason: null,
+        listeners: [],
+        then: function (f) {
+          n.listeners.push(f);
+        },
+      };
+      r.T !== null ? u(!0) : n.isTransition = !1,
+        a(n),
+        u = t.pending,
+        u === null
+          ? (n.next = t.pending = n, D0(t, n))
+          : (n.next = u.next, t.pending = u.next = n);
+    }
+  }
+  function D0(l, t) {
+    var u = t.action, a = t.payload, e = l.state;
+    if (t.isTransition) {
+      var n = r.T, f = {};
+      r.T = f;
+      try {
+        var c = u(e, a), i = r.S;
+        i !== null && i(f, c), U0(l, t, c);
+      } catch (h) {
+        Vf(l, t, h);
+      } finally {
+        r.T = n;
+      }
+    } else {try {
+        n = u(e, a), U0(l, t, n);
+      } catch (h) {
+        Vf(l, t, h);
+      }}
+  }
+  function U0(l, t, u) {
+    u !== null && typeof u == "object" && typeof u.then == "function"
+      ? u.then(function (a) {
+        R0(l, t, a);
+      }, function (a) {
+        return Vf(l, t, a);
+      })
+      : R0(l, t, u);
+  }
+  function R0(l, t, u) {
+    t.status = "fulfilled",
+      t.value = u,
+      H0(t),
+      l.state = u,
+      t = l.pending,
+      t !== null &&
+      (u = t.next,
+        u === t ? l.pending = null : (u = u.next, t.next = u, D0(l, u)));
+  }
+  function Vf(l, t, u) {
+    var a = l.pending;
+    if (l.pending = null, a !== null) {
+      a = a.next;
+      do t.status = "rejected", t.reason = u, H0(t), t = t.next; while (
+        t !== a
+      );
+    }
+    l.action = null;
+  }
+  function H0(l) {
+    l = l.listeners;
+    for (var t = 0; t < l.length; t++) (0, l[t])();
+  }
+  function N0(l, t) {
+    return t;
+  }
+  function q0(l, t) {
+    if (J) {
+      var u = ul.formState;
+      if (u !== null) {
+        l: {
+          var a = Q;
+          if (J) {
+            if (cl) {
+              t: {
+                for (var e = cl, n = rt; e.nodeType !== 8;) {
+                  if (!n) {
+                    e = null;
+                    break t;
+                  }
+                  if (e = mt(e.nextSibling), e === null) {
+                    e = null;
+                    break t;
+                  }
+                }
+                n = e.data, e = n === "F!" || n === "F" ? e : null;
+              }
+              if (e) {
+                cl = mt(e.nextSibling), a = e.data === "F!";
+                break l;
+              }
+            }
+            zu(a);
+          }
+          a = !1;
+        }
+        a && (t = u[0]);
+      }
+    }
+    return u = xl(),
+      u.memoizedState = u.baseState = t,
+      a = {
+        pending: null,
+        lanes: 0,
+        dispatch: null,
+        lastRenderedReducer: N0,
+        lastRenderedState: t,
+      },
+      u.queue = a,
+      u = F0.bind(null, Q, a),
+      a.dispatch = u,
+      a = Cf(!1),
+      n = Wf.bind(null, Q, !1, a.queue),
+      a = xl(),
+      e = { state: t, dispatch: null, action: l, pending: null },
+      a.queue = e,
+      u = Td.bind(null, Q, e, n, u),
+      e.dispatch = u,
+      a.memoizedState = l,
+      [t, u, !1];
+  }
+  function Y0(l) {
+    var t = ol();
+    return B0(t, $, l);
+  }
+  function B0(l, t, u) {
+    if (
+      t = Zf(l, t, N0)[0],
+        l = We(qt)[0],
+        typeof t == "object" && t !== null && typeof t.then == "function"
+    ) {
+      try {
+        var a = La(t);
+      } catch (f) {
+        throw f === Qa ? Ce : f;
+      }
+    } else a = t;
+    t = ol();
+    var e = t.queue, n = e.dispatch;
+    return u !== t.memoizedState &&
+      (Q.flags |= 2048, ua(9, $e(), Ed.bind(null, e, u), null)),
+      [a, n, l];
+  }
+  function Ed(l, t) {
+    l.action = t;
+  }
+  function p0(l) {
+    var t = ol(), u = $;
+    if (u !== null) return B0(t, u, l);
+    ol(), t = t.memoizedState, u = ol();
+    var a = u.queue.dispatch;
+    return u.memoizedState = l, [t, a, !1];
+  }
+  function ua(l, t, u, a) {
+    return l = { tag: l, create: u, deps: a, inst: t, next: null },
+      t = Q.updateQueue,
+      t === null && (t = Qf(), Q.updateQueue = t),
+      u = t.lastEffect,
+      u === null
+        ? t.lastEffect = l.next = l
+        : (a = u.next, u.next = l, l.next = a, t.lastEffect = l),
+      l;
+  }
+  function $e() {
+    return { destroy: void 0, resource: void 0 };
+  }
+  function G0() {
+    return ol().memoizedState;
+  }
+  function ke(l, t, u, a) {
+    var e = xl();
+    a = a === void 0 ? null : a,
+      Q.flags |= l,
+      e.memoizedState = ua(1 | t, $e(), u, a);
+  }
+  function Ka(l, t, u, a) {
+    var e = ol();
+    a = a === void 0 ? null : a;
+    var n = e.memoizedState.inst;
+    $ !== null && a !== null && Yf(a, $.memoizedState.deps)
+      ? e.memoizedState = ua(t, n, u, a)
+      : (Q.flags |= l, e.memoizedState = ua(1 | t, n, u, a));
+  }
+  function X0(l, t) {
+    ke(8390656, 8, l, t);
+  }
+  function Q0(l, t) {
+    Ka(2048, 8, l, t);
+  }
+  function x0(l, t) {
+    return Ka(4, 2, l, t);
+  }
+  function Z0(l, t) {
+    return Ka(4, 4, l, t);
+  }
+  function j0(l, t) {
+    if (typeof t == "function") {
+      l = l();
+      var u = t(l);
+      return function () {
+        typeof u == "function" ? u() : t(null);
+      };
+    }
+    if (t != null) {
+      return l = l(), t.current = l, function () {
+        t.current = null;
+      };
+    }
+  }
+  function C0(l, t, u) {
+    u = u != null ? u.concat([l]) : null, Ka(4, 4, j0.bind(null, t, l), u);
+  }
+  function Lf() {}
+  function V0(l, t) {
+    var u = ol();
+    t = t === void 0 ? null : t;
+    var a = u.memoizedState;
+    return t !== null && Yf(t, a[1]) ? a[0] : (u.memoizedState = [l, t], l);
+  }
+  function L0(l, t) {
+    var u = ol();
+    t = t === void 0 ? null : t;
+    var a = u.memoizedState;
+    if (t !== null && Yf(t, a[1])) return a[0];
+    if (a = l(), Du) {
+      jt(!0);
+      try {
+        l();
+      } finally {
+        jt(!1);
+      }
+    }
+    return u.memoizedState = [a, t], a;
+  }
+  function Kf(l, t, u) {
+    return u === void 0 || (Wt & 1073741824) !== 0
+      ? l.memoizedState = t
+      : (l.memoizedState = u, l = ws(), Q.lanes |= l, tu |= l, u);
+  }
+  function K0(l, t, u, a) {
+    return Wl(u, t)
+      ? u
+      : Pu.current !== null
+      ? (l = Kf(l, u, a), Wl(l, t) || (bl = !0), l)
+      : (Wt & 42) === 0
+      ? (bl = !0, l.memoizedState = u)
+      : (l = ws(), Q.lanes |= l, tu |= l, t);
+  }
+  function J0(l, t, u, a, e) {
+    var n = _.p;
+    _.p = n !== 0 && 8 > n ? n : 8;
+    var f = r.T, c = {};
+    r.T = c, Wf(l, !1, t, u);
+    try {
+      var i = e(), h = r.S;
+      if (
+        h !== null && h(c, i),
+          i !== null && typeof i == "object" && typeof i.then == "function"
+      ) {
+        var g = gd(i, a);
+        Ja(l, t, g, Pl(l));
+      } else Ja(l, t, a, Pl(l));
+    } catch (T) {
+      Ja(l, t, { then: function () {}, status: "rejected", reason: T }, Pl());
+    } finally {
+      _.p = n, r.T = f;
+    }
+  }
+  function Ad() {}
+  function Jf(l, t, u, a) {
+    if (l.tag !== 5) throw Error(S(476));
+    var e = w0(l).queue;
+    J0(
+      l,
+      e,
+      t,
+      B,
+      u === null ? Ad : function () {
+        return W0(l), u(a);
+      },
+    );
+  }
+  function w0(l) {
+    var t = l.memoizedState;
+    if (t !== null) return t;
+    t = {
+      memoizedState: B,
+      baseState: B,
+      baseQueue: null,
+      queue: {
+        pending: null,
+        lanes: 0,
+        dispatch: null,
+        lastRenderedReducer: qt,
+        lastRenderedState: B,
+      },
+      next: null,
+    };
+    var u = {};
+    return t.next = {
+      memoizedState: u,
+      baseState: u,
+      baseQueue: null,
+      queue: {
+        pending: null,
+        lanes: 0,
+        dispatch: null,
+        lastRenderedReducer: qt,
+        lastRenderedState: u,
+      },
+      next: null,
+    },
+      l.memoizedState = t,
+      l = l.alternate,
+      l !== null && (l.memoizedState = t),
+      t;
+  }
+  function W0(l) {
+    var t = w0(l).next.queue;
+    Ja(l, t, {}, Pl());
+  }
+  function wf() {
+    return Hl(ve);
+  }
+  function $0() {
+    return ol().memoizedState;
+  }
+  function k0() {
+    return ol().memoizedState;
+  }
+  function zd(l) {
+    for (var t = l.return; t !== null;) {
+      switch (t.tag) {
+        case 24:
+        case 3:
+          var u = Pl();
+          l = Jt(u);
+          var a = wt(t, l, u);
+          a !== null && (lt(a, t, u), Za(a, t, u)),
+            t = { cache: zf() },
+            l.payload = t;
+          return;
+      }
+      t = t.return;
+    }
+  }
+  function _d(l, t, u) {
+    var a = Pl();
+    u = {
+      lane: a,
+      revertLane: 0,
+      action: u,
+      hasEagerState: !1,
+      eagerState: null,
+      next: null,
+    },
+      Fe(l)
+        ? I0(t, u)
+        : (u = hf(l, t, u, a), u !== null && (lt(u, l, a), P0(u, t, a)));
+  }
+  function F0(l, t, u) {
+    var a = Pl();
+    Ja(l, t, u, a);
+  }
+  function Ja(l, t, u, a) {
+    var e = {
+      lane: a,
+      revertLane: 0,
+      action: u,
+      hasEagerState: !1,
+      eagerState: null,
+      next: null,
+    };
+    if (Fe(l)) I0(t, e);
+    else {
+      var n = l.alternate;
+      if (
+        l.lanes === 0 && (n === null || n.lanes === 0) &&
+        (n = t.lastRenderedReducer, n !== null)
+      ) {
+        try {
+          var f = t.lastRenderedState, c = n(f, u);
+          if (e.hasEagerState = !0, e.eagerState = c, Wl(c, f)) {
+            return Be(l, t, e, 0), ul === null && Ye(), !1;
+          }
+        } catch {
+        } finally {
+        }
+      }
+      if (u = hf(l, t, e, a), u !== null) return lt(u, l, a), P0(u, t, a), !0;
+    }
+    return !1;
+  }
+  function Wf(l, t, u, a) {
+    if (
+      a = {
+        lane: 2,
+        revertLane: Mc(),
+        action: a,
+        hasEagerState: !1,
+        eagerState: null,
+        next: null,
+      }, Fe(l)
+    ) { if (t) throw Error(S(479)); } else {t = hf(l, u, a, 2),
+        t !== null && lt(t, l, 2);}
+  }
+  function Fe(l) {
+    var t = l.alternate;
+    return l === Q || t !== null && t === Q;
+  }
+  function I0(l, t) {
+    la = Ke = !0;
+    var u = l.pending;
+    u === null ? t.next = t : (t.next = u.next, u.next = t), l.pending = t;
+  }
+  function P0(l, t, u) {
+    if ((u & 4194048) !== 0) {
+      var a = t.lanes;
+      a &= l.pendingLanes, u |= a, t.lanes = u, ci(l, u);
+    }
+  }
+  var Ie = {
+      readContext: Hl,
+      use: we,
+      useCallback: yl,
+      useContext: yl,
+      useEffect: yl,
+      useImperativeHandle: yl,
+      useLayoutEffect: yl,
+      useInsertionEffect: yl,
+      useMemo: yl,
+      useReducer: yl,
+      useRef: yl,
+      useState: yl,
+      useDebugValue: yl,
+      useDeferredValue: yl,
+      useTransition: yl,
+      useSyncExternalStore: yl,
+      useId: yl,
+      useHostTransitionStatus: yl,
+      useFormState: yl,
+      useActionState: yl,
+      useOptimistic: yl,
+      useMemoCache: yl,
+      useCacheRefresh: yl,
+    },
+    ls = {
+      readContext: Hl,
+      use: we,
+      useCallback: function (l, t) {
+        return xl().memoizedState = [l, t === void 0 ? null : t], l;
+      },
+      useContext: Hl,
+      useEffect: X0,
+      useImperativeHandle: function (l, t, u) {
+        u = u != null ? u.concat([l]) : null,
+          ke(4194308, 4, j0.bind(null, t, l), u);
+      },
+      useLayoutEffect: function (l, t) {
+        return ke(4194308, 4, l, t);
+      },
+      useInsertionEffect: function (l, t) {
+        ke(4, 2, l, t);
+      },
+      useMemo: function (l, t) {
+        var u = xl();
+        t = t === void 0 ? null : t;
+        var a = l();
+        if (Du) {
+          jt(!0);
+          try {
+            l();
+          } finally {
+            jt(!1);
+          }
+        }
+        return u.memoizedState = [a, t], a;
+      },
+      useReducer: function (l, t, u) {
+        var a = xl();
+        if (u !== void 0) {
+          var e = u(t);
+          if (Du) {
+            jt(!0);
+            try {
+              u(t);
+            } finally {
+              jt(!1);
+            }
+          }
+        } else e = t;
+        return a.memoizedState = a.baseState = e,
+          l = {
+            pending: null,
+            lanes: 0,
+            dispatch: null,
+            lastRenderedReducer: l,
+            lastRenderedState: e,
+          },
+          a.queue = l,
+          l = l.dispatch = _d.bind(null, Q, l),
+          [a.memoizedState, l];
+      },
+      useRef: function (l) {
+        var t = xl();
+        return l = { current: l }, t.memoizedState = l;
+      },
+      useState: function (l) {
+        l = Cf(l);
+        var t = l.queue, u = F0.bind(null, Q, t);
+        return t.dispatch = u, [l.memoizedState, u];
+      },
+      useDebugValue: Lf,
+      useDeferredValue: function (l, t) {
+        var u = xl();
+        return Kf(u, l, t);
+      },
+      useTransition: function () {
+        var l = Cf(!1);
+        return l = J0.bind(null, Q, l.queue, !0, !1),
+          xl().memoizedState = l,
+          [!1, l];
+      },
+      useSyncExternalStore: function (l, t, u) {
+        var a = Q, e = xl();
+        if (J) {
+          if (u === void 0) throw Error(S(407));
+          u = u();
+        } else {
+          if (u = t(), ul === null) throw Error(S(349));
+          (C & 124) !== 0 || E0(a, t, u);
+        }
+        e.memoizedState = u;
+        var n = { value: u, getSnapshot: t };
+        return e.queue = n,
+          X0(z0.bind(null, a, n, l), [l]),
+          a.flags |= 2048,
+          ua(9, $e(), A0.bind(null, a, n, u, t), null),
+          u;
+      },
+      useId: function () {
+        var l = xl(), t = ul.identifierPrefix;
+        if (J) {
+          var u = Rt, a = Ut;
+          u = (a & ~(1 << 32 - wl(a) - 1)).toString(32) + u,
+            t = "«" + t + "R" + u,
+            u = Je++,
+            0 < u && (t += "H" + u.toString(32)),
+            t += "»";
+        } else u = rd++, t = "«" + t + "r" + u.toString(32) + "»";
+        return l.memoizedState = t;
+      },
+      useHostTransitionStatus: wf,
+      useFormState: q0,
+      useActionState: q0,
+      useOptimistic: function (l) {
+        var t = xl();
+        t.memoizedState = t.baseState = l;
+        var u = {
+          pending: null,
+          lanes: 0,
+          dispatch: null,
+          lastRenderedReducer: null,
+          lastRenderedState: null,
+        };
+        return t.queue = u, t = Wf.bind(null, Q, !0, u), u.dispatch = t, [l, t];
+      },
+      useMemoCache: xf,
+      useCacheRefresh: function () {
+        return xl().memoizedState = zd.bind(null, Q);
+      },
+    },
+    ts = {
+      readContext: Hl,
+      use: we,
+      useCallback: V0,
+      useContext: Hl,
+      useEffect: Q0,
+      useImperativeHandle: C0,
+      useInsertionEffect: x0,
+      useLayoutEffect: Z0,
+      useMemo: L0,
+      useReducer: We,
+      useRef: G0,
+      useState: function () {
+        return We(qt);
+      },
+      useDebugValue: Lf,
+      useDeferredValue: function (l, t) {
+        var u = ol();
+        return K0(u, $.memoizedState, l, t);
+      },
+      useTransition: function () {
+        var l = We(qt)[0], t = ol().memoizedState;
+        return [typeof l == "boolean" ? l : La(l), t];
+      },
+      useSyncExternalStore: T0,
+      useId: $0,
+      useHostTransitionStatus: wf,
+      useFormState: Y0,
+      useActionState: Y0,
+      useOptimistic: function (l, t) {
+        var u = ol();
+        return M0(u, $, l, t);
+      },
+      useMemoCache: xf,
+      useCacheRefresh: k0,
+    },
+    Od = {
+      readContext: Hl,
+      use: we,
+      useCallback: V0,
+      useContext: Hl,
+      useEffect: Q0,
+      useImperativeHandle: C0,
+      useInsertionEffect: x0,
+      useLayoutEffect: Z0,
+      useMemo: L0,
+      useReducer: jf,
+      useRef: G0,
+      useState: function () {
+        return jf(qt);
+      },
+      useDebugValue: Lf,
+      useDeferredValue: function (l, t) {
+        var u = ol();
+        return $ === null ? Kf(u, l, t) : K0(u, $.memoizedState, l, t);
+      },
+      useTransition: function () {
+        var l = jf(qt)[0], t = ol().memoizedState;
+        return [typeof l == "boolean" ? l : La(l), t];
+      },
+      useSyncExternalStore: T0,
+      useId: $0,
+      useHostTransitionStatus: wf,
+      useFormState: p0,
+      useActionState: p0,
+      useOptimistic: function (l, t) {
+        var u = ol();
+        return $ !== null
+          ? M0(u, $, l, t)
+          : (u.baseState = l, [l, u.queue.dispatch]);
+      },
+      useMemoCache: xf,
+      useCacheRefresh: k0,
+    },
+    aa = null,
+    wa = 0;
+  function Pe(l) {
+    var t = wa;
+    return wa += 1, aa === null && (aa = []), d0(aa, l, t);
+  }
+  function Wa(l, t) {
+    t = t.props.ref, l.ref = t !== void 0 ? t : null;
+  }
+  function ln(l, t) {
+    throw t.$$typeof === al
+      ? Error(S(525))
+      : (l = Object.prototype.toString.call(t),
+        Error(S(
+          31,
+          l === "[object Object]"
+            ? "object with keys {" + Object.keys(t).join(", ") + "}"
+            : l,
+        )));
+  }
+  function us(l) {
+    var t = l._init;
+    return t(l._payload);
+  }
+  function as(l) {
+    function t(y, v) {
+      if (l) {
+        var d = y.deletions;
+        d === null ? (y.deletions = [v], y.flags |= 16) : d.push(v);
+      }
+    }
+    function u(y, v) {
+      if (!l) return null;
+      for (; v !== null;) t(y, v), v = v.sibling;
+      return null;
+    }
+    function a(y) {
+      for (var v = new Map(); y !== null;) {
+        y.key !== null ? v.set(y.key, y) : v.set(y.index, y), y = y.sibling;
+      }
+      return v;
+    }
+    function e(y, v) {
+      return y = Dt(y, v), y.index = 0, y.sibling = null, y;
+    }
+    function n(y, v, d) {
+      return y.index = d,
+        l
+          ? (d = y.alternate,
+            d !== null
+              ? (d = d.index, d < v ? (y.flags |= 67108866, v) : d)
+              : (y.flags |= 67108866, v))
+          : (y.flags |= 1048576, v);
+    }
+    function f(y) {
+      return l && y.alternate === null && (y.flags |= 67108866), y;
+    }
+    function c(y, v, d, b) {
+      return v === null || v.tag !== 6
+        ? (v = mf(d, y.mode, b), v.return = y, v)
+        : (v = e(v, d), v.return = y, v);
+    }
+    function i(y, v, d, b) {
+      var M = d.type;
+      return M === Bl ? g(y, v, d.props.children, b, d.key) : v !== null &&
+          (v.elementType === M ||
+            typeof M == "object" && M !== null && M.$$typeof === Ll &&
+              us(M) === v.type)
+        ? (v = e(v, d.props), Wa(v, d), v.return = y, v)
+        : (v = Ge(d.type, d.key, d.props, null, y.mode, b),
+          Wa(v, d),
+          v.return = y,
+          v);
+    }
+    function h(y, v, d, b) {
+      return v === null || v.tag !== 4 ||
+          v.stateNode.containerInfo !== d.containerInfo ||
+          v.stateNode.implementation !== d.implementation
+        ? (v = Sf(d, y.mode, b), v.return = y, v)
+        : (v = e(v, d.children || []), v.return = y, v);
+    }
+    function g(y, v, d, b, M) {
+      return v === null || v.tag !== 7
+        ? (v = bu(d, y.mode, b, M), v.return = y, v)
+        : (v = e(v, d), v.return = y, v);
+    }
+    function T(y, v, d) {
+      if (
+        typeof v == "string" && v !== "" || typeof v == "number" ||
+        typeof v == "bigint"
+      ) return v = mf("" + v, y.mode, d), v.return = y, v;
+      if (typeof v == "object" && v !== null) {
+        switch (v.$$typeof) {
+          case tl:
+            return d = Ge(v.type, v.key, v.props, null, y.mode, d),
+              Wa(d, v),
+              d.return = y,
+              d;
+          case Yl:
+            return v = Sf(v, y.mode, d), v.return = y, v;
+          case Ll:
+            var b = v._init;
+            return v = b(v._payload), T(y, v, d);
+        }
+        if (Ul(v) || Dl(v)) return v = bu(v, y.mode, d, null), v.return = y, v;
+        if (typeof v.then == "function") return T(y, Pe(v), d);
+        if (v.$$typeof === Ml) return T(y, Ze(y, v), d);
+        ln(y, v);
+      }
+      return null;
+    }
+    function o(y, v, d, b) {
+      var M = v !== null ? v.key : null;
+      if (
+        typeof d == "string" && d !== "" || typeof d == "number" ||
+        typeof d == "bigint"
+      ) return M !== null ? null : c(y, v, "" + d, b);
+      if (typeof d == "object" && d !== null) {
+        switch (d.$$typeof) {
+          case tl:
+            return d.key === M ? i(y, v, d, b) : null;
+          case Yl:
+            return d.key === M ? h(y, v, d, b) : null;
+          case Ll:
+            return M = d._init, d = M(d._payload), o(y, v, d, b);
+        }
+        if (Ul(d) || Dl(d)) return M !== null ? null : g(y, v, d, b, null);
+        if (typeof d.then == "function") return o(y, v, Pe(d), b);
+        if (d.$$typeof === Ml) return o(y, v, Ze(y, d), b);
+        ln(y, d);
+      }
+      return null;
+    }
+    function m(y, v, d, b, M) {
+      if (
+        typeof b == "string" && b !== "" || typeof b == "number" ||
+        typeof b == "bigint"
+      ) return y = y.get(d) || null, c(v, y, "" + b, M);
+      if (typeof b == "object" && b !== null) {
+        switch (b.$$typeof) {
+          case tl:
+            return y = y.get(b.key === null ? d : b.key) || null, i(v, y, b, M);
+          case Yl:
+            return y = y.get(b.key === null ? d : b.key) || null, h(v, y, b, M);
+          case Ll:
+            var x = b._init;
+            return b = x(b._payload), m(y, v, d, b, M);
+        }
+        if (Ul(b) || Dl(b)) return y = y.get(d) || null, g(v, y, b, M, null);
+        if (typeof b.then == "function") return m(y, v, d, Pe(b), M);
+        if (b.$$typeof === Ml) return m(y, v, d, Ze(v, b), M);
+        ln(v, b);
+      }
+      return null;
+    }
+    function p(y, v, d, b) {
+      for (
+        var M = null, x = null, U = v, Y = v = 0, El = null;
+        U !== null && Y < d.length;
+        Y++
+      ) {
+        U.index > Y ? (El = U, U = null) : El = U.sibling;
+        var K = o(y, U, d[Y], b);
+        if (K === null) {
+          U === null && (U = El);
+          break;
+        }
+        l && U && K.alternate === null && t(y, U),
+          v = n(K, v, Y),
+          x === null ? M = K : x.sibling = K,
+          x = K,
+          U = El;
+      }
+      if (Y === d.length) return u(y, U), J && Eu(y, Y), M;
+      if (U === null) {
+        for (; Y < d.length; Y++) {
+          U = T(y, d[Y], b),
+            U !== null &&
+            (v = n(U, v, Y), x === null ? M = U : x.sibling = U, x = U);
+        }
+        return J && Eu(y, Y), M;
+      }
+      for (U = a(U); Y < d.length; Y++) {
+        El = m(U, y, Y, d[Y], b),
+          El !== null &&
+          (l && El.alternate !== null && U.delete(El.key === null ? Y : El.key),
+            v = n(El, v, Y),
+            x === null ? M = El : x.sibling = El,
+            x = El);
+      }
+      return l && U.forEach(function (vu) {
+        return t(y, vu);
+      }),
+        J && Eu(y, Y),
+        M;
+    }
+    function q(y, v, d, b) {
+      if (d == null) throw Error(S(151));
+      for (
+        var M = null, x = null, U = v, Y = v = 0, El = null, K = d.next();
+        U !== null && !K.done;
+        Y++, K = d.next()
+      ) {
+        U.index > Y ? (El = U, U = null) : El = U.sibling;
+        var vu = o(y, U, K.value, b);
+        if (vu === null) {
+          U === null && (U = El);
+          break;
+        }
+        l && U && vu.alternate === null && t(y, U),
+          v = n(vu, v, Y),
+          x === null ? M = vu : x.sibling = vu,
+          x = vu,
+          U = El;
+      }
+      if (K.done) return u(y, U), J && Eu(y, Y), M;
+      if (U === null) {
+        for (; !K.done; Y++, K = d.next()) {
+          K = T(y, K.value, b),
+            K !== null &&
+            (v = n(K, v, Y), x === null ? M = K : x.sibling = K, x = K);
+        }
+        return J && Eu(y, Y), M;
+      }
+      for (U = a(U); !K.done; Y++, K = d.next()) {
+        K = m(U, y, Y, K.value, b),
+          K !== null &&
+          (l && K.alternate !== null && U.delete(K.key === null ? Y : K.key),
+            v = n(K, v, Y),
+            x === null ? M = K : x.sibling = K,
+            x = K);
+      }
+      return l && U.forEach(function (M1) {
+        return t(y, M1);
+      }),
+        J && Eu(y, Y),
+        M;
+    }
+    function F(y, v, d, b) {
+      if (
+        typeof d == "object" && d !== null && d.type === Bl && d.key === null &&
+        (d = d.props.children), typeof d == "object" && d !== null
+      ) {
+        switch (d.$$typeof) {
+          case tl:
+            l: {
+              for (var M = d.key; v !== null;) {
+                if (v.key === M) {
+                  if (M = d.type, M === Bl) {
+                    if (v.tag === 7) {
+                      u(y, v.sibling),
+                        b = e(v, d.props.children),
+                        b.return = y,
+                        y = b;
+                      break l;
+                    }
+                  } else if (
+                    v.elementType === M ||
+                    typeof M == "object" && M !== null && M.$$typeof === Ll &&
+                      us(M) === v.type
+                  ) {
+                    u(y, v.sibling),
+                      b = e(v, d.props),
+                      Wa(b, d),
+                      b.return = y,
+                      y = b;
+                    break l;
+                  }
+                  u(y, v);
+                  break;
+                } else t(y, v);
+                v = v.sibling;
+              }
+              d.type === Bl
+                ? (b = bu(d.props.children, y.mode, b, d.key),
+                  b.return = y,
+                  y = b)
+                : (b = Ge(d.type, d.key, d.props, null, y.mode, b),
+                  Wa(b, d),
+                  b.return = y,
+                  y = b);
+            }
+            return f(y);
+          case Yl:
+            l: {
+              for (M = d.key; v !== null;) {
+                if (v.key === M) {
+                  if (
+                    v.tag === 4 &&
+                    v.stateNode.containerInfo === d.containerInfo &&
+                    v.stateNode.implementation === d.implementation
+                  ) {
+                    u(y, v.sibling),
+                      b = e(v, d.children || []),
+                      b.return = y,
+                      y = b;
+                    break l;
+                  } else {
+                    u(y, v);
+                    break;
+                  }
+                } else t(y, v);
+                v = v.sibling;
+              }
+              b = Sf(d, y.mode, b), b.return = y, y = b;
+            }
+            return f(y);
+          case Ll:
+            return M = d._init, d = M(d._payload), F(y, v, d, b);
+        }
+        if (Ul(d)) return p(y, v, d, b);
+        if (Dl(d)) {
+          if (M = Dl(d), typeof M != "function") throw Error(S(150));
+          return d = M.call(d), q(y, v, d, b);
+        }
+        if (typeof d.then == "function") return F(y, v, Pe(d), b);
+        if (d.$$typeof === Ml) return F(y, v, Ze(y, d), b);
+        ln(y, d);
+      }
+      return typeof d == "string" && d !== "" || typeof d == "number" ||
+          typeof d == "bigint"
+        ? (d = "" + d,
+          v !== null && v.tag === 6
+            ? (u(y, v.sibling), b = e(v, d), b.return = y, y = b)
+            : (u(y, v), b = mf(d, y.mode, b), b.return = y, y = b),
+          f(y))
+        : u(y, v);
+    }
+    return function (y, v, d, b) {
+      try {
+        wa = 0;
+        var M = F(y, v, d, b);
+        return aa = null, M;
+      } catch (U) {
+        if (U === Qa || U === Ce) throw U;
+        var x = $l(29, U, null, y.mode);
+        return x.lanes = b, x.return = y, x;
+      } finally {
+      }
+    };
+  }
+  var ea = as(!0), es = as(!1), it = E(null), bt = null;
+  function $t(l) {
+    var t = l.alternate;
+    z(gl, gl.current & 1),
+      z(it, l),
+      bt === null &&
+      (t === null || Pu.current !== null || t.memoizedState !== null) &&
+      (bt = l);
+  }
+  function ns(l) {
+    if (l.tag === 22) {
+      if (z(gl, gl.current), z(it, l), bt === null) {
+        var t = l.alternate;
+        t !== null && t.memoizedState !== null && (bt = l);
+      }
+    } else kt();
+  }
+  function kt() {
+    z(gl, gl.current), z(it, it.current);
+  }
+  function Yt(l) {
+    O(it), bt === l && (bt = null), O(gl);
+  }
+  var gl = E(0);
+  function tn(l) {
+    for (var t = l; t !== null;) {
+      if (t.tag === 13) {
+        var u = t.memoizedState;
+        if (
+          u !== null &&
+          (u = u.dehydrated, u === null || u.data === "$?" || Qc(u))
+        ) return t;
+      } else if (t.tag === 19 && t.memoizedProps.revealOrder !== void 0) {
+        if ((t.flags & 128) !== 0) {
+          return t;
+        }
+      } else if (t.child !== null) {
+        t.child.return = t, t = t.child;
+        continue;
+      }
+      if (t === l) break;
+      for (; t.sibling === null;) {
+        if (t.return === null || t.return === l) return null;
+        t = t.return;
+      }
+      t.sibling.return = t.return, t = t.sibling;
+    }
+    return null;
+  }
+  function $f(l, t, u, a) {
+    t = l.memoizedState,
+      u = u(a, t),
+      u = u == null ? t : R({}, t, u),
+      l.memoizedState = u,
+      l.lanes === 0 && (l.updateQueue.baseState = u);
+  }
+  var kf = {
+    enqueueSetState: function (l, t, u) {
+      l = l._reactInternals;
+      var a = Pl(), e = Jt(a);
+      e.payload = t,
+        u != null && (e.callback = u),
+        t = wt(l, e, a),
+        t !== null && (lt(t, l, a), Za(t, l, a));
+    },
+    enqueueReplaceState: function (l, t, u) {
+      l = l._reactInternals;
+      var a = Pl(), e = Jt(a);
+      e.tag = 1,
+        e.payload = t,
+        u != null && (e.callback = u),
+        t = wt(l, e, a),
+        t !== null && (lt(t, l, a), Za(t, l, a));
+    },
+    enqueueForceUpdate: function (l, t) {
+      l = l._reactInternals;
+      var u = Pl(), a = Jt(u);
+      a.tag = 2,
+        t != null && (a.callback = t),
+        t = wt(l, a, u),
+        t !== null && (lt(t, l, u), Za(t, l, u));
+    },
+  };
+  function fs(l, t, u, a, e, n, f) {
+    return l = l.stateNode,
+      typeof l.shouldComponentUpdate == "function"
+        ? l.shouldComponentUpdate(a, n, f)
+        : t.prototype && t.prototype.isPureReactComponent
+        ? !Ha(u, a) || !Ha(e, n)
+        : !0;
+  }
+  function cs(l, t, u, a) {
+    l = t.state,
+      typeof t.componentWillReceiveProps == "function" &&
+      t.componentWillReceiveProps(u, a),
+      typeof t.UNSAFE_componentWillReceiveProps == "function" &&
+      t.UNSAFE_componentWillReceiveProps(u, a),
+      t.state !== l && kf.enqueueReplaceState(t, t.state, null);
+  }
+  function Uu(l, t) {
+    var u = t;
+    if ("ref" in t) {
+      u = {};
+      for (var a in t) a !== "ref" && (u[a] = t[a]);
+    }
+    if (l = l.defaultProps) {
+      u === t && (u = R({}, u));
+      for (var e in l) u[e] === void 0 && (u[e] = l[e]);
+    }
+    return u;
+  }
+  var un = typeof reportError == "function" ? reportError : function (l) {
+    if (typeof window == "object" && typeof globalThis.ErrorEvent == "function") {
+      var t = new globalThis.ErrorEvent("error", {
+        bubbles: !0,
+        cancelable: !0,
+        message:
+          typeof l == "object" && l !== null && typeof l.message == "string"
+            ? String(l.message)
+            : String(l),
+        error: l,
+      });
+      if (!globalThis.dispatchEvent(t)) return;
+    } else if (
+      typeof process == "object" && typeof process.emit == "function"
+    ) {
+      process.emit("uncaughtException", l);
+      return;
+    }
+    console.error(l);
+  };
+  function is(l) {
+    un(l);
+  }
+  function ss(l) {
+    console.error(l);
+  }
+  function vs(l) {
+    un(l);
+  }
+  function an(l, t) {
+    try {
+      var u = l.onUncaughtError;
+      u(t.value, { componentStack: t.stack });
+    } catch (a) {
+      setTimeout(function () {
+        throw a;
+      });
+    }
+  }
+  function ys(l, t, u) {
+    try {
+      var a = l.onCaughtError;
+      a(u.value, {
+        componentStack: u.stack,
+        errorBoundary: t.tag === 1 ? t.stateNode : null,
+      });
+    } catch (e) {
+      setTimeout(function () {
+        throw e;
+      });
+    }
+  }
+  function Ff(l, t, u) {
+    return u = Jt(u),
+      u.tag = 3,
+      u.payload = { element: null },
+      u.callback = function () {
+        an(l, t);
+      },
+      u;
+  }
+  function ds(l) {
+    return l = Jt(l), l.tag = 3, l;
+  }
+  function hs(l, t, u, a) {
+    var e = u.type.getDerivedStateFromError;
+    if (typeof e == "function") {
+      var n = a.value;
+      l.payload = function () {
+        return e(n);
+      },
+        l.callback = function () {
+          ys(t, u, a);
+        };
+    }
+    var f = u.stateNode;
+    f !== null && typeof f.componentDidCatch == "function" &&
+      (l.callback = function () {
+        ys(t, u, a),
+          typeof e != "function" &&
+          (uu === null ? uu = new Set([this]) : uu.add(this));
+        var c = a.stack;
+        this.componentDidCatch(a.value, {
+          componentStack: c !== null ? c : "",
+        });
+      });
+  }
+  function Md(l, t, u, a, e) {
+    if (
+      u.flags |= 32768,
+        a !== null && typeof a == "object" && typeof a.then == "function"
+    ) {
+      if (
+        t = u.alternate,
+          t !== null && pa(t, u, e, !0),
+          u = it.current,
+          u !== null
+      ) {
+        switch (u.tag) {
+          case 13:
+            return bt === null
+              ? Ec()
+              : u.alternate === null && il === 0 && (il = 3),
+              u.flags &= -257,
+              u.flags |= 65536,
+              u.lanes = e,
+              a === Mf
+                ? u.flags |= 16384
+                : (t = u.updateQueue,
+                  t === null ? u.updateQueue = new Set([a]) : t.add(a),
+                  zc(l, a, e)),
+              !1;
+          case 22:
+            return u.flags |= 65536,
+              a === Mf
+                ? u.flags |= 16384
+                : (t = u.updateQueue,
+                  t === null
+                    ? (t = {
+                      transitions: null,
+                      markerInstances: null,
+                      retryQueue: new Set([a]),
+                    },
+                      u.updateQueue = t)
+                    : (u = t.retryQueue,
+                      u === null ? t.retryQueue = new Set([a]) : u.add(a)),
+                  zc(l, a, e)),
+              !1;
+        }
+        throw Error(S(435, u.tag));
+      }
+      return zc(l, a, e), Ec(), !1;
+    }
+    if (J) {
+      return t = it.current,
+        t !== null
+          ? ((t.flags & 65536) === 0 && (t.flags |= 256),
+            t.flags |= 65536,
+            t.lanes = e,
+            a !== bf && (l = Error(S(422), { cause: a }), Ba(et(l, u))))
+          : (a !== bf && (t = Error(S(423), { cause: a }), Ba(et(t, u))),
+            l = l.current.alternate,
+            l.flags |= 65536,
+            e &= -e,
+            l.lanes |= e,
+            a = et(a, u),
+            e = Ff(l.stateNode, a, e),
+            Rf(l, e),
+            il !== 4 && (il = 2)),
+        !1;
+    }
+    var n = Error(S(520), { cause: a });
+    if (
+      n = et(n, u),
+        te === null ? te = [n] : te.push(n),
+        il !== 4 && (il = 2),
+        t === null
+    ) return !0;
+    a = et(a, u), u = t;
+    do {
+      switch (u.tag) {
+        case 3:
+          return u.flags |= 65536,
+            l = e & -e,
+            u.lanes |= l,
+            l = Ff(u.stateNode, a, l),
+            Rf(u, l),
+            !1;
+        case 1:
+          if (
+            t = u.type,
+              n = u.stateNode,
+              (u.flags & 128) === 0 &&
+              (typeof t.getDerivedStateFromError == "function" ||
+                n !== null && typeof n.componentDidCatch == "function" &&
+                  (uu === null || !uu.has(n)))
+          ) {
+            return u.flags |= 65536,
+              e &= -e,
+              u.lanes |= e,
+              e = ds(e),
+              hs(e, l, u, a),
+              Rf(u, e),
+              !1;
+          }
+      }
+      u = u.return;
+    } while (u !== null);
+    return !1;
+  }
+  var os = Error(S(461)), bl = !1;
+  function zl(l, t, u, a) {
+    t.child = l === null ? es(t, null, u, a) : ea(t, l.child, u, a);
+  }
+  function ms(l, t, u, a, e) {
+    u = u.render;
+    var n = t.ref;
+    if ("ref" in a) {
+      var f = {};
+      for (var c in a) c !== "ref" && (f[c] = a[c]);
+    } else f = a;
+    return Ou(t),
+      a = Bf(l, t, u, f, n, e),
+      c = pf(),
+      l !== null && !bl
+        ? (Gf(l, t, e), Bt(l, t, e))
+        : (J && c && gf(t), t.flags |= 1, zl(l, t, a, e), t.child);
+  }
+  function Ss(l, t, u, a, e) {
+    if (l === null) {
+      var n = u.type;
+      return typeof n == "function" && !of(n) && n.defaultProps === void 0 &&
+          u.compare === null
+        ? (t.tag = 15, t.type = n, gs(l, t, n, a, e))
+        : (l = Ge(u.type, null, a, t, t.mode, e),
+          l.ref = t.ref,
+          l.return = t,
+          t.child = l);
+    }
+    if (n = l.child, !nc(l, e)) {
+      var f = n.memoizedProps;
+      if (u = u.compare, u = u !== null ? u : Ha, u(f, a) && l.ref === t.ref) {
+        return Bt(l, t, e);
+      }
+    }
+    return t.flags |= 1, l = Dt(n, a), l.ref = t.ref, l.return = t, t.child = l;
+  }
+  function gs(l, t, u, a, e) {
+    if (l !== null) {
+      var n = l.memoizedProps;
+      if (Ha(n, a) && l.ref === t.ref) {
+        if (bl = !1, t.pendingProps = a = n, nc(l, e)) {
+          (l.flags & 131072) !== 0 && (bl = !0);
+        } else return t.lanes = l.lanes, Bt(l, t, e);
+      }
+    }
+    return If(l, t, u, a, e);
+  }
+  function rs(l, t, u) {
+    var a = t.pendingProps,
+      e = a.children,
+      n = l !== null ? l.memoizedState : null;
+    if (a.mode === "hidden") {
+      if ((t.flags & 128) !== 0) {
+        if (a = n !== null ? n.baseLanes | u : u, l !== null) {
+          for (e = t.child = l.child, n = 0; e !== null;) {
+            n = n | e.lanes | e.childLanes, e = e.sibling;
+          }
+          t.childLanes = n & ~a;
+        } else t.childLanes = 0, t.child = null;
+        return bs(l, t, a, u);
+      }
+      if ((u & 536870912) !== 0) {
+        t.memoizedState = { baseLanes: 0, cachePool: null },
+          l !== null && je(t, n !== null ? n.cachePool : null),
+          n !== null ? g0(t, n) : Nf(),
+          ns(t);
+      } else {return t.lanes = t.childLanes = 536870912,
+          bs(l, t, n !== null ? n.baseLanes | u : u, u);}
+    } else {n !== null
+        ? (je(t, n.cachePool), g0(t, n), kt(), t.memoizedState = null)
+        : (l !== null && je(t, null), Nf(), kt());}
+    return zl(l, t, e, u), t.child;
+  }
+  function bs(l, t, u, a) {
+    var e = Of();
+    return e = e === null ? null : { parent: Sl._currentValue, pool: e },
+      t.memoizedState = { baseLanes: u, cachePool: e },
+      l !== null && je(t, null),
+      Nf(),
+      ns(t),
+      l !== null && pa(l, t, a, !0),
+      null;
+  }
+  function en(l, t) {
+    var u = t.ref;
+    if (u === null) l !== null && l.ref !== null && (t.flags |= 4194816);
+    else {
+      if (typeof u != "function" && typeof u != "object") throw Error(S(284));
+      (l === null || l.ref !== u) && (t.flags |= 4194816);
+    }
+  }
+  function If(l, t, u, a, e) {
+    return Ou(t),
+      u = Bf(l, t, u, a, void 0, e),
+      a = pf(),
+      l !== null && !bl
+        ? (Gf(l, t, e), Bt(l, t, e))
+        : (J && a && gf(t), t.flags |= 1, zl(l, t, u, e), t.child);
+  }
+  function Ts(l, t, u, a, e, n) {
+    return Ou(t),
+      t.updateQueue = null,
+      u = b0(t, a, u, e),
+      r0(l),
+      a = pf(),
+      l !== null && !bl
+        ? (Gf(l, t, n), Bt(l, t, n))
+        : (J && a && gf(t), t.flags |= 1, zl(l, t, u, n), t.child);
+  }
+  function Es(l, t, u, a, e) {
+    if (Ou(t), t.stateNode === null) {
+      var n = Wu, f = u.contextType;
+      typeof f == "object" && f !== null && (n = Hl(f)),
+        n = new u(a, n),
+        t.memoizedState = n.state !== null && n.state !== void 0
+          ? n.state
+          : null,
+        n.updater = kf,
+        t.stateNode = n,
+        n._reactInternals = t,
+        n = t.stateNode,
+        n.props = a,
+        n.state = t.memoizedState,
+        n.refs = {},
+        Df(t),
+        f = u.contextType,
+        n.context = typeof f == "object" && f !== null ? Hl(f) : Wu,
+        n.state = t.memoizedState,
+        f = u.getDerivedStateFromProps,
+        typeof f == "function" && ($f(t, u, f, a), n.state = t.memoizedState),
+        typeof u.getDerivedStateFromProps == "function" ||
+        typeof n.getSnapshotBeforeUpdate == "function" ||
+        typeof n.UNSAFE_componentWillMount != "function" &&
+          typeof n.componentWillMount != "function" ||
+        (f = n.state,
+          typeof n.componentWillMount == "function" && n.componentWillMount(),
+          typeof n.UNSAFE_componentWillMount == "function" &&
+          n.UNSAFE_componentWillMount(),
+          f !== n.state && kf.enqueueReplaceState(n, n.state, null),
+          Ca(t, a, n, e),
+          ja(),
+          n.state = t.memoizedState),
+        typeof n.componentDidMount == "function" && (t.flags |= 4194308),
+        a = !0;
+    } else if (l === null) {
+      n = t.stateNode;
+      var c = t.memoizedProps, i = Uu(u, c);
+      n.props = i;
+      var h = n.context, g = u.contextType;
+      f = Wu, typeof g == "object" && g !== null && (f = Hl(g));
+      var T = u.getDerivedStateFromProps;
+      g = typeof T == "function" ||
+        typeof n.getSnapshotBeforeUpdate == "function",
+        c = t.pendingProps !== c,
+        g ||
+        typeof n.UNSAFE_componentWillReceiveProps != "function" &&
+          typeof n.componentWillReceiveProps != "function" ||
+        (c || h !== f) && cs(t, n, a, f),
+        Kt = !1;
+      var o = t.memoizedState;
+      n.state = o,
+        Ca(t, a, n, e),
+        ja(),
+        h = t.memoizedState,
+        c || o !== h || Kt
+          ? (typeof T == "function" && ($f(t, u, T, a), h = t.memoizedState),
+            (i = Kt || fs(t, u, i, a, o, h, f))
+              ? (g ||
+                typeof n.UNSAFE_componentWillMount != "function" &&
+                  typeof n.componentWillMount != "function" ||
+                (typeof n.componentWillMount == "function" &&
+                  n.componentWillMount(),
+                  typeof n.UNSAFE_componentWillMount == "function" &&
+                  n.UNSAFE_componentWillMount()),
+                typeof n.componentDidMount == "function" &&
+                (t.flags |= 4194308))
+              : (typeof n.componentDidMount == "function" &&
+                (t.flags |= 4194308),
+                t.memoizedProps = a,
+                t.memoizedState = h),
+            n.props = a,
+            n.state = h,
+            n.context = f,
+            a = i)
+          : (typeof n.componentDidMount == "function" && (t.flags |= 4194308),
+            a = !1);
+    } else {
+      n = t.stateNode,
+        Uf(l, t),
+        f = t.memoizedProps,
+        g = Uu(u, f),
+        n.props = g,
+        T = t.pendingProps,
+        o = n.context,
+        h = u.contextType,
+        i = Wu,
+        typeof h == "object" && h !== null && (i = Hl(h)),
+        c = u.getDerivedStateFromProps,
+        (h = typeof c == "function" ||
+          typeof n.getSnapshotBeforeUpdate == "function") ||
+        typeof n.UNSAFE_componentWillReceiveProps != "function" &&
+          typeof n.componentWillReceiveProps != "function" ||
+        (f !== T || o !== i) && cs(t, n, a, i),
+        Kt = !1,
+        o = t.memoizedState,
+        n.state = o,
+        Ca(t, a, n, e),
+        ja();
+      var m = t.memoizedState;
+      f !== T || o !== m || Kt ||
+        l !== null && l.dependencies !== null && xe(l.dependencies)
+        ? (typeof c == "function" && ($f(t, u, c, a), m = t.memoizedState),
+          (g = Kt || fs(t, u, g, a, o, m, i) ||
+              l !== null && l.dependencies !== null && xe(l.dependencies))
+            ? (h ||
+              typeof n.UNSAFE_componentWillUpdate != "function" &&
+                typeof n.componentWillUpdate != "function" ||
+              (typeof n.componentWillUpdate == "function" &&
+                n.componentWillUpdate(a, m, i),
+                typeof n.UNSAFE_componentWillUpdate == "function" &&
+                n.UNSAFE_componentWillUpdate(a, m, i)),
+              typeof n.componentDidUpdate == "function" && (t.flags |= 4),
+              typeof n.getSnapshotBeforeUpdate == "function" &&
+              (t.flags |= 1024))
+            : (typeof n.componentDidUpdate != "function" ||
+              f === l.memoizedProps && o === l.memoizedState || (t.flags |= 4),
+              typeof n.getSnapshotBeforeUpdate != "function" ||
+              f === l.memoizedProps && o === l.memoizedState ||
+              (t.flags |= 1024),
+              t.memoizedProps = a,
+              t.memoizedState = m),
+          n.props = a,
+          n.state = m,
+          n.context = i,
+          a = g)
+        : (typeof n.componentDidUpdate != "function" ||
+          f === l.memoizedProps && o === l.memoizedState || (t.flags |= 4),
+          typeof n.getSnapshotBeforeUpdate != "function" ||
+          f === l.memoizedProps && o === l.memoizedState || (t.flags |= 1024),
+          a = !1);
+    }
+    return n = a,
+      en(l, t),
+      a = (t.flags & 128) !== 0,
+      n || a
+        ? (n = t.stateNode,
+          u = a && typeof u.getDerivedStateFromError != "function"
+            ? null
+            : n.render(),
+          t.flags |= 1,
+          l !== null && a
+            ? (t.child = ea(t, l.child, null, e), t.child = ea(t, null, u, e))
+            : zl(l, t, u, e),
+          t.memoizedState = n.state,
+          l = t.child)
+        : l = Bt(l, t, e),
+      l;
+  }
+  function As(l, t, u, a) {
+    return Ya(), t.flags |= 256, zl(l, t, u, a), t.child;
+  }
+  var Pf = {
+    dehydrated: null,
+    treeContext: null,
+    retryLane: 0,
+    hydrationErrors: null,
+  };
+  function lc(l) {
+    return { baseLanes: l, cachePool: s0() };
+  }
+  function tc(l, t, u) {
+    return l = l !== null ? l.childLanes & ~u : 0, t && (l |= st), l;
+  }
+  function zs(l, t, u) {
+    var a = t.pendingProps, e = !1, n = (t.flags & 128) !== 0, f;
+    if (
+      (f = n) ||
+      (f = l !== null && l.memoizedState === null
+        ? !1
+        : (gl.current & 2) !== 0),
+        f && (e = !0, t.flags &= -129),
+        f = (t.flags & 32) !== 0,
+        t.flags &= -33,
+        l === null
+    ) {
+      if (J) {
+        if (e ? $t(t) : kt(), J) {
+          var c = cl, i;
+          if (i = c) {
+            l: {
+              for (i = c, c = rt; i.nodeType !== 8;) {
+                if (!c) {
+                  c = null;
+                  break l;
+                }
+                if (i = mt(i.nextSibling), i === null) {
+                  c = null;
+                  break l;
+                }
+              }
+              c = i;
+            }
+            c !== null
+              ? (t.memoizedState = {
+                dehydrated: c,
+                treeContext: Tu !== null ? { id: Ut, overflow: Rt } : null,
+                retryLane: 536870912,
+                hydrationErrors: null,
+              },
+                i = $l(18, null, null, 0),
+                i.stateNode = c,
+                i.return = t,
+                t.child = i,
+                pl = t,
+                cl = null,
+                i = !0)
+              : i = !1;
+          }
+          i || zu(t);
+        }
+        if (c = t.memoizedState, c !== null && (c = c.dehydrated, c !== null)) {
+          return Qc(c) ? t.lanes = 32 : t.lanes = 536870912, null;
+        }
+        Yt(t);
+      }
+      return c = a.children,
+        a = a.fallback,
+        e
+          ? (kt(),
+            e = t.mode,
+            c = nn({ mode: "hidden", children: c }, e),
+            a = bu(a, e, u, null),
+            c.return = t,
+            a.return = t,
+            c.sibling = a,
+            t.child = c,
+            e = t.child,
+            e.memoizedState = lc(u),
+            e.childLanes = tc(l, f, u),
+            t.memoizedState = Pf,
+            a)
+          : ($t(t), uc(t, c));
+    }
+    if (i = l.memoizedState, i !== null && (c = i.dehydrated, c !== null)) {
+      if (n) {
+        t.flags & 256
+          ? ($t(t), t.flags &= -257, t = ac(l, t, u))
+          : t.memoizedState !== null
+          ? (kt(), t.child = l.child, t.flags |= 128, t = null)
+          : (kt(),
+            e = a.fallback,
+            c = t.mode,
+            a = nn({ mode: "visible", children: a.children }, c),
+            e = bu(e, c, u, null),
+            e.flags |= 2,
+            a.return = t,
+            e.return = t,
+            a.sibling = e,
+            t.child = a,
+            ea(t, l.child, null, u),
+            a = t.child,
+            a.memoizedState = lc(u),
+            a.childLanes = tc(l, f, u),
+            t.memoizedState = Pf,
+            t = e);
+      } else if ($t(t), Qc(c)) {
+        if (f = c.nextSibling && c.nextSibling.dataset, f) { var h = f.dgst; }
+        f = h,
+          a = Error(S(419)),
+          a.stack = "",
+          a.digest = f,
+          Ba({ value: a, source: null, stack: null }),
+          t = ac(l, t, u);
+      } else if (bl || pa(l, t, u, !1), f = (u & l.childLanes) !== 0, bl || f) {
+        if (
+          f = ul,
+            f !== null &&
+            (a = u & -u,
+              a = (a & 42) !== 0 ? 1 : Qn(a),
+              a = (a & (f.suspendedLanes | u)) !== 0 ? 0 : a,
+              a !== 0 && a !== i.retryLane)
+        ) throw i.retryLane = a, wu(l, a), lt(f, l, a), os;
+        c.data === "$?" || Ec(), t = ac(l, t, u);
+      } else {c.data === "$?"
+          ? (t.flags |= 192, t.child = l.child, t = null)
+          : (l = i.treeContext,
+            cl = mt(c.nextSibling),
+            pl = t,
+            J = !0,
+            Au = null,
+            rt = !1,
+            l !== null &&
+            (ft[ct++] = Ut,
+              ft[ct++] = Rt,
+              ft[ct++] = Tu,
+              Ut = l.id,
+              Rt = l.overflow,
+              Tu = t),
+            t = uc(t, a.children),
+            t.flags |= 4096);}
+      return t;
+    }
+    return e
+      ? (kt(),
+        e = a.fallback,
+        c = t.mode,
+        i = l.child,
+        h = i.sibling,
+        a = Dt(i, { mode: "hidden", children: a.children }),
+        a.subtreeFlags = i.subtreeFlags & 65011712,
+        h !== null ? e = Dt(h, e) : (e = bu(e, c, u, null), e.flags |= 2),
+        e.return = t,
+        a.return = t,
+        a.sibling = e,
+        t.child = a,
+        a = e,
+        e = t.child,
+        c = l.child.memoizedState,
+        c === null
+          ? c = lc(u)
+          : (i = c.cachePool,
+            i !== null
+              ? (h = Sl._currentValue,
+                i = i.parent !== h ? { parent: h, pool: h } : i)
+              : i = s0(),
+            c = { baseLanes: c.baseLanes | u, cachePool: i }),
+        e.memoizedState = c,
+        e.childLanes = tc(l, f, u),
+        t.memoizedState = Pf,
+        a)
+      : ($t(t),
+        u = l.child,
+        l = u.sibling,
+        u = Dt(u, { mode: "visible", children: a.children }),
+        u.return = t,
+        u.sibling = null,
+        l !== null &&
+        (f = t.deletions,
+          f === null ? (t.deletions = [l], t.flags |= 16) : f.push(l)),
+        t.child = u,
+        t.memoizedState = null,
+        u);
+  }
+  function uc(l, t) {
+    return t = nn({ mode: "visible", children: t }, l.mode),
+      t.return = l,
+      l.child = t;
+  }
+  function nn(l, t) {
+    return l = $l(22, l, null, t),
+      l.lanes = 0,
+      l.stateNode = {
+        _visibility: 1,
+        _pendingMarkers: null,
+        _retryCache: null,
+        _transitions: null,
+      },
+      l;
+  }
+  function ac(l, t, u) {
+    return ea(t, l.child, null, u),
+      l = uc(t, t.pendingProps.children),
+      l.flags |= 2,
+      t.memoizedState = null,
+      l;
+  }
+  function _s(l, t, u) {
+    l.lanes |= t;
+    var a = l.alternate;
+    a !== null && (a.lanes |= t), Ef(l.return, t, u);
+  }
+  function ec(l, t, u, a, e) {
+    var n = l.memoizedState;
+    n === null
+      ? l.memoizedState = {
+        isBackwards: t,
+        rendering: null,
+        renderingStartTime: 0,
+        last: a,
+        tail: u,
+        tailMode: e,
+      }
+      : (n.isBackwards = t,
+        n.rendering = null,
+        n.renderingStartTime = 0,
+        n.last = a,
+        n.tail = u,
+        n.tailMode = e);
+  }
+  function Os(l, t, u) {
+    var a = t.pendingProps, e = a.revealOrder, n = a.tail;
+    if (zl(l, t, a.children, u), a = gl.current, (a & 2) !== 0) {
+      a = a & 1 | 2, t.flags |= 128;
+    } else {
+      if (l !== null && (l.flags & 128) !== 0) {
+        l: for (l = t.child; l !== null;) {
+          if (l.tag === 13) {
+            l.memoizedState !== null && _s(l, u, t);
+          } else if (l.tag === 19) _s(l, u, t);
+          else if (l.child !== null) {
+            l.child.return = l, l = l.child;
+            continue;
+          }
+          if (l === t) break l;
+          for (; l.sibling === null;) {
+            if (l.return === null || l.return === t) break l;
+            l = l.return;
+          }
+          l.sibling.return = l.return, l = l.sibling;
+        }
+      }
+      a &= 1;
+    }
+    switch (z(gl, a), e) {
+      case "forwards":
+        for (u = t.child, e = null; u !== null;) {
+          l = u.alternate,
+            l !== null && tn(l) === null && (e = u),
+            u = u.sibling;
+        }
+        u = e,
+          u === null
+            ? (e = t.child, t.child = null)
+            : (e = u.sibling, u.sibling = null),
+          ec(t, !1, e, u, n);
+        break;
+      case "backwards":
+        for (u = null, e = t.child, t.child = null; e !== null;) {
+          if (l = e.alternate, l !== null && tn(l) === null) {
+            t.child = e;
+            break;
+          }
+          l = e.sibling, e.sibling = u, u = e, e = l;
+        }
+        ec(t, !0, u, null, n);
+        break;
+      case "together":
+        ec(t, !1, null, null, void 0);
+        break;
+      default:
+        t.memoizedState = null;
+    }
+    return t.child;
+  }
+  function Bt(l, t, u) {
+    if (
+      l !== null && (t.dependencies = l.dependencies),
+        tu |= t.lanes,
+        (u & t.childLanes) === 0
+    ) {
+      if (l !== null) {
+        if (pa(l, t, u, !1), (u & t.childLanes) === 0) return null;
+      } else return null;
+    }
+    if (l !== null && t.child !== l.child) throw Error(S(153));
+    if (t.child !== null) {
+      for (
+        l = t.child, u = Dt(l, l.pendingProps), t.child = u, u.return = t;
+        l.sibling !== null;
+      ) l = l.sibling, u = u.sibling = Dt(l, l.pendingProps), u.return = t;
+      u.sibling = null;
+    }
+    return t.child;
+  }
+  function nc(l, t) {
+    return (l.lanes & t) !== 0
+      ? !0
+      : (l = l.dependencies, !!(l !== null && xe(l)));
+  }
+  function Dd(l, t, u) {
+    switch (t.tag) {
+      case 3:
+        el(t, t.stateNode.containerInfo),
+          Lt(t, Sl, l.memoizedState.cache),
+          Ya();
+        break;
+      case 27:
+      case 5:
+        Yn(t);
+        break;
+      case 4:
+        el(t, t.stateNode.containerInfo);
+        break;
+      case 10:
+        Lt(t, t.type, t.memoizedProps.value);
+        break;
+      case 13:
+        var a = t.memoizedState;
+        if (a !== null) {
+          return a.dehydrated !== null
+            ? ($t(t), t.flags |= 128, null)
+            : (u & t.child.childLanes) !== 0
+            ? zs(l, t, u)
+            : ($t(t), l = Bt(l, t, u), l !== null ? l.sibling : null);
+        }
+        $t(t);
+        break;
+      case 19:
+        var e = (l.flags & 128) !== 0;
+        if (
+          a = (u & t.childLanes) !== 0,
+            a || (pa(l, t, u, !1), a = (u & t.childLanes) !== 0),
+            e
+        ) {
+          if (a) return Os(l, t, u);
+          t.flags |= 128;
+        }
+        if (
+          e = t.memoizedState,
+            e !== null &&
+            (e.rendering = null, e.tail = null, e.lastEffect = null),
+            z(gl, gl.current),
+            a
+        ) break;
+        return null;
+      case 22:
+      case 23:
+        return t.lanes = 0, rs(l, t, u);
+      case 24:
+        Lt(t, Sl, l.memoizedState.cache);
+    }
+    return Bt(l, t, u);
+  }
+  function Ms(l, t, u) {
+    if (l !== null) {
+      if (l.memoizedProps !== t.pendingProps) bl = !0;
+      else {
+        if (!nc(l, u) && (t.flags & 128) === 0) return bl = !1, Dd(l, t, u);
+        bl = (l.flags & 131072) !== 0;
+      }
+    } else bl = !1, J && (t.flags & 1048576) !== 0 && u0(t, Qe, t.index);
+    switch (t.lanes = 0, t.tag) {
+      case 16:
+        l: {
+          l = t.pendingProps;
+          var a = t.elementType, e = a._init;
+          if (a = e(a._payload), t.type = a, typeof a == "function") {
+            of(a)
+              ? (l = Uu(a, l), t.tag = 1, t = Es(null, t, a, l, u))
+              : (t.tag = 0, t = If(null, t, a, l, u));
+          } else {
+            if (a != null) {
+              if (e = a.$$typeof, e === dt) {
+                t.tag = 11, t = ms(null, t, a, l, u);
+                break l;
+              } else if (e === Vl) {
+                t.tag = 14, t = Ss(null, t, a, l, u);
+                break l;
+              }
+            }
+            throw t = hu(a) || a, Error(S(306, t, ""));
+          }
+        }
+        return t;
+      case 0:
+        return If(l, t, t.type, t.pendingProps, u);
+      case 1:
+        return a = t.type, e = Uu(a, t.pendingProps), Es(l, t, a, e, u);
+      case 3:
+        l: {
+          if (el(t, t.stateNode.containerInfo), l === null) throw Error(S(387));
+          a = t.pendingProps;
+          var n = t.memoizedState;
+          e = n.element, Uf(l, t), Ca(t, a, null, u);
+          var f = t.memoizedState;
+          if (
+            a = f.cache,
+              Lt(t, Sl, a),
+              a !== n.cache && Af(t, [Sl], u, !0),
+              ja(),
+              a = f.element,
+              n.isDehydrated
+          ) {
+            if (
+              n = { element: a, isDehydrated: !1, cache: f.cache },
+                t.updateQueue.baseState = n,
+                t.memoizedState = n,
+                t.flags & 256
+            ) {
+              t = As(l, t, a, u);
+              break l;
+            } else if (a !== e) {
+              e = et(Error(S(424)), t), Ba(e), t = As(l, t, a, u);
+              break l;
+            } else {
+              switch (l = t.stateNode.containerInfo, l.nodeType) {
+                case 9:
+                  l = l.body;
+                  break;
+                default:
+                  l = l.nodeName === "HTML" ? l.ownerDocument.body : l;
+              }
+              for (
+                cl = mt(l.firstChild),
+                  pl = t,
+                  J = !0,
+                  Au = null,
+                  rt = !0,
+                  u = es(t, null, a, u),
+                  t.child = u;
+                u;
+              ) u.flags = u.flags & -3 | 4096, u = u.sibling;
+            }
+          } else {
+            if (Ya(), a === e) {
+              t = Bt(l, t, u);
+              break l;
+            }
+            zl(l, t, a, u);
+          }
+          t = t.child;
+        }
+        return t;
+      case 26:
+        return en(l, t),
+          l === null
+            ? (u = Hv(t.type, null, t.pendingProps, null))
+              ? t.memoizedState = u
+              : J ||
+                (u = t.type,
+                  l = t.pendingProps,
+                  a = Tn(G.current).createElement(u),
+                  a[Rl] = t,
+                  a[Xl] = l,
+                  Ol(a, u, l),
+                  rl(a),
+                  t.stateNode = a)
+            : t.memoizedState = Hv(
+              t.type,
+              l.memoizedProps,
+              t.pendingProps,
+              l.memoizedState,
+            ),
+          null;
+      case 27:
+        return Yn(t),
+          l === null && J &&
+          (a = t.stateNode = Dv(t.type, t.pendingProps, G.current),
+            pl = t,
+            rt = !0,
+            e = cl,
+            nu(t.type) ? (xc = e, cl = mt(a.firstChild)) : cl = e),
+          zl(l, t, t.pendingProps.children, u),
+          en(l, t),
+          l === null && (t.flags |= 4194304),
+          t.child;
+      case 5:
+        return l === null && J &&
+          ((e = a = cl) &&
+            (a = t1(a, t.type, t.pendingProps, rt),
+              a !== null
+                ? (t.stateNode = a,
+                  pl = t,
+                  cl = mt(a.firstChild),
+                  rt = !1,
+                  e = !0)
+                : e = !1),
+            e || zu(t)),
+          Yn(t),
+          e = t.type,
+          n = t.pendingProps,
+          f = l !== null ? l.memoizedProps : null,
+          a = n.children,
+          pc(e, n) ? a = null : f !== null && pc(e, f) && (t.flags |= 32),
+          t.memoizedState !== null &&
+          (e = Bf(l, t, bd, null, null, u), ve._currentValue = e),
+          en(l, t),
+          zl(l, t, a, u),
+          t.child;
+      case 6:
+        return l === null && J &&
+          ((l = u = cl) &&
+            (u = u1(u, t.pendingProps, rt),
+              u !== null
+                ? (t.stateNode = u, pl = t, cl = null, l = !0)
+                : l = !1),
+            l || zu(t)),
+          null;
+      case 13:
+        return zs(l, t, u);
+      case 4:
+        return el(t, t.stateNode.containerInfo),
+          a = t.pendingProps,
+          l === null ? t.child = ea(t, null, a, u) : zl(l, t, a, u),
+          t.child;
+      case 11:
+        return ms(l, t, t.type, t.pendingProps, u);
+      case 7:
+        return zl(l, t, t.pendingProps, u), t.child;
+      case 8:
+        return zl(l, t, t.pendingProps.children, u), t.child;
+      case 12:
+        return zl(l, t, t.pendingProps.children, u), t.child;
+      case 10:
+        return a = t.pendingProps,
+          Lt(t, t.type, a.value),
+          zl(l, t, a.children, u),
+          t.child;
+      case 9:
+        return e = t.type._context,
+          a = t.pendingProps.children,
+          Ou(t),
+          e = Hl(e),
+          a = a(e),
+          t.flags |= 1,
+          zl(l, t, a, u),
+          t.child;
+      case 14:
+        return Ss(l, t, t.type, t.pendingProps, u);
+      case 15:
+        return gs(l, t, t.type, t.pendingProps, u);
+      case 19:
+        return Os(l, t, u);
+      case 31:
+        return a = t.pendingProps,
+          u = t.mode,
+          a = { mode: a.mode, children: a.children },
+          l === null
+            ? (u = nn(a, u), u.ref = t.ref, t.child = u, u.return = t, t = u)
+            : (u = Dt(l.child, a),
+              u.ref = t.ref,
+              t.child = u,
+              u.return = t,
+              t = u),
+          t;
+      case 22:
+        return rs(l, t, u);
+      case 24:
+        return Ou(t),
+          a = Hl(Sl),
+          l === null
+            ? (e = Of(),
+              e === null &&
+              (e = ul,
+                n = zf(),
+                e.pooledCache = n,
+                n.refCount++,
+                n !== null && (e.pooledCacheLanes |= u),
+                e = n),
+              t.memoizedState = { parent: a, cache: e },
+              Df(t),
+              Lt(t, Sl, e))
+            : ((l.lanes & u) !== 0 && (Uf(l, t), Ca(t, null, null, u), ja()),
+              e = l.memoizedState,
+              n = t.memoizedState,
+              e.parent !== a
+                ? (e = { parent: a, cache: a },
+                  t.memoizedState = e,
+                  t.lanes === 0 &&
+                  (t.memoizedState = t.updateQueue.baseState = e),
+                  Lt(t, Sl, a))
+                : (a = n.cache,
+                  Lt(t, Sl, a),
+                  a !== e.cache && Af(t, [Sl], u, !0))),
+          zl(l, t, t.pendingProps.children, u),
+          t.child;
+      case 29:
+        throw t.pendingProps;
+    }
+    throw Error(S(156, t.tag));
+  }
+  function pt(l) {
+    l.flags |= 4;
+  }
+  function Ds(l, t) {
+    if (t.type !== "stylesheet" || (t.state.loading & 4) !== 0) {
+      l.flags &= -16777217;
+    } else if (l.flags |= 16777216, !pv(t)) {
+      if (
+        t = it.current,
+          t !== null &&
+          ((C & 4194048) === C
+            ? bt !== null
+            : (C & 62914560) !== C && (C & 536870912) === 0 || t !== bt)
+      ) throw xa = Mf, v0;
+      l.flags |= 8192;
+    }
+  }
+  function fn(l, t) {
+    t !== null && (l.flags |= 4),
+      l.flags & 16384 &&
+      (t = l.tag !== 22 ? ni() : 536870912, l.lanes |= t, ia |= t);
+  }
+  function $a(l, t) {
+    if (!J) {
+      switch (l.tailMode) {
+        case "hidden":
+          t = l.tail;
+          for (var u = null; t !== null;) {
+            t.alternate !== null && (u = t), t = t.sibling;
+          }
+          u === null ? l.tail = null : u.sibling = null;
+          break;
+        case "collapsed":
+          u = l.tail;
+          for (var a = null; u !== null;) {
+            u.alternate !== null && (a = u), u = u.sibling;
+          }
+          a === null
+            ? t || l.tail === null ? l.tail = null : l.tail.sibling = null
+            : a.sibling = null;
+      }
+    }
+  }
+  function fl(l) {
+    var t = l.alternate !== null && l.alternate.child === l.child, u = 0, a = 0;
+    if (t) {
+      for (var e = l.child; e !== null;) {
+        u |= e.lanes | e.childLanes,
+          a |= e.subtreeFlags & 65011712,
+          a |= e.flags & 65011712,
+          e.return = l,
+          e = e.sibling;
+      }
+    } else {for (e = l.child; e !== null;) {
+        u |= e.lanes | e.childLanes,
+          a |= e.subtreeFlags,
+          a |= e.flags,
+          e.return = l,
+          e = e.sibling;
+      }}
+    return l.subtreeFlags |= a, l.childLanes = u, t;
+  }
+  function Ud(l, t, u) {
+    var a = t.pendingProps;
+    switch (rf(t), t.tag) {
+      case 31:
+      case 16:
+      case 15:
+      case 0:
+      case 11:
+      case 7:
+      case 8:
+      case 12:
+      case 9:
+      case 14:
+        return fl(t), null;
+      case 1:
+        return fl(t), null;
+      case 3:
+        return u = t.stateNode,
+          a = null,
+          l !== null && (a = l.memoizedState.cache),
+          t.memoizedState.cache !== a && (t.flags |= 2048),
+          Nt(Sl),
+          Zt(),
+          u.pendingContext &&
+          (u.context = u.pendingContext, u.pendingContext = null),
+          (l === null || l.child === null) &&
+          (qa(t) ? pt(t) : l === null ||
+            l.memoizedState.isDehydrated && (t.flags & 256) === 0 ||
+            (t.flags |= 1024, n0())),
+          fl(t),
+          null;
+      case 26:
+        return u = t.memoizedState,
+          l === null
+            ? (pt(t),
+              u !== null ? (fl(t), Ds(t, u)) : (fl(t), t.flags &= -16777217))
+            : u
+            ? u !== l.memoizedState
+              ? (pt(t), fl(t), Ds(t, u))
+              : (fl(t), t.flags &= -16777217)
+            : (l.memoizedProps !== a && pt(t), fl(t), t.flags &= -16777217),
+          null;
+      case 27:
+        ge(t), u = G.current;
+        var e = t.type;
+        if (l !== null && t.stateNode != null) l.memoizedProps !== a && pt(t);
+        else {
+          if (!a) {
+            if (t.stateNode === null) throw Error(S(166));
+            return fl(t), null;
+          }
+          l = N.current,
+            qa(t) ? a0(t) : (l = Dv(e, a, u), t.stateNode = l, pt(t));
+        }
+        return fl(t), null;
+      case 5:
+        if (ge(t), u = t.type, l !== null && t.stateNode != null) {
+          l.memoizedProps !== a && pt(t);
+        } else {
+          if (!a) {
+            if (t.stateNode === null) throw Error(S(166));
+            return fl(t), null;
+          }
+          if (l = N.current, qa(t)) a0(t);
+          else {
+            switch (e = Tn(G.current), l) {
+              case 1:
+                l = e.createElementNS("http://www.w3.org/2000/svg", u);
+                break;
+              case 2:
+                l = e.createElementNS("http://www.w3.org/1998/Math/MathML", u);
+                break;
+              default:
+                switch (u) {
+                  case "svg":
+                    l = e.createElementNS("http://www.w3.org/2000/svg", u);
+                    break;
+                  case "math":
+                    l = e.createElementNS(
+                      "http://www.w3.org/1998/Math/MathML",
+                      u,
+                    );
+                    break;
+                  case "script":
+                    l = e.createElement("div"),
+                      l.innerHTML = "<script><\/script>",
+                      l = l.removeChild(l.firstChild);
+                    break;
+                  case "select":
+                    l = typeof a.is == "string"
+                      ? e.createElement("select", { is: a.is })
+                      : e.createElement("select"),
+                      a.multiple
+                        ? l.multiple = !0
+                        : a.size && (l.size = a.size);
+                    break;
+                  default:
+                    l = typeof a.is == "string"
+                      ? e.createElement(u, { is: a.is })
+                      : e.createElement(u);
+                }
+            }
+            l[Rl] = t, l[Xl] = a;
+            l: for (e = t.child; e !== null;) {
+              if (e.tag === 5 || e.tag === 6) l.appendChild(e.stateNode);
+              else if (e.tag !== 4 && e.tag !== 27 && e.child !== null) {
+                e.child.return = e, e = e.child;
+                continue;
+              }
+              if (e === t) break l;
+              for (; e.sibling === null;) {
+                if (e.return === null || e.return === t) break l;
+                e = e.return;
+              }
+              e.sibling.return = e.return, e = e.sibling;
+            }
+            t.stateNode = l;
+            l: switch (Ol(l, u, a), u) {
+              case "button":
+              case "input":
+              case "select":
+              case "textarea":
+                l = !!a.autoFocus;
+                break l;
+              case "img":
+                l = !0;
+                break l;
+              default:
+                l = !1;
+            }
+            l && pt(t);
+          }
+        }
+        return fl(t), t.flags &= -16777217, null;
+      case 6:
+        if (l && t.stateNode != null) l.memoizedProps !== a && pt(t);
+        else {
+          if (typeof a != "string" && t.stateNode === null) throw Error(S(166));
+          if (l = G.current, qa(t)) {
+            if (
+              l = t.stateNode, u = t.memoizedProps, a = null, e = pl, e !== null
+            ) {
+              switch (e.tag) {
+                case 27:
+                case 5:
+                  a = e.memoizedProps;
+              }
+            }
+            l[Rl] = t,
+              l = !!(l.nodeValue === u ||
+                a !== null && a.suppressHydrationWarning === !0 ||
+                Tv(l.nodeValue, u)),
+              l || zu(t);
+          } else l = Tn(l).createTextNode(a), l[Rl] = t, t.stateNode = l;
+        }
+        return fl(t), null;
+      case 13:
+        if (
+          a = t.memoizedState,
+            l === null ||
+            l.memoizedState !== null && l.memoizedState.dehydrated !== null
+        ) {
+          if (e = qa(t), a !== null && a.dehydrated !== null) {
+            if (l === null) {
+              if (!e) throw Error(S(318));
+              if (
+                e = t.memoizedState, e = e !== null ? e.dehydrated : null, !e
+              ) throw Error(S(317));
+              e[Rl] = t;
+            } else {Ya(),
+                (t.flags & 128) === 0 && (t.memoizedState = null),
+                t.flags |= 4;}
+            fl(t), e = !1;
+          } else {e = n0(),
+              l !== null && l.memoizedState !== null &&
+              (l.memoizedState.hydrationErrors = e),
+              e = !0;}
+          if (!e) return t.flags & 256 ? (Yt(t), t) : (Yt(t), null);
+        }
+        if (Yt(t), (t.flags & 128) !== 0) return t.lanes = u, t;
+        if (u = a !== null, l = l !== null && l.memoizedState !== null, u) {
+          a = t.child,
+            e = null,
+            a.alternate !== null && a.alternate.memoizedState !== null &&
+            a.alternate.memoizedState.cachePool !== null &&
+            (e = a.alternate.memoizedState.cachePool.pool);
+          var n = null;
+          a.memoizedState !== null && a.memoizedState.cachePool !== null &&
+          (n = a.memoizedState.cachePool.pool), n !== e && (a.flags |= 2048);
+        }
+        return u !== l && u && (t.child.flags |= 8192),
+          fn(t, t.updateQueue),
+          fl(t),
+          null;
+      case 4:
+        return Zt(), l === null && Hc(t.stateNode.containerInfo), fl(t), null;
+      case 10:
+        return Nt(t.type), fl(t), null;
+      case 19:
+        if (O(gl), e = t.memoizedState, e === null) return fl(t), null;
+        if (a = (t.flags & 128) !== 0, n = e.rendering, n === null) {
+          if (a) $a(e, !1);
+          else {
+            if (il !== 0 || l !== null && (l.flags & 128) !== 0) {
+              for (l = t.child; l !== null;) {
+                if (n = tn(l), n !== null) {
+                  for (
+                    t.flags |= 128,
+                      $a(e, !1),
+                      l = n.updateQueue,
+                      t.updateQueue = l,
+                      fn(t, l),
+                      t.subtreeFlags = 0,
+                      l = u,
+                      u = t.child;
+                    u !== null;
+                  ) {
+                    t0(u, l), u = u.sibling;
+                  }
+                  return z(gl, gl.current & 1 | 2), t.child;
+                }
+                l = l.sibling;
+              }
+            }
+            e.tail !== null && gt() > vn &&
+              (t.flags |= 128, a = !0, $a(e, !1), t.lanes = 4194304);
+          }
+        } else {
+          if (!a) {
+            if (l = tn(n), l !== null) {
+              if (
+                t.flags |= 128,
+                  a = !0,
+                  l = l.updateQueue,
+                  t.updateQueue = l,
+                  fn(t, l),
+                  $a(e, !0),
+                  e.tail === null && e.tailMode === "hidden" && !n.alternate &&
+                  !J
+              ) return fl(t), null;
+            } else {2 * gt() - e.renderingStartTime > vn && u !== 536870912 &&
+                (t.flags |= 128, a = !0, $a(e, !1), t.lanes = 4194304);}
+          }
+          e.isBackwards
+            ? (n.sibling = t.child, t.child = n)
+            : (l = e.last,
+              l !== null ? l.sibling = n : t.child = n,
+              e.last = n);
+        }
+        return e.tail !== null
+          ? (t = e.tail,
+            e.rendering = t,
+            e.tail = t.sibling,
+            e.renderingStartTime = gt(),
+            t.sibling = null,
+            l = gl.current,
+            z(gl, a ? l & 1 | 2 : l & 1),
+            t)
+          : (fl(t), null);
+      case 22:
+      case 23:
+        return Yt(t),
+          qf(),
+          a = t.memoizedState !== null,
+          l !== null
+            ? l.memoizedState !== null !== a && (t.flags |= 8192)
+            : a && (t.flags |= 8192),
+          a
+            ? (u & 536870912) !== 0 && (t.flags & 128) === 0 &&
+              (fl(t), t.subtreeFlags & 6 && (t.flags |= 8192))
+            : fl(t),
+          u = t.updateQueue,
+          u !== null && fn(t, u.retryQueue),
+          u = null,
+          l !== null && l.memoizedState !== null &&
+          l.memoizedState.cachePool !== null &&
+          (u = l.memoizedState.cachePool.pool),
+          a = null,
+          t.memoizedState !== null && t.memoizedState.cachePool !== null &&
+          (a = t.memoizedState.cachePool.pool),
+          a !== u && (t.flags |= 2048),
+          l !== null && O(Mu),
+          null;
+      case 24:
+        return u = null,
+          l !== null && (u = l.memoizedState.cache),
+          t.memoizedState.cache !== u && (t.flags |= 2048),
+          Nt(Sl),
+          fl(t),
+          null;
+      case 25:
+        return null;
+      case 30:
+        return null;
+    }
+    throw Error(S(156, t.tag));
+  }
+  function Rd(l, t) {
+    switch (rf(t), t.tag) {
+      case 1:
+        return l = t.flags, l & 65536 ? (t.flags = l & -65537 | 128, t) : null;
+      case 3:
+        return Nt(Sl),
+          Zt(),
+          l = t.flags,
+          (l & 65536) !== 0 && (l & 128) === 0
+            ? (t.flags = l & -65537 | 128, t)
+            : null;
+      case 26:
+      case 27:
+      case 5:
+        return ge(t), null;
+      case 13:
+        if (Yt(t), l = t.memoizedState, l !== null && l.dehydrated !== null) {
+          if (t.alternate === null) throw Error(S(340));
+          Ya();
+        }
+        return l = t.flags, l & 65536 ? (t.flags = l & -65537 | 128, t) : null;
+      case 19:
+        return O(gl), null;
+      case 4:
+        return Zt(), null;
+      case 10:
+        return Nt(t.type), null;
+      case 22:
+      case 23:
+        return Yt(t),
+          qf(),
+          l !== null && O(Mu),
+          l = t.flags,
+          l & 65536 ? (t.flags = l & -65537 | 128, t) : null;
+      case 24:
+        return Nt(Sl), null;
+      case 25:
+        return null;
+      default:
+        return null;
+    }
+  }
+  function Us(l, t) {
+    switch (rf(t), t.tag) {
+      case 3:
+        Nt(Sl), Zt();
+        break;
+      case 26:
+      case 27:
+      case 5:
+        ge(t);
+        break;
+      case 4:
+        Zt();
+        break;
+      case 13:
+        Yt(t);
+        break;
+      case 19:
+        O(gl);
+        break;
+      case 10:
+        Nt(t.type);
+        break;
+      case 22:
+      case 23:
+        Yt(t), qf(), l !== null && O(Mu);
+        break;
+      case 24:
+        Nt(Sl);
+    }
+  }
+  function ka(l, t) {
+    try {
+      var u = t.updateQueue, a = u !== null ? u.lastEffect : null;
+      if (a !== null) {
+        var e = a.next;
+        u = e;
+        do {
+          if ((u.tag & l) === l) {
+            a = void 0;
+            var n = u.create, f = u.inst;
+            a = n(), f.destroy = a;
+          }
+          u = u.next;
+        } while (u !== e);
+      }
+    } catch (c) {
+      P(t, t.return, c);
+    }
+  }
+  function Ft(l, t, u) {
+    try {
+      var a = t.updateQueue, e = a !== null ? a.lastEffect : null;
+      if (e !== null) {
+        var n = e.next;
+        a = n;
+        do {
+          if ((a.tag & l) === l) {
+            var f = a.inst, c = f.destroy;
+            if (c !== void 0) {
+              f.destroy = void 0, e = t;
+              var i = u, h = c;
+              try {
+                h();
+              } catch (g) {
+                P(e, i, g);
+              }
+            }
+          }
+          a = a.next;
+        } while (a !== n);
+      }
+    } catch (g) {
+      P(t, t.return, g);
+    }
+  }
+  function Rs(l) {
+    var t = l.updateQueue;
+    if (t !== null) {
+      var u = l.stateNode;
+      try {
+        S0(t, u);
+      } catch (a) {
+        P(l, l.return, a);
+      }
+    }
+  }
+  function Hs(l, t, u) {
+    u.props = Uu(l.type, l.memoizedProps), u.state = l.memoizedState;
+    try {
+      u.componentWillUnmount();
+    } catch (a) {
+      P(l, t, a);
+    }
+  }
+  function Fa(l, t) {
+    try {
+      var u = l.ref;
+      if (u !== null) {
+        switch (l.tag) {
+          case 26:
+          case 27:
+          case 5:
+            var a = l.stateNode;
+            break;
+          case 30:
+            a = l.stateNode;
+            break;
+          default:
+            a = l.stateNode;
+        }
+        typeof u == "function" ? l.refCleanup = u(a) : u.current = a;
+      }
+    } catch (e) {
+      P(l, t, e);
+    }
+  }
+  function Tt(l, t) {
+    var u = l.ref, a = l.refCleanup;
+    if (u !== null) {
+      if (typeof a == "function") {
+        try {
+          a();
+        } catch (e) {
+          P(l, t, e);
+        } finally {
+          l.refCleanup = null,
+            l = l.alternate,
+            l != null && (l.refCleanup = null);
+        }
+      } else if (typeof u == "function") {
+        try {
+          u(null);
+        } catch (e) {
+          P(l, t, e);
+        }
+      } else u.current = null;
+    }
+  }
+  function Ns(l) {
+    var t = l.type, u = l.memoizedProps, a = l.stateNode;
+    try {
+      l: switch (t) {
+        case "button":
+        case "input":
+        case "select":
+        case "textarea":
+          u.autoFocus && a.focus();
+          break l;
+        case "img":
+          u.src ? a.src = u.src : u.srcSet && (a.srcset = u.srcSet);
+      }
+    } catch (e) {
+      P(l, l.return, e);
+    }
+  }
+  function fc(l, t, u) {
+    try {
+      var a = l.stateNode;
+      kd(a, l.type, u, t), a[Xl] = t;
+    } catch (e) {
+      P(l, l.return, e);
+    }
+  }
+  function qs(l) {
+    return l.tag === 5 || l.tag === 3 || l.tag === 26 ||
+      l.tag === 27 && nu(l.type) || l.tag === 4;
+  }
+  function cc(l) {
+    l: for (;;) {
+      for (; l.sibling === null;) {
+        if (l.return === null || qs(l.return)) return null;
+        l = l.return;
+      }
+      for (
+        l.sibling.return = l.return, l = l.sibling;
+        l.tag !== 5 && l.tag !== 6 && l.tag !== 18;
+      ) {
+        if (
+          l.tag === 27 && nu(l.type) || l.flags & 2 || l.child === null ||
+          l.tag === 4
+        ) continue l;
+        l.child.return = l, l = l.child;
+      }
+      if (!(l.flags & 2)) return l.stateNode;
+    }
+  }
+  function ic(l, t, u) {
+    var a = l.tag;
+    if (a === 5 || a === 6) {
+      l = l.stateNode,
+        t
+          ? (u.nodeType === 9
+            ? u.body
+            : u.nodeName === "HTML"
+            ? u.ownerDocument.body
+            : u).insertBefore(l, t)
+          : (t = u.nodeType === 9
+            ? u.body
+            : u.nodeName === "HTML"
+            ? u.ownerDocument.body
+            : u,
+            t.appendChild(l),
+            u = u._reactRootContainer,
+            u != null || t.onclick !== null || (t.onclick = bn));
+    } else if (
+      a !== 4 &&
+      (a === 27 && nu(l.type) && (u = l.stateNode, t = null),
+        l = l.child,
+        l !== null)
+    ) {
+      for (ic(l, t, u), l = l.sibling; l !== null;) {
+        ic(l, t, u), l = l.sibling;
+      }
+    }
+  }
+  function cn(l, t, u) {
+    var a = l.tag;
+    if (a === 5 || a === 6) {
+      l = l.stateNode, t ? u.insertBefore(l, t) : u.appendChild(l);
+    } else if (
+      a !== 4 &&
+      (a === 27 && nu(l.type) && (u = l.stateNode), l = l.child, l !== null)
+    ) {
+      for (cn(l, t, u), l = l.sibling; l !== null;) {
+        cn(l, t, u), l = l.sibling;
+      }
+    }
+  }
+  function Ys(l) {
+    var t = l.stateNode, u = l.memoizedProps;
+    try {
+      for (var a = l.type, e = t.attributes; e.length;) {
+        t.removeAttributeNode(e[0]);
+      }
+      Ol(t, a, u), t[Rl] = l, t[Xl] = u;
+    } catch (n) {
+      P(l, l.return, n);
+    }
+  }
+  var Gt = !1,
+    dl = !1,
+    sc = !1,
+    Bs = typeof WeakSet == "function" ? WeakSet : Set,
+    Tl = null;
+  function Hd(l, t) {
+    if (l = l.containerInfo, Yc = Mn, l = Ki(l), ff(l)) {
+      if ("selectionStart" in l) {
+        var u = { start: l.selectionStart, end: l.selectionEnd };
+      } else {l: {
+          u = (u = l.ownerDocument) && u.defaultView || window;
+          var a = u.getSelection && u.getSelection();
+          if (a && a.rangeCount !== 0) {
+            u = a.anchorNode;
+            var e = a.anchorOffset, n = a.focusNode;
+            a = a.focusOffset;
+            try {
+              u.nodeType, n.nodeType;
+            } catch {
+              u = null;
+              break l;
+            }
+            var f = 0, c = -1, i = -1, h = 0, g = 0, T = l, o = null;
+            t: for (;;) {
+              for (
+                var m;
+                T !== u || e !== 0 && T.nodeType !== 3 || (c = f + e),
+                  T !== n || a !== 0 && T.nodeType !== 3 || (i = f + a),
+                  T.nodeType === 3 && (f += T.nodeValue.length),
+                  (m = T.firstChild) !== null;
+              ) o = T, T = m;
+              for (;;) {
+                if (T === l) break t;
+                if (
+                  o === u && ++h === e && (c = f),
+                    o === n && ++g === a && (i = f),
+                    (m = T.nextSibling) !== null
+                ) break;
+                T = o, o = T.parentNode;
+              }
+              T = m;
+            }
+            u = c === -1 || i === -1 ? null : { start: c, end: i };
+          } else u = null;
+        }}
+      u = u || { start: 0, end: 0 };
+    } else u = null;
+    for (
+      Bc = { focusedElem: l, selectionRange: u }, Mn = !1, Tl = t;
+      Tl !== null;
+    ) {
+      if (t = Tl, l = t.child, (t.subtreeFlags & 1024) !== 0 && l !== null) {
+        l.return = t, Tl = l;
+      } else {for (; Tl !== null;) {
+          switch (t = Tl, n = t.alternate, l = t.flags, t.tag) {
+            case 0:
+              break;
+            case 11:
+            case 15:
+              break;
+            case 1:
+              if ((l & 1024) !== 0 && n !== null) {
+                l = void 0,
+                  u = t,
+                  e = n.memoizedProps,
+                  n = n.memoizedState,
+                  a = u.stateNode;
+                try {
+                  var p = Uu(u.type, e, u.elementType === u.type);
+                  l = a.getSnapshotBeforeUpdate(p, n),
+                    a.__reactInternalSnapshotBeforeUpdate = l;
+                } catch (q) {
+                  P(u, u.return, q);
+                }
+              }
+              break;
+            case 3:
+              if ((l & 1024) !== 0) {
+                if (l = t.stateNode.containerInfo, u = l.nodeType, u === 9) {
+                  Xc(l);
+                } else if (u === 1) {
+                  switch (l.nodeName) {
+                    case "HEAD":
+                    case "HTML":
+                    case "BODY":
+                      Xc(l);
+                      break;
+                    default:
+                      l.textContent = "";
+                  }
+                }
+              }
+              break;
+            case 5:
+            case 26:
+            case 27:
+            case 6:
+            case 4:
+            case 17:
+              break;
+            default:
+              if ((l & 1024) !== 0) throw Error(S(163));
+          }
+          if (l = t.sibling, l !== null) {
+            l.return = t.return, Tl = l;
+            break;
+          }
+          Tl = t.return;
+        }}
+    }
+  }
+  function ps(l, t, u) {
+    var a = u.flags;
+    switch (u.tag) {
+      case 0:
+      case 11:
+      case 15:
+        It(l, u), a & 4 && ka(5, u);
+        break;
+      case 1:
+        if (It(l, u), a & 4) {
+          if (l = u.stateNode, t === null) {
+            try {
+              l.componentDidMount();
+            } catch (f) {
+              P(u, u.return, f);
+            }
+          } else {
+            var e = Uu(u.type, t.memoizedProps);
+            t = t.memoizedState;
+            try {
+              l.componentDidUpdate(e, t, l.__reactInternalSnapshotBeforeUpdate);
+            } catch (f) {
+              P(u, u.return, f);
+            }
+          }
+        }
+        a & 64 && Rs(u), a & 512 && Fa(u, u.return);
+        break;
+      case 3:
+        if (It(l, u), a & 64 && (l = u.updateQueue, l !== null)) {
+          if (t = null, u.child !== null) {
+            switch (u.child.tag) {
+              case 27:
+              case 5:
+                t = u.child.stateNode;
+                break;
+              case 1:
+                t = u.child.stateNode;
+            }
+          }
+          try {
+            S0(l, t);
+          } catch (f) {
+            P(u, u.return, f);
+          }
+        }
+        break;
+      case 27:
+        t === null && a & 4 && Ys(u);
+      case 26:
+      case 5:
+        It(l, u), t === null && a & 4 && Ns(u), a & 512 && Fa(u, u.return);
+        break;
+      case 12:
+        It(l, u);
+        break;
+      case 13:
+        It(l, u),
+          a & 4 && Qs(l, u),
+          a & 64 &&
+          (l = u.memoizedState,
+            l !== null &&
+            (l = l.dehydrated, l !== null && (u = xd.bind(null, u), a1(l, u))));
+        break;
+      case 22:
+        if (a = u.memoizedState !== null || Gt, !a) {
+          t = t !== null && t.memoizedState !== null || dl, e = Gt;
+          var n = dl;
+          Gt = a,
+            (dl = t) && !n ? Pt(l, u, (u.subtreeFlags & 8772) !== 0) : It(l, u),
+            Gt = e,
+            dl = n;
+        }
+        break;
+      case 30:
+        break;
+      default:
+        It(l, u);
+    }
+  }
+  function Gs(l) {
+    var t = l.alternate;
+    t !== null && (l.alternate = null, Gs(t)),
+      l.child = null,
+      l.deletions = null,
+      l.sibling = null,
+      l.tag === 5 && (t = l.stateNode, t !== null && jn(t)),
+      l.stateNode = null,
+      l.return = null,
+      l.dependencies = null,
+      l.memoizedProps = null,
+      l.memoizedState = null,
+      l.pendingProps = null,
+      l.stateNode = null,
+      l.updateQueue = null;
+  }
+  var nl = null, Zl = !1;
+  function Xt(l, t, u) {
+    for (u = u.child; u !== null;) Xs(l, t, u), u = u.sibling;
+  }
+  function Xs(l, t, u) {
+    if (Jl && typeof Jl.onCommitFiberUnmount == "function") {
+      try {
+        Jl.onCommitFiberUnmount(ra, u);
+      } catch {}
+    }
+    switch (u.tag) {
+      case 26:
+        dl || Tt(u, t),
+          Xt(l, t, u),
+          u.memoizedState
+            ? u.memoizedState.count--
+            : u.stateNode && (u = u.stateNode, u.parentNode.removeChild(u));
+        break;
+      case 27:
+        dl || Tt(u, t);
+        var a = nl, e = Zl;
+        nu(u.type) && (nl = u.stateNode, Zl = !1),
+          Xt(l, t, u),
+          fe(u.stateNode),
+          nl = a,
+          Zl = e;
+        break;
+      case 5:
+        dl || Tt(u, t);
+      case 6:
+        if (
+          a = nl, e = Zl, nl = null, Xt(l, t, u), nl = a, Zl = e, nl !== null
+        ) {
+          if (Zl) {
+            try {
+              (nl.nodeType === 9
+                ? nl.body
+                : nl.nodeName === "HTML"
+                ? nl.ownerDocument.body
+                : nl).removeChild(u.stateNode);
+            } catch (n) {
+              P(u, t, n);
+            }
+          } else {try {
+              nl.removeChild(u.stateNode);
+            } catch (n) {
+              P(u, t, n);
+            }}
+        }
+        break;
+      case 18:
+        nl !== null &&
+          (Zl
+            ? (l = nl,
+              Ov(
+                l.nodeType === 9
+                  ? l.body
+                  : l.nodeName === "HTML"
+                  ? l.ownerDocument.body
+                  : l,
+                u.stateNode,
+              ),
+              oe(l))
+            : Ov(nl, u.stateNode));
+        break;
+      case 4:
+        a = nl,
+          e = Zl,
+          nl = u.stateNode.containerInfo,
+          Zl = !0,
+          Xt(l, t, u),
+          nl = a,
+          Zl = e;
+        break;
+      case 0:
+      case 11:
+      case 14:
+      case 15:
+        dl || Ft(2, u, t), dl || Ft(4, u, t), Xt(l, t, u);
+        break;
+      case 1:
+        dl ||
+        (Tt(u, t),
+          a = u.stateNode,
+          typeof a.componentWillUnmount == "function" && Hs(u, t, a)),
+          Xt(l, t, u);
+        break;
+      case 21:
+        Xt(l, t, u);
+        break;
+      case 22:
+        dl = (a = dl) || u.memoizedState !== null, Xt(l, t, u), dl = a;
+        break;
+      default:
+        Xt(l, t, u);
+    }
+  }
+  function Qs(l, t) {
+    if (
+      t.memoizedState === null &&
+      (l = t.alternate,
+        l !== null &&
+        (l = l.memoizedState, l !== null && (l = l.dehydrated, l !== null)))
+    ) {
+      try {
+        oe(l);
+      } catch (u) {
+        P(t, t.return, u);
+      }
+    }
+  }
+  function Nd(l) {
+    switch (l.tag) {
+      case 13:
+      case 19:
+        var t = l.stateNode;
+        return t === null && (t = l.stateNode = new Bs()), t;
+      case 22:
+        return l = l.stateNode,
+          t = l._retryCache,
+          t === null && (t = l._retryCache = new Bs()),
+          t;
+      default:
+        throw Error(S(435, l.tag));
+    }
+  }
+  function vc(l, t) {
+    var u = Nd(l);
+    t.forEach(function (a) {
+      var e = Zd.bind(null, l, a);
+      u.has(a) || (u.add(a), a.then(e, e));
+    });
+  }
+  function kl(l, t) {
+    var u = t.deletions;
+    if (u !== null) {
+      for (var a = 0; a < u.length; a++) {
+        var e = u[a], n = l, f = t, c = f;
+        l: for (; c !== null;) {
+          switch (c.tag) {
+            case 27:
+              if (nu(c.type)) {
+                nl = c.stateNode, Zl = !1;
+                break l;
+              }
+              break;
+            case 5:
+              nl = c.stateNode, Zl = !1;
+              break l;
+            case 3:
+            case 4:
+              nl = c.stateNode.containerInfo, Zl = !0;
+              break l;
+          }
+          c = c.return;
+        }
+        if (nl === null) throw Error(S(160));
+        Xs(n, f, e),
+          nl = null,
+          Zl = !1,
+          n = e.alternate,
+          n !== null && (n.return = null),
+          e.return = null;
+      }
+    }
+    if (t.subtreeFlags & 13878) {
+      for (t = t.child; t !== null;) xs(t, l), t = t.sibling;
+    }
+  }
+  var ot = null;
+  function xs(l, t) {
+    var u = l.alternate, a = l.flags;
+    switch (l.tag) {
+      case 0:
+      case 11:
+      case 14:
+      case 15:
+        kl(t, l),
+          Fl(l),
+          a & 4 && (Ft(3, l, l.return), ka(3, l), Ft(5, l, l.return));
+        break;
+      case 1:
+        kl(t, l),
+          Fl(l),
+          a & 512 && (dl || u === null || Tt(u, u.return)),
+          a & 64 && Gt &&
+          (l = l.updateQueue,
+            l !== null &&
+            (a = l.callbacks,
+              a !== null &&
+              (u = l.shared.hiddenCallbacks,
+                l.shared.hiddenCallbacks = u === null ? a : u.concat(a))));
+        break;
+      case 26:
+        var e = ot;
+        if (
+          kl(t, l),
+            Fl(l),
+            a & 512 && (dl || u === null || Tt(u, u.return)),
+            a & 4
+        ) {
+          var n = u !== null ? u.memoizedState : null;
+          if (a = l.memoizedState, u === null) {
+            if (a === null) {
+              if (l.stateNode === null) {
+                l: {
+                  a = l.type, u = l.memoizedProps, e = e.ownerDocument || e;
+                  t: switch (a) {
+                    case "title":
+                      n = e.getElementsByTagName("title")[0],
+                        (!n || n[Ea] || n[Rl] ||
+                          n.namespaceURI === "http://www.w3.org/2000/svg" ||
+                          n.hasAttribute("itemprop")) &&
+                        (n = e.createElement(a),
+                          e.head.insertBefore(
+                            n,
+                            e.querySelector("head > title"),
+                          )),
+                        Ol(n, a, u),
+                        n[Rl] = l,
+                        rl(n),
+                        a = n;
+                      break l;
+                    case "link":
+                      var f = Yv("link", "href", e).get(a + (u.href || ""));
+                      if (f) {
+                        for (var c = 0; c < f.length; c++) {
+                          if (
+                            n = f[c],
+                              n.getAttribute("href") ===
+                                (u.href == null || u.href === ""
+                                  ? null
+                                  : u.href) &&
+                              n.getAttribute("rel") ===
+                                (u.rel == null ? null : u.rel) &&
+                              n.getAttribute("title") ===
+                                (u.title == null ? null : u.title) &&
+                              n.getAttribute("crossorigin") ===
+                                (u.crossOrigin == null ? null : u.crossOrigin)
+                          ) {
+                            f.splice(c, 1);
+                            break t;
+                          }
+                        }
+                      }
+                      n = e.createElement(a),
+                        Ol(n, a, u),
+                        e.head.appendChild(n);
+                      break;
+                    case "meta":
+                      if (
+                        f = Yv("meta", "content", e).get(a + (u.content || ""))
+                      ) {
+                        for (c = 0; c < f.length; c++) {
+                          if (
+                            n = f[c],
+                              n.getAttribute("content") ===
+                                (u.content == null ? null : "" + u.content) &&
+                              n.getAttribute("name") ===
+                                (u.name == null ? null : u.name) &&
+                              n.getAttribute("property") ===
+                                (u.property == null ? null : u.property) &&
+                              n.getAttribute("http-equiv") ===
+                                (u.httpEquiv == null ? null : u.httpEquiv) &&
+                              n.getAttribute("charset") ===
+                                (u.charSet == null ? null : u.charSet)
+                          ) {
+                            f.splice(c, 1);
+                            break t;
+                          }
+                        }
+                      }
+                      n = e.createElement(a),
+                        Ol(n, a, u),
+                        e.head.appendChild(n);
+                      break;
+                    default:
+                      throw Error(S(468, a));
+                  }
+                  n[Rl] = l, rl(n), a = n;
+                }
+                l.stateNode = a;
+              } else Bv(e, l.type, l.stateNode);
+            } else l.stateNode = qv(e, a, l.memoizedProps);
+          } else {n !== a
+              ? (n === null
+                ? u.stateNode !== null &&
+                  (u = u.stateNode, u.parentNode.removeChild(u))
+                : n.count--,
+                a === null
+                  ? Bv(e, l.type, l.stateNode)
+                  : qv(e, a, l.memoizedProps))
+              : a === null && l.stateNode !== null &&
+                fc(l, l.memoizedProps, u.memoizedProps);}
+        }
+        break;
+      case 27:
+        kl(t, l),
+          Fl(l),
+          a & 512 && (dl || u === null || Tt(u, u.return)),
+          u !== null && a & 4 && fc(l, l.memoizedProps, u.memoizedProps);
+        break;
+      case 5:
+        if (
+          kl(t, l),
+            Fl(l),
+            a & 512 && (dl || u === null || Tt(u, u.return)),
+            l.flags & 32
+        ) {
+          e = l.stateNode;
+          try {
+            Zu(e, "");
+          } catch (m) {
+            P(l, l.return, m);
+          }
+        }
+        a & 4 && l.stateNode != null &&
+        (e = l.memoizedProps, fc(l, e, u !== null ? u.memoizedProps : e)),
+          a & 1024 && (sc = !0);
+        break;
+      case 6:
+        if (kl(t, l), Fl(l), a & 4) {
+          if (l.stateNode === null) throw Error(S(162));
+          a = l.memoizedProps, u = l.stateNode;
+          try {
+            u.nodeValue = a;
+          } catch (m) {
+            P(l, l.return, m);
+          }
+        }
+        break;
+      case 3:
+        if (
+          zn = null,
+            e = ot,
+            ot = En(t.containerInfo),
+            kl(t, l),
+            ot = e,
+            Fl(l),
+            a & 4 && u !== null && u.memoizedState.isDehydrated
+        ) {
+          try {
+            oe(t.containerInfo);
+          } catch (m) {
+            P(l, l.return, m);
+          }
+        }
+        sc && (sc = !1, Zs(l));
+        break;
+      case 4:
+        a = ot, ot = En(l.stateNode.containerInfo), kl(t, l), Fl(l), ot = a;
+        break;
+      case 12:
+        kl(t, l), Fl(l);
+        break;
+      case 13:
+        kl(t, l),
+          Fl(l),
+          l.child.flags & 8192 &&
+          l.memoizedState !== null !=
+            (u !== null && u.memoizedState !== null) &&
+          (Sc = gt()),
+          a & 4 &&
+          (a = l.updateQueue, a !== null && (l.updateQueue = null, vc(l, a)));
+        break;
+      case 22:
+        e = l.memoizedState !== null;
+        var i = u !== null && u.memoizedState !== null, h = Gt, g = dl;
+        if (
+          Gt = h || e, dl = g || i, kl(t, l), dl = g, Gt = h, Fl(l), a & 8192
+        ) {
+          l: for (
+            t = l.stateNode,
+              t._visibility = e ? t._visibility & -2 : t._visibility | 1,
+              e && (u === null || i || Gt || dl || Ru(l)),
+              u = null,
+              t = l;;
+          ) {
+            if (t.tag === 5 || t.tag === 26) {
+              if (u === null) {
+                i = u = t;
+                try {
+                  if (n = i.stateNode, e) {
+                    f = n.style,
+                      typeof f.setProperty == "function"
+                        ? f.setProperty("display", "none", "important")
+                        : f.display = "none";
+                  } else {
+                    c = i.stateNode;
+                    var T = i.memoizedProps.style,
+                      o = T != null && T.hasOwnProperty("display")
+                        ? T.display
+                        : null;
+                    c.style.display = o == null || typeof o == "boolean"
+                      ? ""
+                      : ("" + o).trim();
+                  }
+                } catch (m) {
+                  P(i, i.return, m);
+                }
+              }
+            } else if (t.tag === 6) {
+              if (u === null) {
+                i = t;
+                try {
+                  i.stateNode.nodeValue = e ? "" : i.memoizedProps;
+                } catch (m) {
+                  P(i, i.return, m);
+                }
+              }
+            } else if (
+              (t.tag !== 22 && t.tag !== 23 || t.memoizedState === null ||
+                t === l) && t.child !== null
+            ) {
+              t.child.return = t, t = t.child;
+              continue;
+            }
+            if (t === l) break l;
+            for (; t.sibling === null;) {
+              if (t.return === null || t.return === l) break l;
+              u === t && (u = null), t = t.return;
+            }
+            u === t && (u = null), t.sibling.return = t.return, t = t.sibling;
+          }
+        }
+        a & 4 &&
+          (a = l.updateQueue,
+            a !== null &&
+            (u = a.retryQueue, u !== null && (a.retryQueue = null, vc(l, u))));
+        break;
+      case 19:
+        kl(t, l),
+          Fl(l),
+          a & 4 &&
+          (a = l.updateQueue, a !== null && (l.updateQueue = null, vc(l, a)));
+        break;
+      case 30:
+        break;
+      case 21:
+        break;
+      default:
+        kl(t, l), Fl(l);
+    }
+  }
+  function Fl(l) {
+    var t = l.flags;
+    if (t & 2) {
+      try {
+        for (var u, a = l.return; a !== null;) {
+          if (qs(a)) {
+            u = a;
+            break;
+          }
+          a = a.return;
+        }
+        if (u == null) throw Error(S(160));
+        switch (u.tag) {
+          case 27:
+            var e = u.stateNode, n = cc(l);
+            cn(l, n, e);
+            break;
+          case 5:
+            var f = u.stateNode;
+            u.flags & 32 && (Zu(f, ""), u.flags &= -33);
+            var c = cc(l);
+            cn(l, c, f);
+            break;
+          case 3:
+          case 4:
+            var i = u.stateNode.containerInfo, h = cc(l);
+            ic(l, h, i);
+            break;
+          default:
+            throw Error(S(161));
+        }
+      } catch (g) {
+        P(l, l.return, g);
+      }
+      l.flags &= -3;
+    }
+    t & 4096 && (l.flags &= -4097);
+  }
+  function Zs(l) {
+    if (l.subtreeFlags & 1024) {
+      for (l = l.child; l !== null;) {
+        var t = l;
+        Zs(t),
+          t.tag === 5 && t.flags & 1024 && t.stateNode.reset(),
+          l = l.sibling;
+      }
+    }
+  }
+  function It(l, t) {
+    if (t.subtreeFlags & 8772) {
+      for (t = t.child; t !== null;) ps(l, t.alternate, t), t = t.sibling;
+    }
+  }
+  function Ru(l) {
+    for (l = l.child; l !== null;) {
+      var t = l;
+      switch (t.tag) {
+        case 0:
+        case 11:
+        case 14:
+        case 15:
+          Ft(4, t, t.return), Ru(t);
+          break;
+        case 1:
+          Tt(t, t.return);
+          var u = t.stateNode;
+          typeof u.componentWillUnmount == "function" && Hs(t, t.return, u),
+            Ru(t);
+          break;
+        case 27:
+          fe(t.stateNode);
+        case 26:
+        case 5:
+          Tt(t, t.return), Ru(t);
+          break;
+        case 22:
+          t.memoizedState === null && Ru(t);
+          break;
+        case 30:
+          Ru(t);
+          break;
+        default:
+          Ru(t);
+      }
+      l = l.sibling;
+    }
+  }
+  function Pt(l, t, u) {
+    for (u = u && (t.subtreeFlags & 8772) !== 0, t = t.child; t !== null;) {
+      var a = t.alternate, e = l, n = t, f = n.flags;
+      switch (n.tag) {
+        case 0:
+        case 11:
+        case 15:
+          Pt(e, n, u), ka(4, n);
+          break;
+        case 1:
+          if (
+            Pt(e, n, u),
+              a = n,
+              e = a.stateNode,
+              typeof e.componentDidMount == "function"
+          ) {
+            try {
+              e.componentDidMount();
+            } catch (h) {
+              P(a, a.return, h);
+            }
+          }
+          if (a = n, e = a.updateQueue, e !== null) {
+            var c = a.stateNode;
+            try {
+              var i = e.shared.hiddenCallbacks;
+              if (i !== null) {
+                for (
+                  e.shared.hiddenCallbacks = null, e = 0;
+                  e < i.length;
+                  e++
+                ) m0(i[e], c);
+              }
+            } catch (h) {
+              P(a, a.return, h);
+            }
+          }
+          u && f & 64 && Rs(n), Fa(n, n.return);
+          break;
+        case 27:
+          Ys(n);
+        case 26:
+        case 5:
+          Pt(e, n, u), u && a === null && f & 4 && Ns(n), Fa(n, n.return);
+          break;
+        case 12:
+          Pt(e, n, u);
+          break;
+        case 13:
+          Pt(e, n, u), u && f & 4 && Qs(e, n);
+          break;
+        case 22:
+          n.memoizedState === null && Pt(e, n, u), Fa(n, n.return);
+          break;
+        case 30:
+          break;
+        default:
+          Pt(e, n, u);
+      }
+      t = t.sibling;
+    }
+  }
+  function yc(l, t) {
+    var u = null;
+    l !== null && l.memoizedState !== null &&
+    l.memoizedState.cachePool !== null && (u = l.memoizedState.cachePool.pool),
+      l = null,
+      t.memoizedState !== null && t.memoizedState.cachePool !== null &&
+      (l = t.memoizedState.cachePool.pool),
+      l !== u && (l != null && l.refCount++, u != null && Ga(u));
+  }
+  function dc(l, t) {
+    l = null,
+      t.alternate !== null && (l = t.alternate.memoizedState.cache),
+      t = t.memoizedState.cache,
+      t !== l && (t.refCount++, l != null && Ga(l));
+  }
+  function Et(l, t, u, a) {
+    if (t.subtreeFlags & 10256) {
+      for (t = t.child; t !== null;) js(l, t, u, a), t = t.sibling;
+    }
+  }
+  function js(l, t, u, a) {
+    var e = t.flags;
+    switch (t.tag) {
+      case 0:
+      case 11:
+      case 15:
+        Et(l, t, u, a), e & 2048 && ka(9, t);
+        break;
+      case 1:
+        Et(l, t, u, a);
+        break;
+      case 3:
+        Et(l, t, u, a),
+          e & 2048 &&
+          (l = null,
+            t.alternate !== null && (l = t.alternate.memoizedState.cache),
+            t = t.memoizedState.cache,
+            t !== l && (t.refCount++, l != null && Ga(l)));
+        break;
+      case 12:
+        if (e & 2048) {
+          Et(l, t, u, a), l = t.stateNode;
+          try {
+            var n = t.memoizedProps, f = n.id, c = n.onPostCommit;
+            typeof c == "function" &&
+              c(
+                f,
+                t.alternate === null ? "mount" : "update",
+                l.passiveEffectDuration,
+                -0,
+              );
+          } catch (i) {
+            P(t, t.return, i);
+          }
+        } else Et(l, t, u, a);
+        break;
+      case 13:
+        Et(l, t, u, a);
+        break;
+      case 23:
+        break;
+      case 22:
+        n = t.stateNode,
+          f = t.alternate,
+          t.memoizedState !== null
+            ? n._visibility & 2 ? Et(l, t, u, a) : Ia(l, t)
+            : n._visibility & 2
+            ? Et(l, t, u, a)
+            : (n._visibility |= 2,
+              na(l, t, u, a, (t.subtreeFlags & 10256) !== 0)),
+          e & 2048 && yc(f, t);
+        break;
+      case 24:
+        Et(l, t, u, a), e & 2048 && dc(t.alternate, t);
+        break;
+      default:
+        Et(l, t, u, a);
+    }
+  }
+  function na(l, t, u, a, e) {
+    for (e = e && (t.subtreeFlags & 10256) !== 0, t = t.child; t !== null;) {
+      var n = l, f = t, c = u, i = a, h = f.flags;
+      switch (f.tag) {
+        case 0:
+        case 11:
+        case 15:
+          na(n, f, c, i, e), ka(8, f);
+          break;
+        case 23:
+          break;
+        case 22:
+          var g = f.stateNode;
+          f.memoizedState !== null
+            ? g._visibility & 2 ? na(n, f, c, i, e) : Ia(n, f)
+            : (g._visibility |= 2, na(n, f, c, i, e)),
+            e && h & 2048 && yc(f.alternate, f);
+          break;
+        case 24:
+          na(n, f, c, i, e), e && h & 2048 && dc(f.alternate, f);
+          break;
+        default:
+          na(n, f, c, i, e);
+      }
+      t = t.sibling;
+    }
+  }
+  function Ia(l, t) {
+    if (t.subtreeFlags & 10256) {
+      for (t = t.child; t !== null;) {
+        var u = l, a = t, e = a.flags;
+        switch (a.tag) {
+          case 22:
+            Ia(u, a), e & 2048 && yc(a.alternate, a);
+            break;
+          case 24:
+            Ia(u, a), e & 2048 && dc(a.alternate, a);
+            break;
+          default:
+            Ia(u, a);
+        }
+        t = t.sibling;
+      }
+    }
+  }
+  var Pa = 8192;
+  function fa(l) {
+    if (l.subtreeFlags & Pa) {
+      for (l = l.child; l !== null;) Cs(l), l = l.sibling;
+    }
+  }
+  function Cs(l) {
+    switch (l.tag) {
+      case 26:
+        fa(l),
+          l.flags & Pa && l.memoizedState !== null &&
+          S1(ot, l.memoizedState, l.memoizedProps);
+        break;
+      case 5:
+        fa(l);
+        break;
+      case 3:
+      case 4:
+        var t = ot;
+        ot = En(l.stateNode.containerInfo), fa(l), ot = t;
+        break;
+      case 22:
+        l.memoizedState === null &&
+          (t = l.alternate,
+            t !== null && t.memoizedState !== null
+              ? (t = Pa, Pa = 16777216, fa(l), Pa = t)
+              : fa(l));
+        break;
+      default:
+        fa(l);
+    }
+  }
+  function Vs(l) {
+    var t = l.alternate;
+    if (t !== null && (l = t.child, l !== null)) {
+      t.child = null;
+      do t = l.sibling, l.sibling = null, l = t; while (l !== null);
+    }
+  }
+  function le(l) {
+    var t = l.deletions;
+    if ((l.flags & 16) !== 0) {
+      if (t !== null) {
+        for (var u = 0; u < t.length; u++) {
+          var a = t[u];
+          Tl = a, Ks(a, l);
+        }
+      }
+      Vs(l);
+    }
+    if (l.subtreeFlags & 10256) {
+      for (l = l.child; l !== null;) Ls(l), l = l.sibling;
+    }
+  }
+  function Ls(l) {
+    switch (l.tag) {
+      case 0:
+      case 11:
+      case 15:
+        le(l), l.flags & 2048 && Ft(9, l, l.return);
+        break;
+      case 3:
+        le(l);
+        break;
+      case 12:
+        le(l);
+        break;
+      case 22:
+        var t = l.stateNode;
+        l.memoizedState !== null && t._visibility & 2 &&
+          (l.return === null || l.return.tag !== 13)
+          ? (t._visibility &= -3, sn(l))
+          : le(l);
+        break;
+      default:
+        le(l);
+    }
+  }
+  function sn(l) {
+    var t = l.deletions;
+    if ((l.flags & 16) !== 0) {
+      if (t !== null) {
+        for (var u = 0; u < t.length; u++) {
+          var a = t[u];
+          Tl = a, Ks(a, l);
+        }
+      }
+      Vs(l);
+    }
+    for (l = l.child; l !== null;) {
+      switch (t = l, t.tag) {
+        case 0:
+        case 11:
+        case 15:
+          Ft(8, t, t.return), sn(t);
+          break;
+        case 22:
+          u = t.stateNode, u._visibility & 2 && (u._visibility &= -3, sn(t));
+          break;
+        default:
+          sn(t);
+      }
+      l = l.sibling;
+    }
+  }
+  function Ks(l, t) {
+    for (; Tl !== null;) {
+      var u = Tl;
+      switch (u.tag) {
+        case 0:
+        case 11:
+        case 15:
+          Ft(8, u, t);
+          break;
+        case 23:
+        case 22:
+          if (u.memoizedState !== null && u.memoizedState.cachePool !== null) {
+            var a = u.memoizedState.cachePool.pool;
+            a != null && a.refCount++;
+          }
+          break;
+        case 24:
+          Ga(u.memoizedState.cache);
+      }
+      if (a = u.child, a !== null) a.return = u, Tl = a;
+      else {l: for (u = l; Tl !== null;) {
+          a = Tl;
+          var e = a.sibling, n = a.return;
+          if (Gs(a), a === u) {
+            Tl = null;
+            break l;
+          }
+          if (e !== null) {
+            e.return = n, Tl = e;
+            break l;
+          }
+          Tl = n;
+        }}
+    }
+  }
+  var qd = {
+      getCacheForType: function (l) {
+        var t = Hl(Sl), u = t.data.get(l);
+        return u === void 0 && (u = l(), t.data.set(l, u)), u;
+      },
+    },
+    Yd = typeof WeakMap == "function" ? WeakMap : Map,
+    w = 0,
+    ul = null,
+    Z = null,
+    C = 0,
+    W = 0,
+    Il = null,
+    lu = !1,
+    ca = !1,
+    hc = !1,
+    Qt = 0,
+    il = 0,
+    tu = 0,
+    Hu = 0,
+    oc = 0,
+    st = 0,
+    ia = 0,
+    te = null,
+    jl = null,
+    mc = !1,
+    Sc = 0,
+    vn = 1 / 0,
+    yn = null,
+    uu = null,
+    _l = 0,
+    au = null,
+    sa = null,
+    va = 0,
+    gc = 0,
+    rc = null,
+    Js = null,
+    ue = 0,
+    bc = null;
+  function Pl() {
+    if ((w & 2) !== 0 && C !== 0) return C & -C;
+    if (r.T !== null) {
+      var l = Fu;
+      return l !== 0 ? l : Mc();
+    }
+    return ii();
+  }
+  function ws() {
+    st === 0 && (st = (C & 536870912) === 0 || J ? ei() : 536870912);
+    var l = it.current;
+    return l !== null && (l.flags |= 32), st;
+  }
+  function lt(l, t, u) {
+    (l === ul && (W === 2 || W === 9) || l.cancelPendingCommit !== null) &&
+    (ya(l, 0), eu(l, C, st, !1)),
+      Ta(l, u),
+      ((w & 2) === 0 || l !== ul) &&
+      (l === ul && ((w & 2) === 0 && (Hu |= u), il === 4 && eu(l, C, st, !1)),
+        At(l));
+  }
+  function Ws(l, t, u) {
+    if ((w & 6) !== 0) throw Error(S(327));
+    var a = !u && (t & 124) === 0 && (t & l.expiredLanes) === 0 || ba(l, t),
+      e = a ? Gd(l, t) : Ac(l, t, !0),
+      n = a;
+    do {
+      if (e === 0) {
+        ca && !a && eu(l, t, 0, !1);
+        break;
+      } else {
+        if (u = l.current.alternate, n && !Bd(u)) {
+          e = Ac(l, t, !1), n = !1;
+          continue;
+        }
+        if (e === 2) {
+          if (n = t, l.errorRecoveryDisabledLanes & n) { var f = 0; }
+          else {f = l.pendingLanes & -536870913,
+              f = f !== 0 ? f : f & 536870912 ? 536870912 : 0;}
+          if (f !== 0) {
+            t = f;
+            l: {
+              var c = l;
+              e = te;
+              var i = c.current.memoizedState.isDehydrated;
+              if (i && (ya(c, f).flags |= 256), f = Ac(c, f, !1), f !== 2) {
+                if (hc && !i) {
+                  c.errorRecoveryDisabledLanes |= n, Hu |= n, e = 4;
+                  break l;
+                }
+                n = jl,
+                  jl = e,
+                  n !== null && (jl === null ? jl = n : jl.push.apply(jl, n));
+              }
+              e = f;
+            }
+            if (n = !1, e !== 2) continue;
+          }
+        }
+        if (e === 1) {
+          ya(l, 0), eu(l, t, 0, !0);
+          break;
+        }
+        l: {
+          switch (a = l, n = e, n) {
+            case 0:
+            case 1:
+              throw Error(S(345));
+            case 4:
+              if ((t & 4194048) !== t) break;
+            case 6:
+              eu(a, t, st, !lu);
+              break l;
+            case 2:
+              jl = null;
+              break;
+            case 3:
+            case 5:
+              break;
+            default:
+              throw Error(S(329));
+          }
+          if ((t & 62914560) === t && (e = Sc + 300 - gt(), 10 < e)) {
+            if (eu(a, t, st, !lu), Ee(a, 0, !0) !== 0) break l;
+            a.timeoutHandle = zv(
+              $s.bind(null, a, u, jl, yn, mc, t, st, Hu, ia, lu, n, 2, -0, 0),
+              e,
+            );
+            break l;
+          }
+          $s(a, u, jl, yn, mc, t, st, Hu, ia, lu, n, 0, -0, 0);
+        }
+      }
+      break;
+    } while (!0);
+    At(l);
+  }
+  function $s(l, t, u, a, e, n, f, c, i, h, g, T, o, m) {
+    if (
+      l.timeoutHandle = -1,
+        T = t.subtreeFlags,
+        (T & 8192 || (T & 16785408) === 16785408) &&
+        (se = { stylesheets: null, count: 0, unsuspend: m1 },
+          Cs(t),
+          T = g1(),
+          T !== null)
+    ) {
+      l.cancelPendingCommit = T(
+        uv.bind(null, l, t, n, u, a, e, f, c, i, g, 1, o, m),
+      ), eu(l, n, f, !h);
+      return;
+    }
+    uv(l, t, n, u, a, e, f, c, i);
+  }
+  function Bd(l) {
+    for (var t = l;;) {
+      var u = t.tag;
+      if (
+        (u === 0 || u === 11 || u === 15) && t.flags & 16384 &&
+        (u = t.updateQueue, u !== null && (u = u.stores, u !== null))
+      ) {
+        for (var a = 0; a < u.length; a++) {
+          var e = u[a], n = e.getSnapshot;
+          e = e.value;
+          try {
+            if (!Wl(n(), e)) return !1;
+          } catch {
+            return !1;
+          }
+        }
+      }
+      if (u = t.child, t.subtreeFlags & 16384 && u !== null) {
+        u.return = t, t = u;
+      } else {
+        if (t === l) break;
+        for (; t.sibling === null;) {
+          if (t.return === null || t.return === l) return !0;
+          t = t.return;
+        }
+        t.sibling.return = t.return, t = t.sibling;
+      }
+    }
+    return !0;
+  }
+  function eu(l, t, u, a) {
+    t &= ~oc,
+      t &= ~Hu,
+      l.suspendedLanes |= t,
+      l.pingedLanes &= ~t,
+      a && (l.warmLanes |= t),
+      a = l.expirationTimes;
+    for (var e = t; 0 < e;) {
+      var n = 31 - wl(e), f = 1 << n;
+      a[n] = -1, e &= ~f;
+    }
+    u !== 0 && fi(l, u, t);
+  }
+  function dn() {
+    return (w & 6) === 0 ? (ae(0), !1) : !0;
+  }
+  function Tc() {
+    if (Z !== null) {
+      if (W === 0) { var l = Z.return; }
+      else l = Z, Ht = _u = null, Xf(l), aa = null, wa = 0, l = Z;
+      for (; l !== null;) Us(l.alternate, l), l = l.return;
+      Z = null;
+    }
+  }
+  function ya(l, t) {
+    var u = l.timeoutHandle;
+    u !== -1 && (l.timeoutHandle = -1, Id(u)),
+      u = l.cancelPendingCommit,
+      u !== null && (l.cancelPendingCommit = null, u()),
+      Tc(),
+      ul = l,
+      Z = u = Dt(l.current, null),
+      C = t,
+      W = 0,
+      Il = null,
+      lu = !1,
+      ca = ba(l, t),
+      hc = !1,
+      ia =
+        st =
+        oc =
+        Hu =
+        tu =
+        il =
+          0,
+      jl = te = null,
+      mc = !1,
+      (t & 8) !== 0 && (t |= t & 32);
+    var a = l.entangledLanes;
+    if (a !== 0) {
+      for (l = l.entanglements, a &= t; 0 < a;) {
+        var e = 31 - wl(a), n = 1 << e;
+        t |= l[e], a &= ~n;
+      }
+    }
+    return Qt = t, Ye(), u;
+  }
+  function ks(l, t) {
+    Q = null,
+      r.H = Ie,
+      t === Qa || t === Ce
+        ? (t = h0(), W = 3)
+        : t === v0
+        ? (t = h0(), W = 4)
+        : W = t === os
+          ? 8
+          : t !== null && typeof t == "object" && typeof t.then == "function"
+          ? 6
+          : 1,
+      Il = t,
+      Z === null && (il = 1, an(l, et(t, l.current)));
+  }
+  function Fs() {
+    var l = r.H;
+    return r.H = Ie, l === null ? Ie : l;
+  }
+  function Is() {
+    var l = r.A;
+    return r.A = qd, l;
+  }
+  function Ec() {
+    il = 4,
+      lu || (C & 4194048) !== C && it.current !== null || (ca = !0),
+      (tu & 134217727) === 0 && (Hu & 134217727) === 0 || ul === null ||
+      eu(ul, C, st, !1);
+  }
+  function Ac(l, t, u) {
+    var a = w;
+    w |= 2;
+    var e = Fs(), n = Is();
+    (ul !== l || C !== t) && (yn = null, ya(l, t)), t = !1;
+    var f = il;
+    l: do try {
+      if (W !== 0 && Z !== null) {
+        var c = Z, i = Il;
+        switch (W) {
+          case 8:
+            Tc(), f = 6;
+            break l;
+          case 3:
+          case 2:
+          case 9:
+          case 6:
+            it.current === null && (t = !0);
+            var h = W;
+            if (W = 0, Il = null, da(l, c, i, h), u && ca) {
+              f = 0;
+              break l;
+            }
+            break;
+          default:
+            h = W, W = 0, Il = null, da(l, c, i, h);
+        }
+      }
+      pd(), f = il;
+      break;
+    } catch (g) {
+      ks(l, g);
+    } while (!0);
+    return t && l.shellSuspendCounter++,
+      Ht = _u = null,
+      w = a,
+      r.H = e,
+      r.A = n,
+      Z === null && (ul = null, C = 0, Ye()),
+      f;
+  }
+  function pd() {
+    for (; Z !== null;) Ps(Z);
+  }
+  function Gd(l, t) {
+    var u = w;
+    w |= 2;
+    var a = Fs(), e = Is();
+    ul !== l || C !== t
+      ? (yn = null, vn = gt() + 500, ya(l, t))
+      : ca = ba(l, t);
+    l: do try {
+      if (W !== 0 && Z !== null) {
+        t = Z;
+        var n = Il;
+        t: switch (W) {
+          case 1:
+            W = 0, Il = null, da(l, t, n, 1);
+            break;
+          case 2:
+          case 9:
+            if (y0(n)) {
+              W = 0, Il = null, lv(t);
+              break;
+            }
+            t = function () {
+              W !== 2 && W !== 9 || ul !== l || (W = 7), At(l);
+            }, n.then(t, t);
+            break l;
+          case 3:
+            W = 7;
+            break l;
+          case 4:
+            W = 5;
+            break l;
+          case 7:
+            y0(n)
+              ? (W = 0, Il = null, lv(t))
+              : (W = 0, Il = null, da(l, t, n, 7));
+            break;
+          case 5:
+            var f = null;
+            switch (Z.tag) {
+              case 26:
+                f = Z.memoizedState;
+              case 5:
+              case 27:
+                var c = Z;
+                if (!f || pv(f)) {
+                  W = 0, Il = null;
+                  var i = c.sibling;
+                  if (i !== null) Z = i;
+                  else {
+                    var h = c.return;
+                    h !== null ? (Z = h, hn(h)) : Z = null;
+                  }
+                  break t;
+                }
+            }
+            W = 0, Il = null, da(l, t, n, 5);
+            break;
+          case 6:
+            W = 0, Il = null, da(l, t, n, 6);
+            break;
+          case 8:
+            Tc(), il = 6;
+            break l;
+          default:
+            throw Error(S(462));
+        }
+      }
+      Xd();
+      break;
+    } catch (g) {
+      ks(l, g);
+    } while (!0);
+    return Ht = _u = null,
+      r.H = a,
+      r.A = e,
+      w = u,
+      Z !== null ? 0 : (ul = null, C = 0, Ye(), il);
+  }
+  function Xd() {
+    for (; Z !== null && !ny();) Ps(Z);
+  }
+  function Ps(l) {
+    var t = Ms(l.alternate, l, Qt);
+    l.memoizedProps = l.pendingProps, t === null ? hn(l) : Z = t;
+  }
+  function lv(l) {
+    var t = l, u = t.alternate;
+    switch (t.tag) {
+      case 15:
+      case 0:
+        t = Ts(u, t, t.pendingProps, t.type, void 0, C);
+        break;
+      case 11:
+        t = Ts(u, t, t.pendingProps, t.type.render, t.ref, C);
+        break;
+      case 5:
+        Xf(t);
+      default:
+        Us(u, t), t = Z = t0(t, Qt), t = Ms(u, t, Qt);
+    }
+    l.memoizedProps = l.pendingProps, t === null ? hn(l) : Z = t;
+  }
+  function da(l, t, u, a) {
+    Ht = _u = null, Xf(t), aa = null, wa = 0;
+    var e = t.return;
+    try {
+      if (Md(l, e, t, u, C)) {
+        il = 1, an(l, et(u, l.current)), Z = null;
+        return;
+      }
+    } catch (n) {
+      if (e !== null) throw Z = e, n;
+      il = 1, an(l, et(u, l.current)), Z = null;
+      return;
+    }
+    t.flags & 32768
+      ? (J || a === 1
+        ? l = !0
+        : ca || (C & 536870912) !== 0
+        ? l = !1
+        : (lu = l = !0,
+          (a === 2 || a === 9 || a === 3 || a === 6) &&
+          (a = it.current, a !== null && a.tag === 13 && (a.flags |= 16384))),
+        tv(t, l))
+      : hn(t);
+  }
+  function hn(l) {
+    var t = l;
+    do {
+      if ((t.flags & 32768) !== 0) {
+        tv(t, lu);
+        return;
+      }
+      l = t.return;
+      var u = Ud(t.alternate, t, Qt);
+      if (u !== null) {
+        Z = u;
+        return;
+      }
+      if (t = t.sibling, t !== null) {
+        Z = t;
+        return;
+      }
+      Z = t = l;
+    } while (t !== null);
+    il === 0 && (il = 5);
+  }
+  function tv(l, t) {
+    do {
+      var u = Rd(l.alternate, l);
+      if (u !== null) {
+        u.flags &= 32767, Z = u;
+        return;
+      }
+      if (
+        u = l.return,
+          u !== null &&
+          (u.flags |= 32768, u.subtreeFlags = 0, u.deletions = null),
+          !t && (l = l.sibling, l !== null)
+      ) {
+        Z = l;
+        return;
+      }
+      Z = l = u;
+    } while (l !== null);
+    il = 6, Z = null;
+  }
+  function uv(l, t, u, a, e, n, f, c, i) {
+    l.cancelPendingCommit = null;
+    do on(); while (_l !== 0);
+    if ((w & 6) !== 0) throw Error(S(327));
+    if (t !== null) {
+      if (t === l.current) throw Error(S(177));
+      if (
+        n = t.lanes | t.childLanes,
+          n |= df,
+          my(l, u, n, f, c, i),
+          l === ul && (Z = ul = null, C = 0),
+          sa = t,
+          au = l,
+          va = u,
+          gc = n,
+          rc = e,
+          Js = a,
+          (t.subtreeFlags & 10256) !== 0 || (t.flags & 10256) !== 0
+            ? (l.callbackNode = null,
+              l.callbackPriority = 0,
+              jd(re, function () {
+                return cv(), null;
+              }))
+            : (l.callbackNode = null, l.callbackPriority = 0),
+          a = (t.flags & 13878) !== 0,
+          (t.subtreeFlags & 13878) !== 0 || a
+      ) {
+        a = r.T, r.T = null, e = _.p, _.p = 2, f = w, w |= 4;
+        try {
+          Hd(l, t, u);
+        } finally {
+          w = f, _.p = e, r.T = a;
+        }
+      }
+      _l = 1, av(), ev(), nv();
+    }
+  }
+  function av() {
+    if (_l === 1) {
+      _l = 0;
+      var l = au, t = sa, u = (t.flags & 13878) !== 0;
+      if ((t.subtreeFlags & 13878) !== 0 || u) {
+        u = r.T, r.T = null;
+        var a = _.p;
+        _.p = 2;
+        var e = w;
+        w |= 4;
+        try {
+          xs(t, l);
+          var n = Bc,
+            f = Ki(l.containerInfo),
+            c = n.focusedElem,
+            i = n.selectionRange;
+          if (
+            f !== c && c && c.ownerDocument &&
+            Li(c.ownerDocument.documentElement, c)
+          ) {
+            if (i !== null && ff(c)) {
+              var h = i.start, g = i.end;
+              if (g === void 0 && (g = h), "selectionStart" in c) {
+                c.selectionStart = h,
+                  c.selectionEnd = Math.min(g, c.value.length);
+              } else {
+                var T = c.ownerDocument || document,
+                  o = T && T.defaultView || window;
+                if (o.getSelection) {
+                  var m = o.getSelection(),
+                    p = c.textContent.length,
+                    q = Math.min(i.start, p),
+                    F = i.end === void 0 ? q : Math.min(i.end, p);
+                  !m.extend && q > F && (f = F, F = q, q = f);
+                  var y = Vi(c, q), v = Vi(c, F);
+                  if (
+                    y && v &&
+                    (m.rangeCount !== 1 || m.anchorNode !== y.node ||
+                      m.anchorOffset !== y.offset || m.focusNode !== v.node ||
+                      m.focusOffset !== v.offset)
+                  ) {
+                    var d = T.createRange();
+                    d.setStart(y.node, y.offset),
+                      m.removeAllRanges(),
+                      q > F
+                        ? (m.addRange(d), m.extend(v.node, v.offset))
+                        : (d.setEnd(v.node, v.offset), m.addRange(d));
+                  }
+                }
+              }
+            }
+            for (T = [], m = c; m = m.parentNode;) {
+              m.nodeType === 1 &&
+                T.push({ element: m, left: m.scrollLeft, top: m.scrollTop });
+            }
+            for (
+              typeof c.focus == "function" && c.focus(), c = 0;
+              c < T.length;
+              c++
+            ) {
+              var b = T[c];
+              b.element.scrollLeft = b.left, b.element.scrollTop = b.top;
+            }
+          }
+          Mn = !!Yc, Bc = Yc = null;
+        } finally {
+          w = e, _.p = a, r.T = u;
+        }
+      }
+      l.current = t, _l = 2;
+    }
+  }
+  function ev() {
+    if (_l === 2) {
+      _l = 0;
+      var l = au, t = sa, u = (t.flags & 8772) !== 0;
+      if ((t.subtreeFlags & 8772) !== 0 || u) {
+        u = r.T, r.T = null;
+        var a = _.p;
+        _.p = 2;
+        var e = w;
+        w |= 4;
+        try {
+          ps(l, t.alternate, t);
+        } finally {
+          w = e, _.p = a, r.T = u;
+        }
+      }
+      _l = 3;
+    }
+  }
+  function nv() {
+    if (_l === 4 || _l === 3) {
+      _l = 0, fy();
+      var l = au, t = sa, u = va, a = Js;
+      (t.subtreeFlags & 10256) !== 0 || (t.flags & 10256) !== 0
+        ? _l = 5
+        : (_l = 0, sa = au = null, fv(l, l.pendingLanes));
+      var e = l.pendingLanes;
+      if (
+        e === 0 && (uu = null),
+          xn(u),
+          t = t.stateNode,
+          Jl && typeof Jl.onCommitFiberRoot == "function"
+      ) {
+        try {
+          Jl.onCommitFiberRoot(ra, t, void 0, (t.current.flags & 128) === 128);
+        } catch {}
+      }
+      if (a !== null) {
+        t = r.T, e = _.p, _.p = 2, r.T = null;
+        try {
+          for (var n = l.onRecoverableError, f = 0; f < a.length; f++) {
+            var c = a[f];
+            n(c.value, { componentStack: c.stack });
+          }
+        } finally {
+          r.T = t, _.p = e;
+        }
+      }
+      (va & 3) !== 0 && on(),
+        At(l),
+        e = l.pendingLanes,
+        (u & 4194090) !== 0 && (e & 42) !== 0
+          ? l === bc ? ue++ : (ue = 0, bc = l)
+          : ue = 0,
+        ae(0);
+    }
+  }
+  function fv(l, t) {
+    (l.pooledCacheLanes &= t) === 0 &&
+      (t = l.pooledCache, t != null && (l.pooledCache = null, Ga(t)));
+  }
+  function on(l) {
+    return av(), ev(), nv(), cv();
+  }
+  function cv() {
+    if (_l !== 5) return !1;
+    var l = au, t = gc;
+    gc = 0;
+    var u = xn(va), a = r.T, e = _.p;
+    try {
+      _.p = 32 > u ? 32 : u, r.T = null, u = rc, rc = null;
+      var n = au, f = va;
+      if (_l = 0, sa = au = null, va = 0, (w & 6) !== 0) throw Error(S(331));
+      var c = w;
+      if (
+        w |= 4,
+          Ls(n.current),
+          js(n, n.current, f, u),
+          w = c,
+          ae(0, !1),
+          Jl && typeof Jl.onPostCommitFiberRoot == "function"
+      ) {
+        try {
+          Jl.onPostCommitFiberRoot(ra, n);
+        } catch {}
+      }
+      return !0;
+    } finally {
+      _.p = e, r.T = a, fv(l, t);
+    }
+  }
+  function iv(l, t, u) {
+    t = et(u, t),
+      t = Ff(l.stateNode, t, 2),
+      l = wt(l, t, 2),
+      l !== null && (Ta(l, 2), At(l));
+  }
+  function P(l, t, u) {
+    if (l.tag === 3) iv(l, l, u);
+    else {for (; t !== null;) {
+        if (t.tag === 3) {
+          iv(t, l, u);
+          break;
+        } else if (t.tag === 1) {
+          var a = t.stateNode;
+          if (
+            typeof t.type.getDerivedStateFromError == "function" ||
+            typeof a.componentDidCatch == "function" &&
+              (uu === null || !uu.has(a))
+          ) {
+            l = et(u, l),
+              u = ds(2),
+              a = wt(t, u, 2),
+              a !== null && (hs(u, a, t, l), Ta(a, 2), At(a));
+            break;
+          }
+        }
+        t = t.return;
+      }}
+  }
+  function zc(l, t, u) {
+    var a = l.pingCache;
+    if (a === null) {
+      a = l.pingCache = new Yd();
+      var e = new Set();
+      a.set(t, e);
+    } else e = a.get(t), e === void 0 && (e = new Set(), a.set(t, e));
+    e.has(u) || (hc = !0, e.add(u), l = Qd.bind(null, l, t, u), t.then(l, l));
+  }
+  function Qd(l, t, u) {
+    var a = l.pingCache;
+    a !== null && a.delete(t),
+      l.pingedLanes |= l.suspendedLanes & u,
+      l.warmLanes &= ~u,
+      ul === l && (C & u) === u &&
+      (il === 4 || il === 3 && (C & 62914560) === C && 300 > gt() - Sc
+        ? (w & 2) === 0 && ya(l, 0)
+        : oc |= u,
+        ia === C && (ia = 0)),
+      At(l);
+  }
+  function sv(l, t) {
+    t === 0 && (t = ni()), l = wu(l, t), l !== null && (Ta(l, t), At(l));
+  }
+  function xd(l) {
+    var t = l.memoizedState, u = 0;
+    t !== null && (u = t.retryLane), sv(l, u);
+  }
+  function Zd(l, t) {
+    var u = 0;
+    switch (l.tag) {
+      case 13:
+        var a = l.stateNode, e = l.memoizedState;
+        e !== null && (u = e.retryLane);
+        break;
+      case 19:
+        a = l.stateNode;
+        break;
+      case 22:
+        a = l.stateNode._retryCache;
+        break;
+      default:
+        throw Error(S(314));
+    }
+    a !== null && a.delete(t), sv(l, u);
+  }
+  function jd(l, t) {
+    return pn(l, t);
+  }
+  var mn = null, ha = null, _c = !1, Sn = !1, Oc = !1, Nu = 0;
+  function At(l) {
+    l !== ha && l.next === null &&
+    (ha === null ? mn = ha = l : ha = ha.next = l),
+      Sn = !0,
+      _c || (_c = !0, Vd());
+  }
+  function ae(l, t) {
+    if (!Oc && Sn) {
+      Oc = !0;
+      do for (var u = !1, a = mn; a !== null;) {
+        if (l !== 0) {
+          var e = a.pendingLanes;
+          if (e === 0) { var n = 0; }
+          else {
+            var f = a.suspendedLanes, c = a.pingedLanes;
+            n = (1 << 31 - wl(42 | l) + 1) - 1,
+              n &= e & ~(f & ~c),
+              n = n & 201326741 ? n & 201326741 | 1 : n ? n | 2 : 0;
+          }
+          n !== 0 && (u = !0, hv(a, n));
+        } else {n = C,
+            n = Ee(
+              a,
+              a === ul ? n : 0,
+              a.cancelPendingCommit !== null || a.timeoutHandle !== -1,
+            ),
+            (n & 3) === 0 || ba(a, n) || (u = !0, hv(a, n));}
+        a = a.next;
+      } while (u);
+      Oc = !1;
+    }
+  }
+  function Cd() {
+    vv();
+  }
+  function vv() {
+    Sn = _c = !1;
+    var l = 0;
+    Nu !== 0 && (Fd() && (l = Nu), Nu = 0);
+    for (var t = gt(), u = null, a = mn; a !== null;) {
+      var e = a.next, n = yv(a, t);
+      n === 0
+        ? (a.next = null,
+          u === null ? mn = e : u.next = e,
+          e === null && (ha = u))
+        : (u = a, (l !== 0 || (n & 3) !== 0) && (Sn = !0)), a = e;
+    }
+    ae(l);
+  }
+  function yv(l, t) {
+    for (
+      var u = l.suspendedLanes,
+        a = l.pingedLanes,
+        e = l.expirationTimes,
+        n = l.pendingLanes & -62914561;
+      0 < n;
+    ) {
+      var f = 31 - wl(n), c = 1 << f, i = e[f];
+      i === -1
+        ? ((c & u) === 0 || (c & a) !== 0) && (e[f] = oy(c, t))
+        : i <= t && (l.expiredLanes |= c), n &= ~c;
+    }
+    if (
+      t = ul,
+        u = C,
+        u = Ee(
+          l,
+          l === t ? u : 0,
+          l.cancelPendingCommit !== null || l.timeoutHandle !== -1,
+        ),
+        a = l.callbackNode,
+        u === 0 || l === t && (W === 2 || W === 9) ||
+        l.cancelPendingCommit !== null
+    ) {
+      return a !== null && a !== null && Gn(a),
+        l.callbackNode = null,
+        l.callbackPriority = 0;
+    }
+    if ((u & 3) === 0 || ba(l, u)) {
+      if (t = u & -u, t === l.callbackPriority) return t;
+      switch (a !== null && Gn(a), xn(u)) {
+        case 2:
+        case 8:
+          u = ui;
+          break;
+        case 32:
+          u = re;
+          break;
+        case 268435456:
+          u = ai;
+          break;
+        default:
+          u = re;
+      }
+      return a = dv.bind(null, l),
+        u = pn(u, a),
+        l.callbackPriority = t,
+        l.callbackNode = u,
+        t;
+    }
+    return a !== null && a !== null && Gn(a),
+      l.callbackPriority = 2,
+      l.callbackNode = null,
+      2;
+  }
+  function dv(l, t) {
+    if (_l !== 0 && _l !== 5) {
+      return l.callbackNode = null, l.callbackPriority = 0, null;
+    }
+    var u = l.callbackNode;
+    if (on() && l.callbackNode !== u) return null;
+    var a = C;
+    return a = Ee(
+      l,
+      l === ul ? a : 0,
+      l.cancelPendingCommit !== null || l.timeoutHandle !== -1,
+    ),
+      a === 0
+        ? null
+        : (Ws(l, a, t),
+          yv(l, gt()),
+          l.callbackNode != null && l.callbackNode === u
+            ? dv.bind(null, l)
+            : null);
+  }
+  function hv(l, t) {
+    if (on()) return null;
+    Ws(l, t, !0);
+  }
+  function Vd() {
+    Pd(function () {
+      (w & 6) !== 0 ? pn(ti, Cd) : vv();
+    });
+  }
+  function Mc() {
+    return Nu === 0 && (Nu = ei()), Nu;
+  }
+  function ov(l) {
+    return l == null || typeof l == "symbol" || typeof l == "boolean"
+      ? null
+      : typeof l == "function"
+      ? l
+      : Me("" + l);
+  }
+  function mv(l, t) {
+    var u = t.ownerDocument.createElement("input");
+    return u.name = t.name,
+      u.value = t.value,
+      l.id && u.setAttribute("form", l.id),
+      t.parentNode.insertBefore(u, t),
+      l = new FormData(l),
+      u.parentNode.removeChild(u),
+      l;
+  }
+  function Ld(l, t, u, a, e) {
+    if (t === "submit" && u && u.stateNode === e) {
+      var n = ov((e[Xl] || null).action), f = a.submitter;
+      f &&
+        (t = (t = f[Xl] || null)
+          ? ov(t.formAction)
+          : f.getAttribute("formAction"),
+          t !== null && (n = t, f = null));
+      var c = new He("action", "action", null, a, e);
+      l.push({
+        event: c,
+        listeners: [{
+          instance: null,
+          listener: function () {
+            if (a.defaultPrevented) {
+              if (Nu !== 0) {
+                var i = f ? mv(e, f) : new FormData(e);
+                Jf(
+                  u,
+                  { pending: !0, data: i, method: e.method, action: n },
+                  null,
+                  i,
+                );
+              }
+            } else {typeof n == "function" &&
+                (c.preventDefault(),
+                  i = f ? mv(e, f) : new FormData(e),
+                  Jf(
+                    u,
+                    { pending: !0, data: i, method: e.method, action: n },
+                    n,
+                    i,
+                  ));}
+          },
+          currentTarget: e,
+        }],
+      });
+    }
+  }
+  for (var Dc = 0; Dc < yf.length; Dc++) {
+    var Uc = yf[Dc],
+      Kd = Uc.toLowerCase(),
+      Jd = Uc[0].toUpperCase() + Uc.slice(1);
+    ht(Kd, "on" + Jd);
+  }
+  ht(Wi, "onAnimationEnd"),
+    ht($i, "onAnimationIteration"),
+    ht(ki, "onAnimationStart"),
+    ht("dblclick", "onDoubleClick"),
+    ht("focusin", "onFocus"),
+    ht("focusout", "onBlur"),
+    ht(sd, "onTransitionRun"),
+    ht(vd, "onTransitionStart"),
+    ht(yd, "onTransitionCancel"),
+    ht(Fi, "onTransitionEnd"),
+    Xu("onMouseEnter", ["mouseout", "mouseover"]),
+    Xu("onMouseLeave", ["mouseout", "mouseover"]),
+    Xu("onPointerEnter", ["pointerout", "pointerover"]),
+    Xu("onPointerLeave", ["pointerout", "pointerover"]),
+    mu(
+      "onChange",
+      "change click focusin focusout input keydown keyup selectionchange".split(
+        " ",
+      ),
+    ),
+    mu(
+      "onSelect",
+      "focusout contextmenu dragend focusin keydown keyup mousedown mouseup selectionchange"
+        .split(" "),
+    ),
+    mu("onBeforeInput", ["compositionend", "keypress", "textInput", "paste"]),
+    mu(
+      "onCompositionEnd",
+      "compositionend focusout keydown keypress keyup mousedown".split(" "),
+    ),
+    mu(
+      "onCompositionStart",
+      "compositionstart focusout keydown keypress keyup mousedown".split(" "),
+    ),
+    mu(
+      "onCompositionUpdate",
+      "compositionupdate focusout keydown keypress keyup mousedown".split(" "),
+    );
+  var ee =
+      "abort canplay canplaythrough durationchange emptied encrypted ended error loadeddata loadedmetadata loadstart pause play playing progress ratechange resize seeked seeking stalled suspend timeupdate volumechange waiting"
+        .split(" "),
+    wd = new Set(
+      "beforetoggle cancel close invalid load scroll scrollend toggle".split(
+        " ",
+      ).concat(ee),
+    );
+  function Sv(l, t) {
+    t = (t & 4) !== 0;
+    for (var u = 0; u < l.length; u++) {
+      var a = l[u], e = a.event;
+      a = a.listeners;
+      l: {
+        var n = void 0;
+        if (t) {
+          for (var f = a.length - 1; 0 <= f; f--) {
+            var c = a[f], i = c.instance, h = c.currentTarget;
+            if (c = c.listener, i !== n && e.isPropagationStopped()) break l;
+            n = c, e.currentTarget = h;
+            try {
+              n(e);
+            } catch (g) {
+              un(g);
+            }
+            e.currentTarget = null, n = i;
+          }
+        } else {for (f = 0; f < a.length; f++) {
+            if (
+              c = a[f],
+                i = c.instance,
+                h = c.currentTarget,
+                c = c.listener,
+                i !== n && e.isPropagationStopped()
+            ) break l;
+            n = c, e.currentTarget = h;
+            try {
+              n(e);
+            } catch (g) {
+              un(g);
+            }
+            e.currentTarget = null, n = i;
+          }}
+      }
+    }
+  }
+  function j(l, t) {
+    var u = t[Zn];
+    u === void 0 && (u = t[Zn] = new Set());
+    var a = l + "__bubble";
+    u.has(a) || (gv(t, l, 2, !1), u.add(a));
+  }
+  function Rc(l, t, u) {
+    var a = 0;
+    t && (a |= 4), gv(u, l, a, t);
+  }
+  var gn = "_reactListening" + Math.random().toString(36).slice(2);
+  function Hc(l) {
+    if (!l[gn]) {
+      l[gn] = !0,
+        vi.forEach(function (u) {
+          u !== "selectionchange" && (wd.has(u) || Rc(u, !1, l), Rc(u, !0, l));
+        });
+      var t = l.nodeType === 9 ? l : l.ownerDocument;
+      t === null || t[gn] || (t[gn] = !0, Rc("selectionchange", !1, t));
+    }
+  }
+  function gv(l, t, u, a) {
+    switch (jv(t)) {
+      case 2:
+        var e = T1;
+        break;
+      case 8:
+        e = E1;
+        break;
+      default:
+        e = Lc;
+    }
+    u = e.bind(null, t, u, l),
+      e = void 0,
+      !Fn || t !== "touchstart" && t !== "touchmove" && t !== "wheel" ||
+      (e = !0),
+      a
+        ? e !== void 0
+          ? l.addEventListener(t, u, { capture: !0, passive: e })
+          : l.addEventListener(t, u, !0)
+        : e !== void 0
+        ? l.addEventListener(t, u, { passive: e })
+        : l.addEventListener(t, u, !1);
+  }
+  function Nc(l, t, u, a, e) {
+    var n = a;
+    if ((t & 1) === 0 && (t & 2) === 0 && a !== null) {
+      l: for (;;) {
+        if (a === null) return;
+        var f = a.tag;
+        if (f === 3 || f === 4) {
+          var c = a.stateNode.containerInfo;
+          if (c === e) break;
+          if (f === 4) {
+            for (f = a.return; f !== null;) {
+              var i = f.tag;
+              if (
+                (i === 3 || i === 4) && f.stateNode.containerInfo === e
+              ) return;
+              f = f.return;
+            }
+          }
+          for (; c !== null;) {
+            if (f = Bu(c), f === null) return;
+            if (i = f.tag, i === 5 || i === 6 || i === 26 || i === 27) {
+              a = n = f;
+              continue l;
+            }
+            c = c.parentNode;
+          }
+        }
+        a = a.return;
+      }
+    }
+    _i(function () {
+      var h = n, g = $n(u), T = [];
+      l: {
+        var o = Ii.get(l);
+        if (o !== void 0) {
+          var m = He, p = l;
+          switch (l) {
+            case "keypress":
+              if (Ue(u) === 0) break l;
+            case "keydown":
+            case "keyup":
+              m = jy;
+              break;
+            case "focusin":
+              p = "focus", m = tf;
+              break;
+            case "focusout":
+              p = "blur", m = tf;
+              break;
+            case "beforeblur":
+            case "afterblur":
+              m = tf;
+              break;
+            case "click":
+              if (u.button === 2) break l;
+            case "auxclick":
+            case "dblclick":
+            case "mousedown":
+            case "mousemove":
+            case "mouseup":
+            case "mouseout":
+            case "mouseover":
+            case "contextmenu":
+              m = Di;
+              break;
+            case "drag":
+            case "dragend":
+            case "dragenter":
+            case "dragexit":
+            case "dragleave":
+            case "dragover":
+            case "dragstart":
+            case "drop":
+              m = Ry;
+              break;
+            case "touchcancel":
+            case "touchend":
+            case "touchmove":
+            case "touchstart":
+              m = Ly;
+              break;
+            case Wi:
+            case $i:
+            case ki:
+              m = qy;
+              break;
+            case Fi:
+              m = Jy;
+              break;
+            case "scroll":
+            case "scrollend":
+              m = Dy;
+              break;
+            case "wheel":
+              m = Wy;
+              break;
+            case "copy":
+            case "cut":
+            case "paste":
+              m = By;
+              break;
+            case "gotpointercapture":
+            case "lostpointercapture":
+            case "pointercancel":
+            case "pointerdown":
+            case "pointermove":
+            case "pointerout":
+            case "pointerover":
+            case "pointerup":
+              m = Ri;
+              break;
+            case "toggle":
+            case "beforetoggle":
+              m = ky;
+          }
+          var q = (t & 4) !== 0,
+            F = !q && (l === "scroll" || l === "scrollend"),
+            y = q ? o !== null ? o + "Capture" : null : o;
+          q = [];
+          for (var v = h, d; v !== null;) {
+            var b = v;
+            if (
+              d = b.stateNode,
+                b = b.tag,
+                b !== 5 && b !== 26 && b !== 27 || d === null || y === null ||
+                (b = za(v, y), b != null && q.push(ne(v, b, d))),
+                F
+            ) break;
+            v = v.return;
+          }
+          0 < q.length &&
+            (o = new m(o, p, null, u, g), T.push({ event: o, listeners: q }));
+        }
+      }
+      if ((t & 7) === 0) {
+        l: {
+          if (
+            o = l === "mouseover" || l === "pointerover",
+              m = l === "mouseout" || l === "pointerout",
+              o && u !== Wn && (p = u.relatedTarget || u.fromElement) &&
+              (Bu(p) || p[Yu])
+          ) break l;
+          if (
+            (m || o) &&
+            (o = g.window === g
+              ? g
+              : (o = g.ownerDocument)
+              ? o.defaultView || o.parentWindow
+              : window,
+              m
+                ? (p = u.relatedTarget || u.toElement,
+                  m = h,
+                  p = p ? Bu(p) : null,
+                  p !== null &&
+                  (F = ml(p),
+                    q = p.tag,
+                    p !== F || q !== 5 && q !== 27 && q !== 6) &&
+                  (p = null))
+                : (m = null, p = h),
+              m !== p)
+          ) {
+            if (
+              q = Di,
+                b = "onMouseLeave",
+                y = "onMouseEnter",
+                v = "mouse",
+                (l === "pointerout" || l === "pointerover") &&
+                (q = Ri,
+                  b = "onPointerLeave",
+                  y = "onPointerEnter",
+                  v = "pointer"),
+                F = m == null ? o : Aa(m),
+                d = p == null ? o : Aa(p),
+                o = new q(b, v + "leave", m, u, g),
+                o.target = F,
+                o.relatedTarget = d,
+                b = null,
+                Bu(g) === h &&
+                (q = new q(y, v + "enter", p, u, g),
+                  q.target = d,
+                  q.relatedTarget = F,
+                  b = q),
+                F = b,
+                m && p
+            ) {
+              t: {
+                for (q = m, y = p, v = 0, d = q; d; d = oa(d)) v++;
+                for (d = 0, b = y; b; b = oa(b)) d++;
+                for (; 0 < v - d;) q = oa(q), v--;
+                for (; 0 < d - v;) y = oa(y), d--;
+                for (; v--;) {
+                  if (q === y || y !== null && q === y.alternate) break t;
+                  q = oa(q), y = oa(y);
+                }
+                q = null;
+              }
+            } else q = null;
+            m !== null && rv(T, o, m, q, !1),
+              p !== null && F !== null && rv(T, F, p, q, !0);
+          }
+        }
+        l: {
+          if (
+            o = h ? Aa(h) : window,
+              m = o.nodeName && o.nodeName.toLowerCase(),
+              m === "select" || m === "input" && o.type === "file"
+          ) { var M = Xi; } else if (pi(o)) {
+            if (Qi) M = fd;
+            else {
+              M = ed;
+              var x = ad;
+            }
+          } else {m = o.nodeName,
+              !m || m.toLowerCase() !== "input" ||
+                o.type !== "checkbox" && o.type !== "radio"
+                ? h && wn(h.elementType) && (M = Xi)
+                : M = nd;}
+          if (M && (M = M(l, h))) {
+            Gi(T, M, u, g);
+            break l;
+          }
+          x && x(l, o, h),
+            l === "focusout" && h && o.type === "number" &&
+            h.memoizedProps.value != null && Jn(o, "number", o.value);
+        }
+        switch (x = h ? Aa(h) : window, l) {
+          case "focusin":
+            (pi(x) || x.contentEditable === "true") &&
+              (Lu = x, cf = h, Na = null);
+            break;
+          case "focusout":
+            Na = cf = Lu = null;
+            break;
+          case "mousedown":
+            sf = !0;
+            break;
+          case "contextmenu":
+          case "mouseup":
+          case "dragend":
+            sf = !1, Ji(T, u, g);
+            break;
+          case "selectionchange":
+            if (id) break;
+          case "keydown":
+          case "keyup":
+            Ji(T, u, g);
+        }
+        var U;
+        if (af) {
+          l: {
+            switch (l) {
+              case "compositionstart":
+                var Y = "onCompositionStart";
+                break l;
+              case "compositionend":
+                Y = "onCompositionEnd";
+                break l;
+              case "compositionupdate":
+                Y = "onCompositionUpdate";
+                break l;
+            }
+            Y = void 0;
+          }
+        } else {Vu
+            ? Yi(l, u) && (Y = "onCompositionEnd")
+            : l === "keydown" && u.keyCode === 229 &&
+              (Y = "onCompositionStart");}
+        Y &&
+        (Hi && u.locale !== "ko" &&
+          (Vu || Y !== "onCompositionStart"
+            ? Y === "onCompositionEnd" && Vu && (U = Oi())
+            : (Vt = g,
+              In = "value" in Vt ? Vt.value : Vt.textContent,
+              Vu = !0)),
+          x = rn(h, Y),
+          0 < x.length &&
+          (Y = new Ui(Y, l, null, u, g),
+            T.push({ event: Y, listeners: x }),
+            U ? Y.data = U : (U = Bi(u), U !== null && (Y.data = U)))),
+          (U = Iy ? Py(l, u) : ld(l, u)) &&
+          (Y = rn(h, "onBeforeInput"),
+            0 < Y.length &&
+            (x = new Ui("onBeforeInput", "beforeinput", null, u, g),
+              T.push({ event: x, listeners: Y }),
+              x.data = U)),
+          Ld(T, l, h, u, g);
+      }
+      Sv(T, t);
+    });
+  }
+  function ne(l, t, u) {
+    return { instance: l, listener: t, currentTarget: u };
+  }
+  function rn(l, t) {
+    for (var u = t + "Capture", a = []; l !== null;) {
+      var e = l, n = e.stateNode;
+      if (
+        e = e.tag,
+          e !== 5 && e !== 26 && e !== 27 || n === null ||
+          (e = za(l, u),
+            e != null && a.unshift(ne(l, e, n)),
+            e = za(l, t),
+            e != null && a.push(ne(l, e, n))),
+          l.tag === 3
+      ) return a;
+      l = l.return;
+    }
+    return [];
+  }
+  function oa(l) {
+    if (l === null) return null;
+    do l = l.return; while (l && l.tag !== 5 && l.tag !== 27);
+    return l || null;
+  }
+  function rv(l, t, u, a, e) {
+    for (var n = t._reactName, f = []; u !== null && u !== a;) {
+      var c = u, i = c.alternate, h = c.stateNode;
+      if (c = c.tag, i !== null && i === a) break;
+      c !== 5 && c !== 26 && c !== 27 || h === null ||
+      (i = h,
+        e
+          ? (h = za(u, n), h != null && f.unshift(ne(u, h, i)))
+          : e || (h = za(u, n), h != null && f.push(ne(u, h, i)))),
+        u = u.return;
+    }
+    f.length !== 0 && l.push({ event: t, listeners: f });
+  }
+  var Wd = /\r\n?/g, $d = /\u0000|\uFFFD/g;
+  function bv(l) {
+    return (typeof l == "string" ? l : "" + l).replace(
+      Wd,
+      `
+`,
+    ).replace($d, "");
+  }
+  function Tv(l, t) {
+    return t = bv(t), bv(l) === t;
+  }
+  function bn() {}
+  function k(l, t, u, a, e, n) {
+    switch (u) {
+      case "children":
+        typeof a == "string"
+          ? t === "body" || t === "textarea" && a === "" || Zu(l, a)
+          : (typeof a == "number" || typeof a == "bigint") && t !== "body" &&
+            Zu(l, "" + a);
+        break;
+      case "className":
+        ze(l, "class", a);
+        break;
+      case "tabIndex":
+        ze(l, "tabindex", a);
+        break;
+      case "dir":
+      case "role":
+      case "viewBox":
+      case "width":
+      case "height":
+        ze(l, u, a);
+        break;
+      case "style":
+        Ai(l, a, n);
+        break;
+      case "data":
+        if (t !== "object") {
+          ze(l, "data", a);
+          break;
+        }
+      case "src":
+      case "href":
+        if (a === "" && (t !== "a" || u !== "href")) {
+          l.removeAttribute(u);
+          break;
+        }
+        if (
+          a == null || typeof a == "function" || typeof a == "symbol" ||
+          typeof a == "boolean"
+        ) {
+          l.removeAttribute(u);
+          break;
+        }
+        a = Me("" + a), l.setAttribute(u, a);
+        break;
+      case "action":
+      case "formAction":
+        if (typeof a == "function") {
+          l.setAttribute(
+            u,
+            "javascript:throw new Error('A React form was unexpectedly submitted. If you called form.submit() manually, consider using form.requestSubmit() instead. If you\\'re trying to use event.stopPropagation() in a submit event handler, consider also calling event.preventDefault().')",
+          );
+          break;
+        } else {typeof n == "function" && (u === "formAction"
+            ? (t !== "input" && k(l, t, "name", e.name, e, null),
+              k(l, t, "formEncType", e.formEncType, e, null),
+              k(l, t, "formMethod", e.formMethod, e, null),
+              k(l, t, "formTarget", e.formTarget, e, null))
+            : (k(l, t, "encType", e.encType, e, null),
+              k(l, t, "method", e.method, e, null),
+              k(l, t, "target", e.target, e, null)));}
+        if (a == null || typeof a == "symbol" || typeof a == "boolean") {
+          l.removeAttribute(u);
+          break;
+        }
+        a = Me("" + a), l.setAttribute(u, a);
+        break;
+      case "onClick":
+        a != null && (l.onclick = bn);
+        break;
+      case "onScroll":
+        a != null && j("scroll", l);
+        break;
+      case "onScrollEnd":
+        a != null && j("scrollend", l);
+        break;
+      case "dangerouslySetInnerHTML":
+        if (a != null) {
+          if (typeof a != "object" || !("__html" in a)) throw Error(S(61));
+          if (u = a.__html, u != null) {
+            if (e.children != null) throw Error(S(60));
+            l.innerHTML = u;
+          }
+        }
+        break;
+      case "multiple":
+        l.multiple = a && typeof a != "function" && typeof a != "symbol";
+        break;
+      case "muted":
+        l.muted = a && typeof a != "function" && typeof a != "symbol";
+        break;
+      case "suppressContentEditableWarning":
+      case "suppressHydrationWarning":
+      case "defaultValue":
+      case "defaultChecked":
+      case "innerHTML":
+      case "ref":
+        break;
+      case "autoFocus":
+        break;
+      case "xlinkHref":
+        if (
+          a == null || typeof a == "function" || typeof a == "boolean" ||
+          typeof a == "symbol"
+        ) {
+          l.removeAttribute("xlink:href");
+          break;
+        }
+        u = Me("" + a),
+          l.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", u);
+        break;
+      case "contentEditable":
+      case "spellCheck":
+      case "draggable":
+      case "value":
+      case "autoReverse":
+      case "externalResourcesRequired":
+      case "focusable":
+      case "preserveAlpha":
+        a != null && typeof a != "function" && typeof a != "symbol"
+          ? l.setAttribute(u, "" + a)
+          : l.removeAttribute(u);
+        break;
+      case "inert":
+      case "allowFullScreen":
+      case "async":
+      case "autoPlay":
+      case "controls":
+      case "default":
+      case "defer":
+      case "disabled":
+      case "disablePictureInPicture":
+      case "disableRemotePlayback":
+      case "formNoValidate":
+      case "hidden":
+      case "loop":
+      case "noModule":
+      case "noValidate":
+      case "open":
+      case "playsInline":
+      case "readOnly":
+      case "required":
+      case "reversed":
+      case "scoped":
+      case "seamless":
+      case "itemScope":
+        a && typeof a != "function" && typeof a != "symbol"
+          ? l.setAttribute(u, "")
+          : l.removeAttribute(u);
+        break;
+      case "capture":
+      case "download":
+        a === !0
+          ? l.setAttribute(u, "")
+          : a !== !1 && a != null && typeof a != "function" &&
+              typeof a != "symbol"
+          ? l.setAttribute(u, a)
+          : l.removeAttribute(u);
+        break;
+      case "cols":
+      case "rows":
+      case "size":
+      case "span":
+        a != null && typeof a != "function" && typeof a != "symbol" &&
+          !isNaN(a) && 1 <= a
+          ? l.setAttribute(u, a)
+          : l.removeAttribute(u);
+        break;
+      case "rowSpan":
+      case "start":
+        a == null || typeof a == "function" || typeof a == "symbol" || isNaN(a)
+          ? l.removeAttribute(u)
+          : l.setAttribute(u, a);
+        break;
+      case "popover":
+        j("beforetoggle", l), j("toggle", l), Ae(l, "popover", a);
+        break;
+      case "xlinkActuate":
+        Ot(l, "http://www.w3.org/1999/xlink", "xlink:actuate", a);
+        break;
+      case "xlinkArcrole":
+        Ot(l, "http://www.w3.org/1999/xlink", "xlink:arcrole", a);
+        break;
+      case "xlinkRole":
+        Ot(l, "http://www.w3.org/1999/xlink", "xlink:role", a);
+        break;
+      case "xlinkShow":
+        Ot(l, "http://www.w3.org/1999/xlink", "xlink:show", a);
+        break;
+      case "xlinkTitle":
+        Ot(l, "http://www.w3.org/1999/xlink", "xlink:title", a);
+        break;
+      case "xlinkType":
+        Ot(l, "http://www.w3.org/1999/xlink", "xlink:type", a);
+        break;
+      case "xmlBase":
+        Ot(l, "http://www.w3.org/XML/1998/namespace", "xml:base", a);
+        break;
+      case "xmlLang":
+        Ot(l, "http://www.w3.org/XML/1998/namespace", "xml:lang", a);
+        break;
+      case "xmlSpace":
+        Ot(l, "http://www.w3.org/XML/1998/namespace", "xml:space", a);
+        break;
+      case "is":
+        Ae(l, "is", a);
+        break;
+      case "innerText":
+      case "textContent":
+        break;
+      default:
+        (!(2 < u.length) || u[0] !== "o" && u[0] !== "O" ||
+          u[1] !== "n" && u[1] !== "N") && (u = Oy.get(u) || u, Ae(l, u, a));
+    }
+  }
+  function qc(l, t, u, a, e, n) {
+    switch (u) {
+      case "style":
+        Ai(l, a, n);
+        break;
+      case "dangerouslySetInnerHTML":
+        if (a != null) {
+          if (typeof a != "object" || !("__html" in a)) throw Error(S(61));
+          if (u = a.__html, u != null) {
+            if (e.children != null) throw Error(S(60));
+            l.innerHTML = u;
+          }
+        }
+        break;
+      case "children":
+        typeof a == "string"
+          ? Zu(l, a)
+          : (typeof a == "number" || typeof a == "bigint") && Zu(l, "" + a);
+        break;
+      case "onScroll":
+        a != null && j("scroll", l);
+        break;
+      case "onScrollEnd":
+        a != null && j("scrollend", l);
+        break;
+      case "onClick":
+        a != null && (l.onclick = bn);
+        break;
+      case "suppressContentEditableWarning":
+      case "suppressHydrationWarning":
+      case "innerHTML":
+      case "ref":
+        break;
+      case "innerText":
+      case "textContent":
+        break;
+      default:
+        if (!yi.hasOwnProperty(u)) {
+          l: {
+            if (
+              u[0] === "o" && u[1] === "n" &&
+              (e = u.endsWith("Capture"),
+                t = u.slice(2, e ? u.length - 7 : void 0),
+                n = l[Xl] || null,
+                n = n != null ? n[u] : null,
+                typeof n == "function" && l.removeEventListener(t, n, e),
+                typeof a == "function")
+            ) {
+              typeof n != "function" && n !== null &&
+              (u in l
+                ? l[u] = null
+                : l.hasAttribute(u) && l.removeAttribute(u)),
+                l.addEventListener(t, a, e);
+              break l;
+            }
+            u in l ? l[u] = a : a === !0 ? l.setAttribute(u, "") : Ae(l, u, a);
+          }
+        }
+    }
+  }
+  function Ol(l, t, u) {
+    switch (t) {
+      case "div":
+      case "span":
+      case "svg":
+      case "path":
+      case "a":
+      case "g":
+      case "p":
+      case "li":
+        break;
+      case "img":
+        j("error", l), j("load", l);
+        var a = !1, e = !1, n;
+        for (n in u) {
+          if (u.hasOwnProperty(n)) {
+            var f = u[n];
+            if (f != null) {
+              switch (n) {
+                case "src":
+                  a = !0;
+                  break;
+                case "srcSet":
+                  e = !0;
+                  break;
+                case "children":
+                case "dangerouslySetInnerHTML":
+                  throw Error(S(137, t));
+                default:
+                  k(l, t, n, f, u, null);
+              }
+            }
+          }
+        }
+        e && k(l, t, "srcSet", u.srcSet, u, null),
+          a && k(l, t, "src", u.src, u, null);
+        return;
+      case "input":
+        j("invalid", l);
+        var c = n = f = e = null, i = null, h = null;
+        for (a in u) {
+          if (u.hasOwnProperty(a)) {
+            var g = u[a];
+            if (g != null) {
+              switch (a) {
+                case "name":
+                  e = g;
+                  break;
+                case "type":
+                  f = g;
+                  break;
+                case "checked":
+                  i = g;
+                  break;
+                case "defaultChecked":
+                  h = g;
+                  break;
+                case "value":
+                  n = g;
+                  break;
+                case "defaultValue":
+                  c = g;
+                  break;
+                case "children":
+                case "dangerouslySetInnerHTML":
+                  if (g != null) throw Error(S(137, t));
+                  break;
+                default:
+                  k(l, t, a, g, u, null);
+              }
+            }
+          }
+        }
+        ri(l, n, c, i, h, f, e, !1), _e(l);
+        return;
+      case "select":
+        j("invalid", l), a = f = n = null;
+        for (e in u) {
+          if (u.hasOwnProperty(e) && (c = u[e], c != null)) {
+            switch (e) {
+              case "value":
+                n = c;
+                break;
+              case "defaultValue":
+                f = c;
+                break;
+              case "multiple":
+                a = c;
+              default:
+                k(l, t, e, c, u, null);
+            }
+          }
+        }
+        t = n,
+          u = f,
+          l.multiple = !!a,
+          t != null ? xu(l, !!a, t, !1) : u != null && xu(l, !!a, u, !0);
+        return;
+      case "textarea":
+        j("invalid", l), n = e = a = null;
+        for (f in u) {
+          if (u.hasOwnProperty(f) && (c = u[f], c != null)) {
+            switch (f) {
+              case "value":
+                a = c;
+                break;
+              case "defaultValue":
+                e = c;
+                break;
+              case "children":
+                n = c;
+                break;
+              case "dangerouslySetInnerHTML":
+                if (c != null) throw Error(S(91));
+                break;
+              default:
+                k(l, t, f, c, u, null);
+            }
+          }
+        }
+        Ti(l, a, e, n), _e(l);
+        return;
+      case "option":
+        for (i in u) {
+          if (u.hasOwnProperty(i) && (a = u[i], a != null)) {
+            switch (i) {
+              case "selected":
+                l.selected = a && typeof a != "function" &&
+                  typeof a != "symbol";
+                break;
+              default:
+                k(l, t, i, a, u, null);
+            }
+          }
+        }
+        return;
+      case "dialog":
+        j("beforetoggle", l), j("toggle", l), j("cancel", l), j("close", l);
+        break;
+      case "iframe":
+      case "object":
+        j("load", l);
+        break;
+      case "video":
+      case "audio":
+        for (a = 0; a < ee.length; a++) j(ee[a], l);
+        break;
+      case "image":
+        j("error", l), j("load", l);
+        break;
+      case "details":
+        j("toggle", l);
+        break;
+      case "embed":
+      case "source":
+      case "link":
+        j("error", l), j("load", l);
+      case "area":
+      case "base":
+      case "br":
+      case "col":
+      case "hr":
+      case "keygen":
+      case "meta":
+      case "param":
+      case "track":
+      case "wbr":
+      case "menuitem":
+        for (h in u) {
+          if (u.hasOwnProperty(h) && (a = u[h], a != null)) {
+            switch (h) {
+              case "children":
+              case "dangerouslySetInnerHTML":
+                throw Error(S(137, t));
+              default:
+                k(l, t, h, a, u, null);
+            }
+          }
+        }
+        return;
+      default:
+        if (wn(t)) {
+          for (g in u) {
+            u.hasOwnProperty(g) &&
+              (a = u[g], a !== void 0 && qc(l, t, g, a, u, void 0));
+          }
+          return;
+        }
+    }
+    for (c in u) {
+      u.hasOwnProperty(c) && (a = u[c], a != null && k(l, t, c, a, u, null));
+    }
+  }
+  function kd(l, t, u, a) {
+    switch (t) {
+      case "div":
+      case "span":
+      case "svg":
+      case "path":
+      case "a":
+      case "g":
+      case "p":
+      case "li":
+        break;
+      case "input":
+        var e = null,
+          n = null,
+          f = null,
+          c = null,
+          i = null,
+          h = null,
+          g = null;
+        for (m in u) {
+          var T = u[m];
+          if (u.hasOwnProperty(m) && T != null) {
+            switch (m) {
+              case "checked":
+                break;
+              case "value":
+                break;
+              case "defaultValue":
+                i = T;
+              default:
+                a.hasOwnProperty(m) || k(l, t, m, null, a, T);
+            }
+          }
+        }
+        for (var o in a) {
+          var m = a[o];
+          if (
+            T = u[o], a.hasOwnProperty(o) && (m != null || T != null)
+          ) {
+            switch (o) {
+              case "type":
+                n = m;
+                break;
+              case "name":
+                e = m;
+                break;
+              case "checked":
+                h = m;
+                break;
+              case "defaultChecked":
+                g = m;
+                break;
+              case "value":
+                f = m;
+                break;
+              case "defaultValue":
+                c = m;
+                break;
+              case "children":
+              case "dangerouslySetInnerHTML":
+                if (m != null) throw Error(S(137, t));
+                break;
+              default:
+                m !== T && k(l, t, o, m, a, T);
+            }
+          }
+        }
+        Kn(l, f, c, i, h, g, n, e);
+        return;
+      case "select":
+        m =
+          f =
+          c =
+          o =
+            null;
+        for (n in u) {
+          if (i = u[n], u.hasOwnProperty(n) && i != null) {
+            switch (n) {
+              case "value":
+                break;
+              case "multiple":
+                m = i;
+              default:
+                a.hasOwnProperty(n) || k(l, t, n, null, a, i);
+            }
+          }
+        }
+        for (e in a) {
+          if (
+            n = a[e], i = u[e], a.hasOwnProperty(e) && (n != null || i != null)
+          ) {
+            switch (e) {
+              case "value":
+                o = n;
+                break;
+              case "defaultValue":
+                c = n;
+                break;
+              case "multiple":
+                f = n;
+              default:
+                n !== i && k(l, t, e, n, a, i);
+            }
+          }
+        }
+        t = c,
+          u = f,
+          a = m,
+          o != null ? xu(l, !!u, o, !1) : !!a != !!u &&
+            (t != null ? xu(l, !!u, t, !0) : xu(l, !!u, u ? [] : "", !1));
+        return;
+      case "textarea":
+        m = o = null;
+        for (c in u) {
+          if (
+            e = u[c], u.hasOwnProperty(c) && e != null && !a.hasOwnProperty(c)
+          ) {
+            switch (c) {
+              case "value":
+                break;
+              case "children":
+                break;
+              default:
+                k(l, t, c, null, a, e);
+            }
+          }
+        }
+        for (f in a) {
+          if (
+            e = a[f], n = u[f], a.hasOwnProperty(f) && (e != null || n != null)
+          ) {
+            switch (f) {
+              case "value":
+                o = e;
+                break;
+              case "defaultValue":
+                m = e;
+                break;
+              case "children":
+                break;
+              case "dangerouslySetInnerHTML":
+                if (e != null) throw Error(S(91));
+                break;
+              default:
+                e !== n && k(l, t, f, e, a, n);
+            }
+          }
+        }
+        bi(l, o, m);
+        return;
+      case "option":
+        for (var p in u) {
+          if (
+            o = u[p], u.hasOwnProperty(p) && o != null && !a.hasOwnProperty(p)
+          ) {
+            switch (p) {
+              case "selected":
+                l.selected = !1;
+                break;
+              default:
+                k(l, t, p, null, a, o);
+            }
+          }
+        }
+        for (i in a) {
+          if (
+            o = a[i],
+              m = u[i],
+              a.hasOwnProperty(i) && o !== m && (o != null || m != null)
+          ) {
+            switch (i) {
+              case "selected":
+                l.selected = o && typeof o != "function" &&
+                  typeof o != "symbol";
+                break;
+              default:
+                k(l, t, i, o, a, m);
+            }
+          }
+        }
+        return;
+      case "img":
+      case "link":
+      case "area":
+      case "base":
+      case "br":
+      case "col":
+      case "embed":
+      case "hr":
+      case "keygen":
+      case "meta":
+      case "param":
+      case "source":
+      case "track":
+      case "wbr":
+      case "menuitem":
+        for (var q in u) {
+          o = u[q],
+            u.hasOwnProperty(q) && o != null && !a.hasOwnProperty(q) &&
+            k(l, t, q, null, a, o);
+        }
+        for (h in a) {
+          if (
+            o = a[h],
+              m = u[h],
+              a.hasOwnProperty(h) && o !== m && (o != null || m != null)
+          ) {
+            switch (h) {
+              case "children":
+              case "dangerouslySetInnerHTML":
+                if (o != null) throw Error(S(137, t));
+                break;
+              default:
+                k(l, t, h, o, a, m);
+            }
+          }
+        }
+        return;
+      default:
+        if (wn(t)) {
+          for (var F in u) {
+            o = u[F],
+              u.hasOwnProperty(F) && o !== void 0 && !a.hasOwnProperty(F) &&
+              qc(l, t, F, void 0, a, o);
+          }
+          for (g in a) {
+            o = a[g],
+              m = u[g],
+              !a.hasOwnProperty(g) || o === m || o === void 0 && m === void 0 ||
+              qc(l, t, g, o, a, m);
+          }
+          return;
+        }
+    }
+    for (var y in u) {
+      o = u[y],
+        u.hasOwnProperty(y) && o != null && !a.hasOwnProperty(y) &&
+        k(l, t, y, null, a, o);
+    }
+    for (T in a) {
+      o = a[T],
+        m = u[T],
+        !a.hasOwnProperty(T) || o === m || o == null && m == null ||
+        k(l, t, T, o, a, m);
+    }
+  }
+  var Yc = null, Bc = null;
+  function Tn(l) {
+    return l.nodeType === 9 ? l : l.ownerDocument;
+  }
+  function Ev(l) {
+    switch (l) {
+      case "http://www.w3.org/2000/svg":
+        return 1;
+      case "http://www.w3.org/1998/Math/MathML":
+        return 2;
+      default:
+        return 0;
+    }
+  }
+  function Av(l, t) {
+    if (l === 0) {
+      switch (t) {
+        case "svg":
+          return 1;
+        case "math":
+          return 2;
+        default:
+          return 0;
+      }
+    }
+    return l === 1 && t === "foreignObject" ? 0 : l;
+  }
+  function pc(l, t) {
+    return l === "textarea" || l === "noscript" ||
+      typeof t.children == "string" || typeof t.children == "number" ||
+      typeof t.children == "bigint" ||
+      typeof t.dangerouslySetInnerHTML == "object" &&
+        t.dangerouslySetInnerHTML !== null &&
+        t.dangerouslySetInnerHTML.__html != null;
+  }
+  var Gc = null;
+  function Fd() {
+    var l = globalThis.event;
+    return l && l.type === "popstate"
+      ? l === Gc ? !1 : (Gc = l, !0)
+      : (Gc = null, !1);
+  }
+  var zv = typeof setTimeout == "function" ? setTimeout : void 0,
+    Id = typeof clearTimeout == "function" ? clearTimeout : void 0,
+    _v = typeof Promise == "function" ? Promise : void 0,
+    Pd = typeof queueMicrotask == "function"
+      ? queueMicrotask
+      : typeof _v < "u"
+      ? function (l) {
+        return _v.resolve(null).then(l).catch(l1);
+      }
+      : zv;
+  function l1(l) {
+    setTimeout(function () {
+      throw l;
+    });
+  }
+  function nu(l) {
+    return l === "head";
+  }
+  function Ov(l, t) {
+    var u = t, a = 0, e = 0;
+    do {
+      var n = u.nextSibling;
+      if (l.removeChild(u), n && n.nodeType === 8) {
+        if (u = n.data, u === "/$") {
+          if (0 < a && 8 > a) {
+            u = a;
+            var f = l.ownerDocument;
+            if (
+              u & 1 && fe(f.documentElement), u & 2 && fe(f.body), u & 4
+            ) {
+              for (u = f.head, fe(u), f = u.firstChild; f;) {
+                var c = f.nextSibling, i = f.nodeName;
+                f[Ea] || i === "SCRIPT" || i === "STYLE" ||
+                i === "LINK" && f.rel.toLowerCase() === "stylesheet" ||
+                u.removeChild(f), f = c;
+              }
+            }
+          }
+          if (e === 0) {
+            l.removeChild(n), oe(t);
+            return;
+          }
+          e--;
+        } else {u === "$" || u === "$?" || u === "$!"
+            ? e++
+            : a = u.charCodeAt(0) - 48;}
+      } else a = 0;
+      u = n;
+    } while (u);
+    oe(t);
+  }
+  function Xc(l) {
+    var t = l.firstChild;
+    for (t && t.nodeType === 10 && (t = t.nextSibling); t;) {
+      var u = t;
+      switch (t = t.nextSibling, u.nodeName) {
+        case "HTML":
+        case "HEAD":
+        case "BODY":
+          Xc(u), jn(u);
+          continue;
+        case "SCRIPT":
+        case "STYLE":
+          continue;
+        case "LINK":
+          if (u.rel.toLowerCase() === "stylesheet") continue;
+      }
+      l.removeChild(u);
+    }
+  }
+  function t1(l, t, u, a) {
+    for (; l.nodeType === 1;) {
+      var e = u;
+      if (l.nodeName.toLowerCase() !== t.toLowerCase()) {
+        if (!a && (l.nodeName !== "INPUT" || l.type !== "hidden")) {
+          break;
+        }
+      } else if (a) {
+        if (!l[Ea]) {
+          switch (t) {
+            case "meta":
+              if (!l.hasAttribute("itemprop")) break;
+              return l;
+            case "link":
+              if (
+                n = l.getAttribute("rel"),
+                  n === "stylesheet" && l.hasAttribute("data-precedence")
+              ) break;
+              if (
+                n !== e.rel ||
+                l.getAttribute("href") !==
+                  (e.href == null || e.href === "" ? null : e.href) ||
+                l.getAttribute("crossorigin") !==
+                  (e.crossOrigin == null ? null : e.crossOrigin) ||
+                l.getAttribute("title") !== (e.title == null ? null : e.title)
+              ) break;
+              return l;
+            case "style":
+              if (l.hasAttribute("data-precedence")) break;
+              return l;
+            case "script":
+              if (
+                n = l.getAttribute("src"),
+                  (n !== (e.src == null ? null : e.src) ||
+                    l.getAttribute("type") !==
+                      (e.type == null ? null : e.type) ||
+                    l.getAttribute("crossorigin") !==
+                      (e.crossOrigin == null ? null : e.crossOrigin)) &&
+                  n && l.hasAttribute("async") && !l.hasAttribute("itemprop")
+              ) break;
+              return l;
+            default:
+              return l;
+          }
+        }
+      } else if (t === "input" && l.type === "hidden") {
+        var n = e.name == null ? null : "" + e.name;
+        if (e.type === "hidden" && l.getAttribute("name") === n) return l;
+      } else return l;
+      if (l = mt(l.nextSibling), l === null) break;
+    }
+    return null;
+  }
+  function u1(l, t, u) {
+    if (t === "") return null;
+    for (; l.nodeType !== 3;) {
+      if (
+        (l.nodeType !== 1 || l.nodeName !== "INPUT" || l.type !== "hidden") &&
+          !u || (l = mt(l.nextSibling), l === null)
+      ) return null;
+    }
+    return l;
+  }
+  function Qc(l) {
+    return l.data === "$!" ||
+      l.data === "$?" && l.ownerDocument.readyState === "complete";
+  }
+  function a1(l, t) {
+    var u = l.ownerDocument;
+    if (l.data !== "$?" || u.readyState === "complete") t();
+    else {
+      var a = function () {
+        t(), u.removeEventListener("DOMContentLoaded", a);
+      };
+      u.addEventListener("DOMContentLoaded", a), l._reactRetry = a;
+    }
+  }
+  function mt(l) {
+    for (; l != null; l = l.nextSibling) {
+      var t = l.nodeType;
+      if (t === 1 || t === 3) break;
+      if (t === 8) {
+        if (
+          t = l.data,
+            t === "$" || t === "$!" || t === "$?" || t === "F!" || t === "F"
+        ) break;
+        if (t === "/$") return null;
+      }
+    }
+    return l;
+  }
+  var xc = null;
+  function Mv(l) {
+    l = l.previousSibling;
+    for (var t = 0; l;) {
+      if (l.nodeType === 8) {
+        var u = l.data;
+        if (u === "$" || u === "$!" || u === "$?") {
+          if (t === 0) return l;
+          t--;
+        } else u === "/$" && t++;
+      }
+      l = l.previousSibling;
+    }
+    return null;
+  }
+  function Dv(l, t, u) {
+    switch (t = Tn(u), l) {
+      case "html":
+        if (l = t.documentElement, !l) throw Error(S(452));
+        return l;
+      case "head":
+        if (l = t.head, !l) throw Error(S(453));
+        return l;
+      case "body":
+        if (l = t.body, !l) throw Error(S(454));
+        return l;
+      default:
+        throw Error(S(451));
+    }
+  }
+  function fe(l) {
+    for (var t = l.attributes; t.length;) l.removeAttributeNode(t[0]);
+    jn(l);
+  }
+  var vt = new Map(), Uv = new Set();
+  function En(l) {
+    return typeof l.getRootNode == "function"
+      ? l.getRootNode()
+      : l.nodeType === 9
+      ? l
+      : l.ownerDocument;
+  }
+  var xt = _.d;
+  _.d = { f: e1, r: n1, D: f1, C: c1, L: i1, m: s1, X: y1, S: v1, M: d1 };
+  function e1() {
+    var l = xt.f(), t = dn();
+    return l || t;
+  }
+  function n1(l) {
+    var t = pu(l);
+    t !== null && t.tag === 5 && t.type === "form" ? W0(t) : xt.r(l);
+  }
+  var ma = typeof document > "u" ? null : document;
+  function Rv(l, t, u) {
+    var a = ma;
+    if (a && typeof t == "string" && t) {
+      var e = at(t);
+      e = 'link[rel="' + l + '"][href="' + e + '"]',
+        typeof u == "string" && (e += '[crossorigin="' + u + '"]'),
+        Uv.has(e) ||
+        (Uv.add(e),
+          l = { rel: l, crossOrigin: u, href: t },
+          a.querySelector(e) === null &&
+          (t = a.createElement("link"),
+            Ol(t, "link", l),
+            rl(t),
+            a.head.appendChild(t)));
+    }
+  }
+  function f1(l) {
+    xt.D(l), Rv("dns-prefetch", l, null);
+  }
+  function c1(l, t) {
+    xt.C(l, t), Rv("preconnect", l, t);
+  }
+  function i1(l, t, u) {
+    xt.L(l, t, u);
+    var a = ma;
+    if (a && l && t) {
+      var e = 'link[rel="preload"][as="' + at(t) + '"]';
+      t === "image" && u && u.imageSrcSet
+        ? (e += '[imagesrcset="' + at(u.imageSrcSet) + '"]',
+          typeof u.imageSizes == "string" &&
+          (e += '[imagesizes="' + at(u.imageSizes) + '"]'))
+        : e += '[href="' + at(l) + '"]';
+      var n = e;
+      switch (t) {
+        case "style":
+          n = Sa(l);
+          break;
+        case "script":
+          n = ga(l);
+      }
+      vt.has(n) ||
+        (l = R({
+          rel: "preload",
+          href: t === "image" && u && u.imageSrcSet ? void 0 : l,
+          as: t,
+        }, u),
+          vt.set(n, l),
+          a.querySelector(e) !== null ||
+          t === "style" && a.querySelector(ce(n)) ||
+          t === "script" && a.querySelector(ie(n)) ||
+          (t = a.createElement("link"),
+            Ol(t, "link", l),
+            rl(t),
+            a.head.appendChild(t)));
+    }
+  }
+  function s1(l, t) {
+    xt.m(l, t);
+    var u = ma;
+    if (u && l) {
+      var a = t && typeof t.as == "string" ? t.as : "script",
+        e = 'link[rel="modulepreload"][as="' + at(a) + '"][href="' + at(l) +
+          '"]',
+        n = e;
+      switch (a) {
+        case "audioworklet":
+        case "paintworklet":
+        case "serviceworker":
+        case "sharedworker":
+        case "worker":
+        case "script":
+          n = ga(l);
+      }
+      if (
+        !vt.has(n) &&
+        (l = R({ rel: "modulepreload", href: l }, t),
+          vt.set(n, l),
+          u.querySelector(e) === null)
+      ) {
+        switch (a) {
+          case "audioworklet":
+          case "paintworklet":
+          case "serviceworker":
+          case "sharedworker":
+          case "worker":
+          case "script":
+            if (u.querySelector(ie(n))) return;
+        }
+        a = u.createElement("link"),
+          Ol(a, "link", l),
+          rl(a),
+          u.head.appendChild(a);
+      }
+    }
+  }
+  function v1(l, t, u) {
+    xt.S(l, t, u);
+    var a = ma;
+    if (a && l) {
+      var e = Gu(a).hoistableStyles, n = Sa(l);
+      t = t || "default";
+      var f = e.get(n);
+      if (!f) {
+        var c = { loading: 0, preload: null };
+        if (f = a.querySelector(ce(n))) c.loading = 5;
+        else {
+          l = R({ rel: "stylesheet", href: l, "data-precedence": t }, u),
+            (u = vt.get(n)) && Zc(l, u);
+          var i = f = a.createElement("link");
+          rl(i),
+            Ol(i, "link", l),
+            i._p = new Promise(function (h, g) {
+              i.onload = h, i.onerror = g;
+            }),
+            i.addEventListener("load", function () {
+              c.loading |= 1;
+            }),
+            i.addEventListener("error", function () {
+              c.loading |= 2;
+            }),
+            c.loading |= 4,
+            An(f, t, a);
+        }
+        f = { type: "stylesheet", instance: f, count: 1, state: c },
+          e.set(n, f);
+      }
+    }
+  }
+  function y1(l, t) {
+    xt.X(l, t);
+    var u = ma;
+    if (u && l) {
+      var a = Gu(u).hoistableScripts, e = ga(l), n = a.get(e);
+      n || (n = u.querySelector(ie(e)),
+        n ||
+        (l = R({ src: l, async: !0 }, t),
+          (t = vt.get(e)) && jc(l, t),
+          n = u.createElement("script"),
+          rl(n),
+          Ol(n, "link", l),
+          u.head.appendChild(n)),
+        n = { type: "script", instance: n, count: 1, state: null },
+        a.set(e, n));
+    }
+  }
+  function d1(l, t) {
+    xt.M(l, t);
+    var u = ma;
+    if (u && l) {
+      var a = Gu(u).hoistableScripts, e = ga(l), n = a.get(e);
+      n || (n = u.querySelector(ie(e)),
+        n ||
+        (l = R({ src: l, async: !0, type: "module" }, t),
+          (t = vt.get(e)) && jc(l, t),
+          n = u.createElement("script"),
+          rl(n),
+          Ol(n, "link", l),
+          u.head.appendChild(n)),
+        n = { type: "script", instance: n, count: 1, state: null },
+        a.set(e, n));
+    }
+  }
+  function Hv(l, t, u, a) {
+    var e = (e = G.current) ? En(e) : null;
+    if (!e) throw Error(S(446));
+    switch (l) {
+      case "meta":
+      case "title":
+        return null;
+      case "style":
+        return typeof u.precedence == "string" && typeof u.href == "string"
+          ? (t = Sa(u.href),
+            u = Gu(e).hoistableStyles,
+            a = u.get(t),
+            a ||
+            (a = { type: "style", instance: null, count: 0, state: null },
+              u.set(t, a)),
+            a)
+          : { type: "void", instance: null, count: 0, state: null };
+      case "link":
+        if (
+          u.rel === "stylesheet" && typeof u.href == "string" &&
+          typeof u.precedence == "string"
+        ) {
+          l = Sa(u.href);
+          var n = Gu(e).hoistableStyles, f = n.get(l);
+          if (
+            f || (e = e.ownerDocument || e,
+              f = {
+                type: "stylesheet",
+                instance: null,
+                count: 0,
+                state: { loading: 0, preload: null },
+              },
+              n.set(l, f),
+              (n = e.querySelector(ce(l))) && !n._p &&
+              (f.instance = n, f.state.loading = 5),
+              vt.has(l) ||
+              (u = {
+                rel: "preload",
+                as: "style",
+                href: u.href,
+                crossOrigin: u.crossOrigin,
+                integrity: u.integrity,
+                media: u.media,
+                hrefLang: u.hrefLang,
+                referrerPolicy: u.referrerPolicy,
+              },
+                vt.set(l, u),
+                n || h1(e, l, u, f.state))), t && a === null
+          ) throw Error(S(528, ""));
+          return f;
+        }
+        if (t && a !== null) throw Error(S(529, ""));
+        return null;
+      case "script":
+        return t = u.async,
+          u = u.src,
+          typeof u == "string" && t && typeof t != "function" &&
+            typeof t != "symbol"
+            ? (t = ga(u),
+              u = Gu(e).hoistableScripts,
+              a = u.get(t),
+              a ||
+              (a = { type: "script", instance: null, count: 0, state: null },
+                u.set(t, a)),
+              a)
+            : { type: "void", instance: null, count: 0, state: null };
+      default:
+        throw Error(S(444, l));
+    }
+  }
+  function Sa(l) {
+    return 'href="' + at(l) + '"';
+  }
+  function ce(l) {
+    return 'link[rel="stylesheet"][' + l + "]";
+  }
+  function Nv(l) {
+    return R({}, l, { "data-precedence": l.precedence, precedence: null });
+  }
+  function h1(l, t, u, a) {
+    l.querySelector('link[rel="preload"][as="style"][' + t + "]")
+      ? a.loading = 1
+      : (t = l.createElement("link"),
+        a.preload = t,
+        t.addEventListener("load", function () {
+          return a.loading |= 1;
+        }),
+        t.addEventListener("error", function () {
+          return a.loading |= 2;
+        }),
+        Ol(t, "link", u),
+        rl(t),
+        l.head.appendChild(t));
+  }
+  function ga(l) {
+    return '[src="' + at(l) + '"]';
+  }
+  function ie(l) {
+    return "script[async]" + l;
+  }
+  function qv(l, t, u) {
+    if (t.count++, t.instance === null) {
+      switch (t.type) {
+        case "style":
+          var a = l.querySelector('style[data-href~="' + at(u.href) + '"]');
+          if (a) return t.instance = a, rl(a), a;
+          var e = R({}, u, {
+            "data-href": u.href,
+            "data-precedence": u.precedence,
+            href: null,
+            precedence: null,
+          });
+          return a = (l.ownerDocument || l).createElement("style"),
+            rl(a),
+            Ol(a, "style", e),
+            An(a, u.precedence, l),
+            t.instance = a;
+        case "stylesheet":
+          e = Sa(u.href);
+          var n = l.querySelector(ce(e));
+          if (n) return t.state.loading |= 4, t.instance = n, rl(n), n;
+          a = Nv(u),
+            (e = vt.get(e)) && Zc(a, e),
+            n = (l.ownerDocument || l).createElement("link"),
+            rl(n);
+          var f = n;
+          return f._p = new Promise(function (c, i) {
+            f.onload = c, f.onerror = i;
+          }),
+            Ol(n, "link", a),
+            t.state.loading |= 4,
+            An(n, u.precedence, l),
+            t.instance = n;
+        case "script":
+          return n = ga(u.src),
+            (e = l.querySelector(ie(n)))
+              ? (t.instance = e, rl(e), e)
+              : (a = u,
+                (e = vt.get(n)) && (a = R({}, u), jc(a, e)),
+                l = l.ownerDocument || l,
+                e = l.createElement("script"),
+                rl(e),
+                Ol(e, "link", a),
+                l.head.appendChild(e),
+                t.instance = e);
+        case "void":
+          return null;
+        default:
+          throw Error(S(443, t.type));
+      }
+    } else {t.type === "stylesheet" && (t.state.loading & 4) === 0 &&
+        (a = t.instance, t.state.loading |= 4, An(a, u.precedence, l));}
+    return t.instance;
+  }
+  function An(l, t, u) {
+    for (
+      var a = u.querySelectorAll(
+          'link[rel="stylesheet"][data-precedence],style[data-precedence]',
+        ),
+        e = a.length ? a[a.length - 1] : null,
+        n = e,
+        f = 0;
+      f < a.length;
+      f++
+    ) {
+      var c = a[f];
+      if (c.dataset.precedence === t) n = c;
+      else if (n !== e) break;
+    }
+    n
+      ? n.parentNode.insertBefore(l, n.nextSibling)
+      : (t = u.nodeType === 9 ? u.head : u, t.insertBefore(l, t.firstChild));
+  }
+  function Zc(l, t) {
+    l.crossOrigin == null && (l.crossOrigin = t.crossOrigin),
+      l.referrerPolicy == null && (l.referrerPolicy = t.referrerPolicy),
+      l.title == null && (l.title = t.title);
+  }
+  function jc(l, t) {
+    l.crossOrigin == null && (l.crossOrigin = t.crossOrigin),
+      l.referrerPolicy == null && (l.referrerPolicy = t.referrerPolicy),
+      l.integrity == null && (l.integrity = t.integrity);
+  }
+  var zn = null;
+  function Yv(l, t, u) {
+    if (zn === null) {
+      var a = new Map(), e = zn = new Map();
+      e.set(u, a);
+    } else e = zn, a = e.get(u), a || (a = new Map(), e.set(u, a));
+    if (a.has(l)) return a;
+    for (
+      a.set(l, null), u = u.getElementsByTagName(l), e = 0;
+      e < u.length;
+      e++
+    ) {
+      var n = u[e];
+      if (
+        !(n[Ea] || n[Rl] ||
+          l === "link" && n.getAttribute("rel") === "stylesheet") &&
+        n.namespaceURI !== "http://www.w3.org/2000/svg"
+      ) {
+        var f = n.getAttribute(t) || "";
+        f = l + f;
+        var c = a.get(f);
+        c ? c.push(n) : a.set(f, [n]);
+      }
+    }
+    return a;
+  }
+  function Bv(l, t, u) {
+    l = l.ownerDocument || l,
+      l.head.insertBefore(
+        u,
+        t === "title" ? l.querySelector("head > title") : null,
+      );
+  }
+  function o1(l, t, u) {
+    if (u === 1 || t.itemProp != null) return !1;
+    switch (l) {
+      case "meta":
+      case "title":
+        return !0;
+      case "style":
+        if (
+          typeof t.precedence != "string" || typeof t.href != "string" ||
+          t.href === ""
+        ) break;
+        return !0;
+      case "link":
+        if (
+          typeof t.rel != "string" || typeof t.href != "string" ||
+          t.href === "" || t.onLoad || t.onError
+        ) break;
+        switch (t.rel) {
+          case "stylesheet":
+            return l = t.disabled, typeof t.precedence == "string" && l == null;
+          default:
+            return !0;
+        }
+      case "script":
+        if (
+          t.async && typeof t.async != "function" &&
+          typeof t.async != "symbol" && !t.onLoad && !t.onError && t.src &&
+          typeof t.src == "string"
+        ) return !0;
+    }
+    return !1;
+  }
+  function pv(l) {
+    return !(l.type === "stylesheet" && (l.state.loading & 3) === 0);
+  }
+  var se = null;
+  function m1() {}
+  function S1(l, t, u) {
+    if (se === null) throw Error(S(475));
+    var a = se;
+    if (
+      t.type === "stylesheet" &&
+      (typeof u.media != "string" || matchMedia(u.media).matches !== !1) &&
+      (t.state.loading & 4) === 0
+    ) {
+      if (t.instance === null) {
+        var e = Sa(u.href), n = l.querySelector(ce(e));
+        if (n) {
+          l = n._p,
+            l !== null && typeof l == "object" && typeof l.then == "function" &&
+            (a.count++, a = _n.bind(a), l.then(a, a)),
+            t.state.loading |= 4,
+            t.instance = n,
+            rl(n);
+          return;
+        }
+        n = l.ownerDocument || l,
+          u = Nv(u),
+          (e = vt.get(e)) && Zc(u, e),
+          n = n.createElement("link"),
+          rl(n);
+        var f = n;
+        f._p = new Promise(function (c, i) {
+          f.onload = c, f.onerror = i;
+        }),
+          Ol(n, "link", u),
+          t.instance = n;
+      }
+      a.stylesheets === null && (a.stylesheets = new Map()),
+        a.stylesheets.set(t, l),
+        (l = t.state.preload) && (t.state.loading & 3) === 0 &&
+        (a.count++,
+          t = _n.bind(a),
+          l.addEventListener("load", t),
+          l.addEventListener("error", t));
+    }
+  }
+  function g1() {
+    if (se === null) throw Error(S(475));
+    var l = se;
+    return l.stylesheets && l.count === 0 && Cc(l, l.stylesheets),
+      0 < l.count
+        ? function (t) {
+          var u = setTimeout(function () {
+            if (l.stylesheets && Cc(l, l.stylesheets), l.unsuspend) {
+              var a = l.unsuspend;
+              l.unsuspend = null, a();
+            }
+          }, 6e4);
+          return l.unsuspend = t, function () {
+            l.unsuspend = null, clearTimeout(u);
+          };
+        }
+        : null;
+  }
+  function _n() {
+    if (this.count--, this.count === 0) {
+      if (this.stylesheets) Cc(this, this.stylesheets);
+      else if (this.unsuspend) {
+        var l = this.unsuspend;
+        this.unsuspend = null, l();
+      }
+    }
+  }
+  var On = null;
+  function Cc(l, t) {
+    l.stylesheets = null,
+      l.unsuspend !== null &&
+      (l.count++, On = new Map(), t.forEach(r1, l), On = null, _n.call(l));
+  }
+  function r1(l, t) {
+    if (!(t.state.loading & 4)) {
+      var u = On.get(l);
+      if (u) { var a = u.get(null); }
+      else {
+        u = new Map(), On.set(l, u);
+        for (
+          var e = l.querySelectorAll(
+              "link[data-precedence],style[data-precedence]",
+            ),
+            n = 0;
+          n < e.length;
+          n++
+        ) {
+          var f = e[n];
+          (f.nodeName === "LINK" || f.getAttribute("media") !== "not all") &&
+            (u.set(f.dataset.precedence, f), a = f);
+        }
+        a && u.set(null, a);
+      }
+      e = t.instance,
+        f = e.getAttribute("data-precedence"),
+        n = u.get(f) || a,
+        n === a && u.set(null, e),
+        u.set(f, e),
+        this.count++,
+        a = _n.bind(this),
+        e.addEventListener("load", a),
+        e.addEventListener("error", a),
+        n
+          ? n.parentNode.insertBefore(e, n.nextSibling)
+          : (l = l.nodeType === 9 ? l.head : l,
+            l.insertBefore(e, l.firstChild)),
+        t.state.loading |= 4;
+    }
+  }
+  var ve = {
+    $$typeof: Ml,
+    Provider: null,
+    Consumer: null,
+    _currentValue: B,
+    _currentValue2: B,
+    _threadCount: 0,
+  };
+  function b1(l, t, u, a, e, n, f, c) {
+    this.tag = 1,
+      this.containerInfo = l,
+      this.pingCache = this.current = this.pendingChildren = null,
+      this.timeoutHandle = -1,
+      this.callbackNode =
+        this.next =
+        this.pendingContext =
+        this.context =
+        this.cancelPendingCommit =
+          null,
+      this.callbackPriority = 0,
+      this.expirationTimes = Xn(-1),
+      this.entangledLanes =
+        this.shellSuspendCounter =
+        this.errorRecoveryDisabledLanes =
+        this.expiredLanes =
+        this.warmLanes =
+        this.pingedLanes =
+        this.suspendedLanes =
+        this.pendingLanes =
+          0,
+      this.entanglements = Xn(0),
+      this.hiddenUpdates = Xn(null),
+      this.identifierPrefix = a,
+      this.onUncaughtError = e,
+      this.onCaughtError = n,
+      this.onRecoverableError = f,
+      this.pooledCache = null,
+      this.pooledCacheLanes = 0,
+      this.formState = c,
+      this.incompleteTransitions = new Map();
+  }
+  function Gv(l, t, u, a, e, n, f, c, i, h, g, T) {
+    return l = new b1(l, t, u, f, c, i, h, T),
+      t = 1,
+      n === !0 && (t |= 24),
+      n = $l(3, null, null, t),
+      l.current = n,
+      n.stateNode = l,
+      t = zf(),
+      t.refCount++,
+      l.pooledCache = t,
+      t.refCount++,
+      n.memoizedState = { element: a, isDehydrated: u, cache: t },
+      Df(n),
+      l;
+  }
+  function Xv(l) {
+    return l ? (l = Wu, l) : Wu;
+  }
+  function Qv(l, t, u, a, e, n) {
+    e = Xv(e),
+      a.context === null ? a.context = e : a.pendingContext = e,
+      a = Jt(t),
+      a.payload = { element: u },
+      n = n === void 0 ? null : n,
+      n !== null && (a.callback = n),
+      u = wt(l, a, t),
+      u !== null && (lt(u, l, t), Za(u, l, t));
+  }
+  function xv(l, t) {
+    if (l = l.memoizedState, l !== null && l.dehydrated !== null) {
+      var u = l.retryLane;
+      l.retryLane = u !== 0 && u < t ? u : t;
+    }
+  }
+  function Vc(l, t) {
+    xv(l, t), (l = l.alternate) && xv(l, t);
+  }
+  function Zv(l) {
+    if (l.tag === 13) {
+      var t = wu(l, 67108864);
+      t !== null && lt(t, l, 67108864), Vc(l, 67108864);
+    }
+  }
+  var Mn = !0;
+  function T1(l, t, u, a) {
+    var e = r.T;
+    r.T = null;
+    var n = _.p;
+    try {
+      _.p = 2, Lc(l, t, u, a);
+    } finally {
+      _.p = n, r.T = e;
+    }
+  }
+  function E1(l, t, u, a) {
+    var e = r.T;
+    r.T = null;
+    var n = _.p;
+    try {
+      _.p = 8, Lc(l, t, u, a);
+    } finally {
+      _.p = n, r.T = e;
+    }
+  }
+  function Lc(l, t, u, a) {
+    if (Mn) {
+      var e = Kc(a);
+      if (e === null) Nc(l, t, a, Dn, u), Cv(l, a);
+      else if (z1(e, l, t, u, a)) a.stopPropagation();
+      else if (Cv(l, a), t & 4 && -1 < A1.indexOf(l)) {
+        for (; e !== null;) {
+          var n = pu(e);
+          if (n !== null) {
+            switch (n.tag) {
+              case 3:
+                if (n = n.stateNode, n.current.memoizedState.isDehydrated) {
+                  var f = ou(n.pendingLanes);
+                  if (f !== 0) {
+                    var c = n;
+                    for (c.pendingLanes |= 2, c.entangledLanes |= 2; f;) {
+                      var i = 1 << 31 - wl(f);
+                      c.entanglements[1] |= i, f &= ~i;
+                    }
+                    At(n), (w & 6) === 0 && (vn = gt() + 500, ae(0));
+                  }
+                }
+                break;
+              case 13:
+                c = wu(n, 2), c !== null && lt(c, n, 2), dn(), Vc(n, 2);
+            }
+          }
+          if (n = Kc(a), n === null && Nc(l, t, a, Dn, u), n === e) break;
+          e = n;
+        }
+        e !== null && a.stopPropagation();
+      } else Nc(l, t, a, null, u);
+    }
+  }
+  function Kc(l) {
+    return l = $n(l), Jc(l);
+  }
+  var Dn = null;
+  function Jc(l) {
+    if (Dn = null, l = Bu(l), l !== null) {
+      var t = ml(l);
+      if (t === null) l = null;
+      else {
+        var u = t.tag;
+        if (u === 13) {
+          if (l = Al(t), l !== null) return l;
+          l = null;
+        } else if (u === 3) {
+          if (t.stateNode.current.memoizedState.isDehydrated) {
+            return t.tag === 3 ? t.stateNode.containerInfo : null;
+          }
+          l = null;
+        } else t !== l && (l = null);
+      }
+    }
+    return Dn = l, null;
+  }
+  function jv(l) {
+    switch (l) {
+      case "beforetoggle":
+      case "cancel":
+      case "click":
+      case "close":
+      case "contextmenu":
+      case "copy":
+      case "cut":
+      case "auxclick":
+      case "dblclick":
+      case "dragend":
+      case "dragstart":
+      case "drop":
+      case "focusin":
+      case "focusout":
+      case "input":
+      case "invalid":
+      case "keydown":
+      case "keypress":
+      case "keyup":
+      case "mousedown":
+      case "mouseup":
+      case "paste":
+      case "pause":
+      case "play":
+      case "pointercancel":
+      case "pointerdown":
+      case "pointerup":
+      case "ratechange":
+      case "reset":
+      case "resize":
+      case "seeked":
+      case "submit":
+      case "toggle":
+      case "touchcancel":
+      case "touchend":
+      case "touchstart":
+      case "volumechange":
+      case "change":
+      case "selectionchange":
+      case "textInput":
+      case "compositionstart":
+      case "compositionend":
+      case "compositionupdate":
+      case "beforeblur":
+      case "afterblur":
+      case "beforeinput":
+      case "blur":
+      case "fullscreenchange":
+      case "focus":
+      case "hashchange":
+      case "popstate":
+      case "select":
+      case "selectstart":
+        return 2;
+      case "drag":
+      case "dragenter":
+      case "dragexit":
+      case "dragleave":
+      case "dragover":
+      case "mousemove":
+      case "mouseout":
+      case "mouseover":
+      case "pointermove":
+      case "pointerout":
+      case "pointerover":
+      case "scroll":
+      case "touchmove":
+      case "wheel":
+      case "mouseenter":
+      case "mouseleave":
+      case "pointerenter":
+      case "pointerleave":
+        return 8;
+      case "message":
+        switch (cy()) {
+          case ti:
+            return 2;
+          case ui:
+            return 8;
+          case re:
+          case iy:
+            return 32;
+          case ai:
+            return 268435456;
+          default:
+            return 32;
+        }
+      default:
+        return 32;
+    }
+  }
+  var wc = !1,
+    fu = null,
+    cu = null,
+    iu = null,
+    ye = new Map(),
+    de = new Map(),
+    su = [],
+    A1 =
+      "mousedown mouseup touchcancel touchend touchstart auxclick dblclick pointercancel pointerdown pointerup dragend dragstart drop compositionend compositionstart keydown keypress keyup input textInput copy cut paste click change contextmenu reset"
+        .split(" ");
+  function Cv(l, t) {
+    switch (l) {
+      case "focusin":
+      case "focusout":
+        fu = null;
+        break;
+      case "dragenter":
+      case "dragleave":
+        cu = null;
+        break;
+      case "mouseover":
+      case "mouseout":
+        iu = null;
+        break;
+      case "pointerover":
+      case "pointerout":
+        ye.delete(t.pointerId);
+        break;
+      case "gotpointercapture":
+      case "lostpointercapture":
+        de.delete(t.pointerId);
+    }
+  }
+  function he(l, t, u, a, e, n) {
+    return l === null || l.nativeEvent !== n
+      ? (l = {
+        blockedOn: t,
+        domEventName: u,
+        eventSystemFlags: a,
+        nativeEvent: n,
+        targetContainers: [e],
+      },
+        t !== null && (t = pu(t), t !== null && Zv(t)),
+        l)
+      : (l.eventSystemFlags |= a,
+        t = l.targetContainers,
+        e !== null && t.indexOf(e) === -1 && t.push(e),
+        l);
+  }
+  function z1(l, t, u, a, e) {
+    switch (t) {
+      case "focusin":
+        return fu = he(fu, l, t, u, a, e), !0;
+      case "dragenter":
+        return cu = he(cu, l, t, u, a, e), !0;
+      case "mouseover":
+        return iu = he(iu, l, t, u, a, e), !0;
+      case "pointerover":
+        var n = e.pointerId;
+        return ye.set(n, he(ye.get(n) || null, l, t, u, a, e)), !0;
+      case "gotpointercapture":
+        return n = e.pointerId,
+          de.set(n, he(de.get(n) || null, l, t, u, a, e)),
+          !0;
+    }
+    return !1;
+  }
+  function Vv(l) {
+    var t = Bu(l.target);
+    if (t !== null) {
+      var u = ml(t);
+      if (u !== null) {
+        if (t = u.tag, t === 13) {
+          if (t = Al(u), t !== null) {
+            l.blockedOn = t,
+              Sy(l.priority, function () {
+                if (u.tag === 13) {
+                  var a = Pl();
+                  a = Qn(a);
+                  var e = wu(u, a);
+                  e !== null && lt(e, u, a), Vc(u, a);
+                }
+              });
+            return;
+          }
+        } else if (t === 3 && u.stateNode.current.memoizedState.isDehydrated) {
+          l.blockedOn = u.tag === 3 ? u.stateNode.containerInfo : null;
+          return;
+        }
+      }
+    }
+    l.blockedOn = null;
+  }
+  function Un(l) {
+    if (l.blockedOn !== null) return !1;
+    for (var t = l.targetContainers; 0 < t.length;) {
+      var u = Kc(l.nativeEvent);
+      if (u === null) {
+        u = l.nativeEvent;
+        var a = new u.constructor(u.type, u);
+        Wn = a, u.target.dispatchEvent(a), Wn = null;
+      } else return t = pu(u), t !== null && Zv(t), l.blockedOn = u, !1;
+      t.shift();
+    }
+    return !0;
+  }
+  function Lv(l, t, u) {
+    Un(l) && u.delete(t);
+  }
+  function _1() {
+    wc = !1,
+      fu !== null && Un(fu) && (fu = null),
+      cu !== null && Un(cu) && (cu = null),
+      iu !== null && Un(iu) && (iu = null),
+      ye.forEach(Lv),
+      de.forEach(Lv);
+  }
+  function Rn(l, t) {
+    l.blockedOn === t &&
+      (l.blockedOn = null,
+        wc ||
+        (wc = !0, D.unstable_scheduleCallback(D.unstable_NormalPriority, _1)));
+  }
+  var Hn = null;
+  function Kv(l) {
+    Hn !== l &&
+      (Hn = l,
+        D.unstable_scheduleCallback(D.unstable_NormalPriority, function () {
+          Hn === l && (Hn = null);
+          for (var t = 0; t < l.length; t += 3) {
+            var u = l[t], a = l[t + 1], e = l[t + 2];
+            if (typeof a != "function") {
+              if (Jc(a || u) === null) continue;
+              break;
+            }
+            var n = pu(u);
+            n !== null &&
+              (l.splice(t, 3),
+                t -= 3,
+                Jf(
+                  n,
+                  { pending: !0, data: e, method: u.method, action: a },
+                  a,
+                  e,
+                ));
+          }
+        }));
+  }
+  function oe(l) {
+    function t(i) {
+      return Rn(i, l);
+    }
+    fu !== null && Rn(fu, l),
+      cu !== null && Rn(cu, l),
+      iu !== null && Rn(iu, l),
+      ye.forEach(t),
+      de.forEach(t);
+    for (var u = 0; u < su.length; u++) {
+      var a = su[u];
+      a.blockedOn === l && (a.blockedOn = null);
+    }
+    for (; 0 < su.length && (u = su[0], u.blockedOn === null);) {
+      Vv(u), u.blockedOn === null && su.shift();
+    }
+    if (u = (l.ownerDocument || l).$$reactFormReplay, u != null) {
+      for (a = 0; a < u.length; a += 3) {
+        var e = u[a], n = u[a + 1], f = e[Xl] || null;
+        if (typeof n == "function") {
+          f || Kv(u);
+        } else if (f) {
+          var c = null;
+          if (n && n.hasAttribute("formAction")) {
+            if (e = n, f = n[Xl] || null) {
+              c = f.formAction;
+            } else if (Jc(e) !== null) continue;
+          } else c = f.action;
+          typeof c == "function" ? u[a + 1] = c : (u.splice(a, 3), a -= 3),
+            Kv(u);
+        }
+      }
+    }
+  }
+  function Wc(l) {
+    this._internalRoot = l;
+  }
+  Nn.prototype.render = Wc.prototype.render = function (l) {
+    var t = this._internalRoot;
+    if (t === null) throw Error(S(409));
+    var u = t.current, a = Pl();
+    Qv(u, a, l, t, null, null);
+  },
+    Nn.prototype.unmount = Wc.prototype.unmount = function () {
+      var l = this._internalRoot;
+      if (l !== null) {
+        this._internalRoot = null;
+        var t = l.containerInfo;
+        Qv(l.current, 2, null, l, null, null), dn(), t[Yu] = null;
+      }
+    };
+  function Nn(l) {
+    this._internalRoot = l;
+  }
+  Nn.prototype.unstable_scheduleHydration = function (l) {
+    if (l) {
+      var t = ii();
+      l = { blockedOn: null, target: l, priority: t };
+      for (var u = 0; u < su.length && t !== 0 && t < su[u].priority; u++);
+      su.splice(u, 0, l), u === 0 && Vv(l);
+    }
+  };
+  var Jv = sl.version;
+  if (Jv !== "19.1.0") throw Error(S(527, Jv, "19.1.0"));
+  _.findDOMNode = function (l) {
+    var t = l._reactInternals;
+    if (t === void 0) {
+      throw typeof l.render == "function"
+        ? Error(S(188))
+        : (l = Object.keys(l).join(","), Error(S(268, l)));
+    }
+    return l = H(t),
+      l = l !== null ? A(l) : null,
+      l = l === null ? null : l.stateNode,
+      l;
+  };
+  var O1 = {
+    bundleType: 0,
+    version: "19.1.0",
+    rendererPackageName: "react-dom",
+    currentDispatcherRef: r,
+    reconcilerVersion: "19.1.0",
+  };
+  if (typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ < "u") {
+    var qn = __REACT_DEVTOOLS_GLOBAL_HOOK__;
+    if (!qn.isDisabled && qn.supportsFiber) {
+      try {
+        ra = qn.inject(O1), Jl = qn;
+      } catch {}
+    }
+  }
+  return Se.createRoot = function (l, t) {
+    if (!vl(l)) throw Error(S(299));
+    var u = !1, a = "", e = is, n = ss, f = vs, c = null;
+    return t != null &&
+      (t.unstable_strictMode === !0 && (u = !0),
+        t.identifierPrefix !== void 0 && (a = t.identifierPrefix),
+        t.onUncaughtError !== void 0 && (e = t.onUncaughtError),
+        t.onCaughtError !== void 0 && (n = t.onCaughtError),
+        t.onRecoverableError !== void 0 && (f = t.onRecoverableError),
+        t.unstable_transitionCallbacks !== void 0 &&
+        (c = t.unstable_transitionCallbacks)),
+      t = Gv(l, 1, !1, null, null, u, a, e, n, f, c, null),
+      l[Yu] = t.current,
+      Hc(l),
+      new Wc(t);
+  },
+    Se.hydrateRoot = function (l, t, u) {
+      if (!vl(l)) throw Error(S(299));
+      var a = !1, e = "", n = is, f = ss, c = vs, i = null, h = null;
+      return u != null &&
+        (u.unstable_strictMode === !0 && (a = !0),
+          u.identifierPrefix !== void 0 && (e = u.identifierPrefix),
+          u.onUncaughtError !== void 0 && (n = u.onUncaughtError),
+          u.onCaughtError !== void 0 && (f = u.onCaughtError),
+          u.onRecoverableError !== void 0 && (c = u.onRecoverableError),
+          u.unstable_transitionCallbacks !== void 0 &&
+          (i = u.unstable_transitionCallbacks),
+          u.formState !== void 0 && (h = u.formState)),
+        t = Gv(l, 1, !0, t, u ?? null, a, e, n, f, c, i, h),
+        t.context = Xv(null),
+        u = t.current,
+        a = Pl(),
+        a = Qn(a),
+        e = Jt(a),
+        e.callback = null,
+        wt(u, e, a),
+        u = a,
+        t.current.lanes = u,
+        Ta(t, u),
+        At(t),
+        l[Yu] = t.current,
+        Hc(l),
+        new Nn(t);
+    },
+    Se.version = "19.1.0",
+    Se;
+}
+var uy;
+function p1() {
+  if (uy) return kc.exports;
+  uy = 1;
+  function D() {
+    if (
+      !(typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ > "u" ||
+        typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE != "function")
+    ) {
+      try {
+        __REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE(D);
+      } catch (sl) {
+        console.error(sl);
+      }
+    }
+  }
+  return D(), kc.exports = B1(), kc.exports;
+}
+var G1 = p1();
+function X1() {
+  return tt.jsxs("div", {
+    className: "app",
+    children: [
+      tt.jsxs("header", {
+        className: "app-header",
+        children: [
+          tt.jsx("h1", { children: "Bolt Foundry" }),
+          tt.jsx("p", { children: "Coming Soon" }),
+        ],
+      }),
+      tt.jsx("main", {
+        className: "app-main",
+        children: tt.jsxs("section", {
+          className: "hello-world",
+          children: [
+            tt.jsx("h2", { children: "Hello World!" }),
+            tt.jsx("p", {
+              children:
+                "This is the Phase 1 implementation of the Bolt Foundry landing page.",
+            }),
+            tt.jsx("p", {
+              children:
+                "Architecture foundation established with Vite + Deno + React.",
+            }),
+          ],
+        }),
+      }),
+      tt.jsx("footer", {
+        className: "app-footer",
+        children: tt.jsx("p", {
+          children: "© 2025 Bolt Foundry. All rights reserved.",
+        }),
+      }),
+    ],
+  });
+}
+function Q1({ environment: D }) {
+  return tt.jsx(X1, {});
+}
+function ay(D) {
+  const sl = document.querySelector("#root");
+  sl
+    ? (console.debug("rehydrating root", sl, D),
+      G1.hydrateRoot(sl, tt.jsx(Q1, { environment: D })),
+      console.debug("rehydrated root"))
+    : console.error("couldn't rehydrate, root not found");
+}
+console.debug("ClientRoot loaded");
+globalThis.__ENVIRONMENT__
+  ? (console.debug("found environment, rehydrating root"),
+    ay(globalThis.__ENVIRONMENT__))
+  : (console.debug("Setting rehydration callback"),
+    globalThis.__REHYDRATE__ = ay);

--- a/apps/boltfoundry-com/static/build/assets/ClientRoot-p-YblEDb.css
+++ b/apps/boltfoundry-com/static/build/assets/ClientRoot-p-YblEDb.css
@@ -1,0 +1,61 @@
+:root {
+  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color-scheme: light dark;
+  color: #ffffffde;
+  background-color: #242424;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-text-size-adjust: 100%;
+}
+a {
+  font-weight: 500;
+  color: #646cff;
+  text-decoration: inherit;
+}
+a:hover {
+  color: #535bf2;
+}
+body {
+  margin: 0;
+  display: flex;
+  place-items: center;
+  min-width: 320px;
+  min-height: 100vh;
+}
+h1 {
+  font-size: 3.2em;
+  line-height: 1.1;
+}
+button {
+  border-radius: 8px;
+  border: 1px solid transparent;
+  padding: 0.6em 1.2em;
+  font-size: 1em;
+  font-weight: 500;
+  font-family: inherit;
+  background-color: #1a1a1a;
+  cursor: pointer;
+  transition: border-color 0.25s;
+}
+button:hover {
+  border-color: #646cff;
+}
+button:focus, button:focus-visible {
+  outline: 4px auto -webkit-focus-ring-color;
+}
+@media (prefers-color-scheme: light) {
+  :root {
+    color: #213547;
+    background-color: #fff;
+  }
+  a:hover {
+    color: #747bff;
+  }
+  button {
+    background-color: #f9f9f9;
+  }
+}

--- a/apps/boltfoundry-com/static/index.css
+++ b/apps/boltfoundry-com/static/index.css
@@ -1,0 +1,72 @@
+.app {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
+    Arial, sans-serif;
+  line-height: 1.6;
+  color: #333;
+}
+
+.app-header {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  padding: 4rem 2rem;
+  text-align: center;
+}
+
+.app-header h1 {
+  font-size: 3rem;
+  margin: 0 0 1rem 0;
+  font-weight: 700;
+}
+
+.app-header p {
+  font-size: 1.2rem;
+  margin: 0;
+  opacity: 0.9;
+}
+
+.app-main {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4rem 2rem;
+  background: #f8f9fa;
+}
+
+.hello-world {
+  text-align: center;
+  max-width: 600px;
+}
+
+.hello-world h2 {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+  color: #2c3e50;
+}
+
+.hello-world p {
+  font-size: 1.1rem;
+  margin-bottom: 1rem;
+  color: #666;
+}
+
+.app-footer {
+  background: #2c3e50;
+  color: white;
+  text-align: center;
+  padding: 2rem;
+}
+
+.app-footer p {
+  margin: 0;
+  opacity: 0.8;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+}

--- a/apps/boltfoundry-com/vite.config.ts
+++ b/apps/boltfoundry-com/vite.config.ts
@@ -13,6 +13,16 @@ export default defineConfig({
       port: 5001, // Dynamic port will be set by CLI
     },
   },
+  build: {
+    rollupOptions: {
+      input: new URL(import.meta.resolve("./ClientRoot.tsx")).pathname,
+      output: {
+        dir: new URL(import.meta.resolve("./static/build")).pathname,
+        entryFileNames: "ClientRoot.js",
+        format: "es",
+      },
+    },
+  },
   resolve: {
     alias: {
       "@bfmono/": new URL(import.meta.resolve("../../../")).pathname,

--- a/deno.lock
+++ b/deno.lock
@@ -114,6 +114,7 @@
     "npm:react@*": "19.1.0",
     "npm:react@19": "19.1.0",
     "npm:react@^19.1.0": "19.1.0",
+    "npm:vite@*": "6.3.5_@types+node@22.15.15_picomatch@4.0.2",
     "npm:vite@6": "6.3.5_@types+node@22.15.15_picomatch@4.0.2",
     "npm:zod@3": "3.25.75"
   },

--- a/deno.lock
+++ b/deno.lock
@@ -71,6 +71,7 @@
     "npm:@hexagon/base64@^1.1.27": "1.1.28",
     "npm:@isograph/babel-plugin@0.3.1": "0.3.1",
     "npm:@isograph/babel-plugin@~0.3.1": "0.3.1",
+    "npm:@isograph/compiler@*": "0.3.1",
     "npm:@isograph/compiler@0.3.1": "0.3.1",
     "npm:@isograph/react@0.3.1": "0.3.1_react@19.1.0",
     "npm:@isograph/react@~0.3.1": "0.3.1_react@19.1.0",

--- a/infra/bft/tasks/app.bft.ts
+++ b/infra/bft/tasks/app.bft.ts
@@ -149,7 +149,7 @@ Examples:
     "run",
     "-A",
     "--watch",
-    new URL(import.meta.resolve("../../../apps/boltfoundry-com/server.ts"))
+    new URL(import.meta.resolve("../../../apps/boltfoundry-com/server.tsx"))
       .pathname,
     "--port",
     String(port),

--- a/infra/bft/tasks/compile.bft.ts
+++ b/infra/bft/tasks/compile.bft.ts
@@ -12,28 +12,28 @@ async function compile(args: Array<string>): Promise<number> {
 Compile applications to single executable binaries.
 
 Available apps:
-  boltfoundry.com    Bolt Foundry landing page
+  boltfoundry-com    Bolt Foundry landing page
 
 Examples:
-  bft compile boltfoundry.com           # Compile boltfoundry.com to binary
-  bft compile boltfoundry.com --help    # Show app-specific help`);
+  bft compile boltfoundry-com           # Compile boltfoundry-com to binary
+  bft compile boltfoundry-com --help    # Show app-specific help`);
     return 0;
   }
 
   if (args.length === 0) {
     ui.error("Usage: bft compile <app-name>");
     ui.output("Available apps:");
-    ui.output("  boltfoundry.com    Bolt Foundry landing page");
+    ui.output("  boltfoundry-com    Bolt Foundry landing page");
     return 1;
   }
 
   const appName = args[0];
   const compileArgs = args.slice(1);
 
-  if (appName !== "boltfoundry.com") {
+  if (appName !== "boltfoundry-com") {
     ui.error(`Unknown app: ${appName}`);
     ui.output("Available apps:");
-    ui.output("  boltfoundry.com    Bolt Foundry landing page");
+    ui.output("  boltfoundry-com    Bolt Foundry landing page");
     return 1;
   }
 
@@ -43,7 +43,7 @@ Examples:
   });
 
   if (flags.help) {
-    ui.output(`Usage: bft compile boltfoundry.com
+    ui.output(`Usage: bft compile boltfoundry-com
 
 Compile Bolt Foundry landing page to single executable binary.
 This will build frontend assets and compile the server into a standalone binary.
@@ -51,12 +51,12 @@ This will build frontend assets and compile the server into a standalone binary.
 The binary will be output to: ./build/boltfoundry-com
 
 Examples:
-  bft compile boltfoundry.com    # Build assets and compile to binary`);
+  bft compile boltfoundry-com    # Build assets and compile to binary`);
     return 0;
   }
 
   const appPath =
-    new URL(import.meta.resolve("../../../apps/boltFoundry.com")).pathname;
+    new URL(import.meta.resolve("../../../apps/boltfoundry-com")).pathname;
   const buildDir = new URL(import.meta.resolve("../../../build")).pathname;
 
   // Ensure build directory exists
@@ -89,7 +89,7 @@ Examples:
 
     // Run the build command
     const buildCommand = new Deno.Command("bft", {
-      args: ["app", "boltfoundry.com", "--build"],
+      args: ["app", "boltfoundry-com", "--build"],
       stdout: "inherit",
       stderr: "inherit",
     });
@@ -105,7 +105,7 @@ Examples:
   ui.output("Compiling server to single binary...");
 
   const binaryPath = `${buildDir}/boltfoundry-com`;
-  const serverPath = `${appPath}/server.ts`;
+  const serverPath = `${appPath}/server.tsx`;
 
   const compileCommand = new Deno.Command("deno", {
     args: [

--- a/infra/testing/e2e/server-registry.ts
+++ b/infra/testing/e2e/server-registry.ts
@@ -6,6 +6,7 @@
  */
 
 import { globToRegExp } from "@std/path/glob-to-regexp";
+import { relative } from "@std/path";
 
 export interface ServerConfig {
   /** Unique identifier for this server */
@@ -41,6 +42,9 @@ export const E2E_SERVER_REGISTRY: Array<ServerRegistryEntry> = [
       serverPath: "./apps/aibff/gui/guiServer.ts",
       defaultPort: 8001,
       envVar: "BF_E2E_AIBFF_GUI_URL",
+      env: {
+        "BF_MODE": "production",
+      },
     },
   },
   {
@@ -50,7 +54,7 @@ export const E2E_SERVER_REGISTRY: Array<ServerRegistryEntry> = [
     ],
     server: {
       name: "boltfoundry-com",
-      serverPath: "./apps/boltfoundry-com/server.ts",
+      serverPath: "./apps/boltfoundry-com/server.tsx",
       defaultPort: 8002,
       envVar: "BF_E2E_BOLTFOUNDRY_COM_URL",
     },
@@ -65,11 +69,17 @@ export function getRequiredServers(
 ): Array<ServerConfig> {
   const requiredServers = new Set<ServerConfig>();
 
+  // Get project root from import.meta.resolve
+  const projectRoot = new URL("../../../", import.meta.url).pathname;
+
   for (const testFile of testFiles) {
+    // Normalize path to be relative to project root
+    const normalizedPath = relative(projectRoot, testFile);
+
     for (const entry of E2E_SERVER_REGISTRY) {
       const isMatch = entry.testPatterns.some((pattern) => {
         const regex = globToRegExp(pattern);
-        return regex.test(testFile);
+        return regex.test(normalizedPath);
       });
 
       if (isMatch) {


### PR DESCRIPTION
Convert boltfoundry-com from client-side SPA to server-side rendered application using React streaming.
This provides better SEO, faster initial page loads, and improved performance while maintaining
the same user experience with proper client-side hydration.

Changes:
- Add ServerRenderedPage component for server-side HTML shell generation
- Add ClientRoot component for client-side hydration using __REHYDRATE__ pattern
- Configure Vite build to generate ClientRoot.js client bundle
- Update server.tsx to use renderToReadableStream instead of static file serving
- Add static asset serving for CSS and JavaScript files
- Create comprehensive e2e tests for SSR functionality and hydration
- Fix BFT task configurations to use correct .tsx file extension
- Update server registry for e2e test framework integration
- Add build directory to deno.json exclude list

Test plan:
1. Run the app: `bft app boltfoundry-com`
2. Navigate to http://localhost:3000 and verify content loads immediately
3. Check browser DevTools Network tab to confirm HTML contains rendered content
4. Run e2e tests: `bft e2e apps/boltfoundry-com/__tests__/e2e/ssr.test.e2e.ts`
5. Verify client-side hydration works by checking console for rehydration messages

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/1409).
* __->__ #1409
* #1408
* #1407
* #1406
* #1405

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/1409)
<!-- GitContextEnd -->