### PR TITLE
Modernize bfDb core API to use storage facade pattern

### DIFF
--- a/apps/bfDb/storage/registerDefaultAdapter.ts
+++ b/apps/bfDb/storage/registerDefaultAdapter.ts
@@ -14,6 +14,10 @@ const logger = getLogger(import.meta);
 
 let registered = false; // guard so we don't double‑register accidentally
 
+export function resetRegistration() {
+  registered = false;
+}
+
 export function registerDefaultAdapter() {
   if (registered) return; // idempotent
 
@@ -25,7 +29,8 @@ export function registerDefaultAdapter() {
     // fallthrough – nothing registered yet
   }
 
-  const env = getConfigurationVariable("DB_BACKEND_TYPE")?.toLowerCase() ??
+  const env = (getConfigurationVariable("FORCE_DB_BACKEND")?.toLowerCase() ||
+    getConfigurationVariable("DB_BACKEND_TYPE")?.toLowerCase()) ??
     "memory";
   logger.info(`registerDefaultAdapter → selecting '${env}' backend`);
 

--- a/apps/bfDb/storage/storage.ts
+++ b/apps/bfDb/storage/storage.ts
@@ -39,6 +39,14 @@ export const storage = {
     return adapter().getItem<T>(bfOid, bfGid);
   },
 
+  getByBfGid<T extends Props>(bfGid: string, className?: string) {
+    return adapter().getItemByBfGid<T>(bfGid, className);
+  },
+
+  getByBfGids<T extends Props>(bfGids: Array<string>, className?: string) {
+    return adapter().getItemsByBfGid<T>(bfGids, className);
+  },
+
   async put<T extends Props, M extends BfNodeMetadata | BfEdgeMetadata>(
     props: T,
     metadata: M,
@@ -66,7 +74,58 @@ export const storage = {
     );
   },
 
+  queryWithSizeLimit<T extends Props>(
+    metadata: Record<string, unknown>,
+    props: Partial<T> = {},
+    bfGids?: Array<string>,
+    order: "ASC" | "DESC" = "ASC",
+    orderBy?: string,
+    cursorValue?: number | string,
+    maxSizeBytes?: number,
+    batchSize?: number,
+  ): Promise<Array<DbItem<T>>> {
+    return adapter().queryItemsWithSizeLimit<T>(
+      metadata,
+      props,
+      bfGids,
+      order,
+      orderBy,
+      cursorValue,
+      maxSizeBytes,
+      batchSize,
+    );
+  },
+
   async delete(bfOid: BfGid, bfGid: BfGid) {
     await adapter().deleteItem(bfOid, bfGid);
+  },
+
+  // ---- Graph traversal -------------------------------------------------
+  queryAncestorsByClassName<T extends Props>(
+    bfOid: string,
+    targetBfGid: string,
+    sourceBfClassName: string,
+    depth: number = 10,
+  ): Promise<Array<DbItem<T>>> {
+    return adapter().queryAncestorsByClassName<T>(
+      bfOid,
+      targetBfGid,
+      sourceBfClassName,
+      depth,
+    );
+  },
+
+  queryDescendantsByClassName<T extends Props>(
+    bfOid: string,
+    sourceBfGid: string,
+    targetBfClassName: string,
+    depth: number = 10,
+  ): Promise<Array<DbItem<T>>> {
+    return adapter().queryDescendantsByClassName<T>(
+      bfOid,
+      sourceBfGid,
+      targetBfClassName,
+      depth,
+    );
   },
 } as const;


### PR DESCRIPTION

Replace direct backend calls with unified storage facade to improve architecture
and provide consistent interface across all database operations.

Changes:
- Update bfDb.ts to use storage facade instead of direct backend imports
- Add proper adapter registry management in withIsolatedDb()
- Improve SQLite traversal queries with better edge filtering
- Fix traversal algorithms to properly filter by target class during recursion
- Remove unnecessary sortValue parameter from storage interface

Test plan:
1. Run core database tests: `bft test apps/bfDb/backend/__tests__/`
2. Run storage tests: `bft test apps/bfDb/storage/__tests__/`
3. Verify adapter switching works in test isolation

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
