### PR TITLE
Add href prop support to BfDsButton component

### DIFF
--- a/apps/bfDs/components/BfDsButton.tsx
+++ b/apps/bfDs/components/BfDsButton.tsx
@@ -21,6 +21,8 @@ export type BfDsButtonProps = {
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
   /** Additional CSS classes */
   className?: string;
+  /** URL to navigate to (for future link support) */
+  href?: string;
   /** Icon name or custom icon element */
   icon?: BfDsIconName | React.ReactNode;
   /** Position of icon relative to text */
@@ -38,6 +40,7 @@ export function BfDsButton({
   disabled = false,
   onClick,
   className,
+  href: _href,
   icon,
   iconPosition = "left",
   iconOnly = false,
@@ -47,6 +50,7 @@ export function BfDsButton({
   const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     if (disabled) return;
     onClick?.(e);
+    // TODO: href navigation will be implemented later
   };
 
   const classes = [


### PR DESCRIPTION

Add href prop to BfDsButton component for future link navigation support.
This prepares the component for enhanced navigation capabilities.

Changes:
- Add href prop to BfDsButton component interface
- Update prop destructuring to handle href parameter
- Add TODO comment for future href navigation implementation
- Use underscore prefix for unused href parameter to satisfy linter

Test plan:
1. Import BfDsButton in test component
2. Pass href prop to BfDsButton component
3. Verify component accepts href without TypeScript errors
4. Confirm component renders normally with href prop
5. Verify no runtime errors when href is provided

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/1412).
* #1414
* #1413
* #1408
* #1411
* #1410
* __->__ #1412