### PR TITLE
Add default type='button' to BfDsButton to prevent form submission

### DIFF
--- a/apps/bfDs/components/BfDsButton.tsx
+++ b/apps/bfDs/components/BfDsButton.tsx
@@ -123,6 +123,7 @@ export function BfDsButton({
   return (
     <button
       {...(props as React.ButtonHTMLAttributes<HTMLButtonElement>)}
+      type={props.type ?? "button"}
       className={classes}
       disabled={disabled}
       onClick={handleClick}

--- a/apps/bfDs/components/__examples__/BfDsForm.example.tsx
+++ b/apps/bfDs/components/__examples__/BfDsForm.example.tsx
@@ -9,6 +9,7 @@ import { BfDsCheckbox } from "../BfDsCheckbox.tsx";
 import { BfDsRadio } from "../BfDsRadio.tsx";
 import { BfDsToggle } from "../BfDsToggle.tsx";
 import { BfDsFormSubmitButton } from "../BfDsFormSubmitButton.tsx";
+import { BfDsButton } from "../BfDsButton.tsx";
 
 const { useState } = React;
 const logger = getLogger(import.meta);

--- a/apps/bfDs/components/__tests__/BfDsForm.test.tsx
+++ b/apps/bfDs/components/__tests__/BfDsForm.test.tsx
@@ -1,6 +1,7 @@
 import { render } from "@bfmono/infra/testing/ui-testing.ts";
 import { assertEquals, assertExists } from "@std/assert";
 import { BfDsForm, useBfDsFormContext } from "../BfDsForm.tsx";
+import { BfDsButton } from "../BfDsButton.tsx";
 
 // Helper component to test the form context
 function FormContextDisplay() {
@@ -207,5 +208,23 @@ Deno.test("BfDsForm renders children correctly", () => {
     secondChild?.textContent,
     "Second child",
     "Second child should have correct content",
+  );
+});
+
+Deno.test("BfDsButton has type='button' by default to prevent form submission", () => {
+  const { doc } = render(
+    <BfDsForm initialData={{}}>
+      <BfDsButton>Regular Button</BfDsButton>
+    </BfDsForm>,
+  );
+
+  const button = doc?.querySelector("button");
+  assertExists(button, "Button should exist");
+  
+  // Verify button has type="button" to prevent accidental form submission
+  assertEquals(
+    button?.getAttribute("type"),
+    "button",
+    "BfDsButton should have type='button' by default to prevent form submission",
   );
 });


### PR DESCRIPTION

BfDsButton now defaults to type='button' to prevent accidental form submission
when used inside forms. This ensures buttons only submit forms when explicitly
set to type='submit' or through BfDsFormSubmitButton.

Add test to verify BfDsButton has correct type attribute by default.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
