### PR TITLE
Restore BfNode traversal methods and add scratch GraphQL connections

### DIFF
--- a/apps/bfDb/classes/GraphQLNode.ts
+++ b/apps/bfDb/classes/GraphQLNode.ts
@@ -60,15 +60,23 @@ export abstract class GraphQLNode extends GraphQLObjectBase {
   constructor() {
     super();
 
-    // Ensure that get id() is implemented in subclasses
-    const proto = Object.getPrototypeOf(this);
-    const hasOwnId = Object.getOwnPropertyDescriptor(proto, "id")?.get;
-
     if (this.constructor === GraphQLNode) {
       throw new TypeError("Cannot instantiate abstract class GraphQLNode");
     }
 
-    if (!hasOwnId) {
+    // Check if get id() is implemented anywhere in the prototype chain
+    let hasIdGetter = false;
+    let proto = Object.getPrototypeOf(this);
+    while (proto && proto !== Object.prototype) {
+      const descriptor = Object.getOwnPropertyDescriptor(proto, "id");
+      if (descriptor?.get) {
+        hasIdGetter = true;
+        break;
+      }
+      proto = Object.getPrototypeOf(proto);
+    }
+
+    if (!hasIdGetter) {
       // Make the id property throw when accessed if it's not implemented
       Object.defineProperty(this, "id", {
         get() {

--- a/apps/bfDb/classes/__tests__/BfNode.connection.test.ts
+++ b/apps/bfDb/classes/__tests__/BfNode.connection.test.ts
@@ -1,0 +1,100 @@
+#! /usr/bin/env -S bff test
+/**
+ * BfNode.connection() – Tests for static connection method
+ *
+ * Tests the scratch GraphQL connections implementation that provides
+ * basic connection functionality while throwing errors for pagination.
+ */
+
+import { assertEquals, assertThrows } from "@std/assert";
+import { BfErrorNotImplemented } from "@bfmono/lib/BfError.ts";
+import { BfNode, type InferProps } from "@bfmono/apps/bfDb/classes/BfNode.ts";
+import { connectionFromArray } from "graphql-relay";
+import type { ConnectionArguments } from "graphql-relay";
+
+// Mock node class for testing
+class TestNode extends BfNode<InferProps<typeof TestNode>> {
+  static override gqlSpec = this.defineGqlNode((f) => f.string("name"));
+
+  static override bfNodeSpec = this.defineBfNode((f) => f.string("name"));
+}
+
+Deno.test("BfNode.connection() - should work with empty args (no pagination)", () => {
+  const nodes: Array<TestNode> = [];
+  const args: ConnectionArguments = {};
+
+  const result = BfNode.connection(nodes, args);
+
+  assertEquals(result.edges.length, 0);
+  assertEquals(result.pageInfo.hasNextPage, false);
+  assertEquals(result.pageInfo.hasPreviousPage, false);
+  assertEquals(result.pageInfo.startCursor, null);
+  assertEquals(result.pageInfo.endCursor, null);
+});
+
+Deno.test("BfNode.connection() - should work with undefined args", () => {
+  const nodes: Array<TestNode> = [];
+  const args: ConnectionArguments = {};
+
+  const result = BfNode.connection(nodes, args);
+
+  assertEquals(result.edges.length, 0);
+});
+
+// Test data for pagination arguments
+const paginationTestCases = [
+  { name: "first arg", args: { first: 10 } },
+  { name: "last arg", args: { last: 5 } },
+  { name: "after arg", args: { after: "cursor123" } },
+  { name: "before arg", args: { before: "cursor456" } },
+  { name: "multiple pagination args", args: { first: 10, after: "cursor123" } },
+];
+
+for (const testCase of paginationTestCases) {
+  Deno.test(`BfNode.connection() - should throw BfErrorNotImplemented when ${testCase.name} provided`, () => {
+    const nodes: Array<TestNode> = [];
+
+    assertThrows(
+      () => BfNode.connection(nodes, testCase.args as ConnectionArguments),
+      BfErrorNotImplemented,
+      "Cursor-based pagination requires node traversal methods",
+    );
+  });
+}
+
+Deno.test("BfNode.connection() - should return same structure as connectionFromArray for valid args", () => {
+  const nodes: Array<TestNode> = [];
+  const args: ConnectionArguments = {};
+
+  const bfNodeResult = BfNode.connection(nodes, args);
+  const expectedResult = connectionFromArray(nodes, {});
+
+  assertEquals(bfNodeResult.edges.length, expectedResult.edges.length);
+  assertEquals(
+    bfNodeResult.pageInfo.hasNextPage,
+    expectedResult.pageInfo.hasNextPage,
+  );
+  assertEquals(
+    bfNodeResult.pageInfo.hasPreviousPage,
+    expectedResult.pageInfo.hasPreviousPage,
+  );
+  assertEquals(
+    bfNodeResult.pageInfo.startCursor,
+    expectedResult.pageInfo.startCursor,
+  );
+  assertEquals(
+    bfNodeResult.pageInfo.endCursor,
+    expectedResult.pageInfo.endCursor,
+  );
+});
+
+Deno.test("BfNode.connection() - error message should be helpful and specific", () => {
+  const nodes: Array<TestNode> = [];
+  const args: ConnectionArguments = { first: 10 };
+
+  assertThrows(
+    () => BfNode.connection(nodes, args),
+    BfErrorNotImplemented,
+    "Use static queries without pagination args for now",
+  );
+});

--- a/apps/bfDb/classes/__tests__/BfNode.traversal.test.ts
+++ b/apps/bfDb/classes/__tests__/BfNode.traversal.test.ts
@@ -1,0 +1,137 @@
+import { assertEquals } from "@std/assert";
+import { withIsolatedDb } from "@bfmono/apps/bfDb/bfDb.ts";
+import { makeLoggedInCv } from "@bfmono/apps/bfDb/utils/testUtils.ts";
+import { BfNode } from "@bfmono/apps/bfDb/classes/BfNode.ts";
+import type { InferProps } from "@bfmono/apps/bfDb/classes/BfNode.ts";
+import type { CurrentViewer } from "@bfmono/apps/bfDb/classes/CurrentViewer.ts";
+
+// Test node classes for graph traversal testing
+class TestPerson extends BfNode<InferProps<typeof TestPerson>> {
+  static override gqlSpec = this.defineGqlNode((f) =>
+    f.string("name").string("email").int("age")
+  );
+  static override bfNodeSpec = this.defineBfNode((f) =>
+    f.string("name").string("email").number("age")
+  );
+}
+
+class TestOrganization extends BfNode<InferProps<typeof TestOrganization>> {
+  static override gqlSpec = this.defineGqlNode((f) =>
+    f.string("orgName").string("domain")
+  );
+  static override bfNodeSpec = this.defineBfNode((f) =>
+    f.string("orgName").string("domain")
+  );
+}
+
+class TestProject extends BfNode<InferProps<typeof TestProject>> {
+  static override gqlSpec = this.defineGqlNode((f) =>
+    f.string("title").string("status")
+  );
+  static override bfNodeSpec = this.defineBfNode((f) =>
+    f.string("title").string("status")
+  );
+}
+
+// Test data setup helper
+async function setupTestGraphData(cv: CurrentViewer) {
+  // Create hierarchy: Org -> Project -> Person
+  const org = await TestOrganization.__DANGEROUS__createUnattached(cv, {
+    orgName: "Test Corp",
+    domain: "testcorp.com",
+  });
+
+  const project = await org.createTargetNode(TestProject, {
+    title: "Test Project",
+    status: "active",
+  }, { role: "owns" });
+
+  const person = await project.createTargetNode(TestPerson, {
+    name: "John Doe",
+    email: "john@testcorp.com",
+    age: 30,
+  }, { role: "assignedTo" });
+
+  return { org, project, person };
+}
+
+// Test 1: queryAncestorsByClassName - finds direct ancestors
+Deno.test("queryAncestorsByClassName - finds direct ancestors", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const { org, person } = await setupTestGraphData(cv);
+
+    // Query ancestors of person, looking for organizations
+    const ancestors = await person.queryAncestorsByClassName(
+      TestOrganization,
+    );
+
+    assertEquals(ancestors.length, 1);
+    assertEquals(ancestors[0].props.orgName, "Test Corp");
+    assertEquals(ancestors[0].metadata.bfGid, org.metadata.bfGid);
+  });
+});
+
+// Test 2: queryDescendantsByClassName - finds direct descendants
+Deno.test("queryDescendantsByClassName - finds direct descendants", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const { org, person } = await setupTestGraphData(cv);
+
+    const descendants = await org.queryDescendantsByClassName(
+      TestPerson,
+    );
+
+    assertEquals(descendants.length, 1);
+    assertEquals(descendants[0].props.name, "John Doe");
+    assertEquals(descendants[0].metadata.bfGid, person.metadata.bfGid);
+  });
+});
+
+// Test 3: querySourceInstances - finds nodes that connect to this node
+Deno.test("querySourceInstances - finds nodes that connect to this node", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const { org, project } = await setupTestGraphData(cv);
+
+    // Find organizations that connect to the project
+    const sources = await project.querySourceInstances(TestOrganization);
+
+    assertEquals(sources.length, 1);
+    assertEquals(sources[0].props.orgName, "Test Corp");
+    assertEquals(sources[0].metadata.bfGid, org.metadata.bfGid);
+  });
+});
+
+// Test 4: queryTargetInstances - finds nodes this node connects to
+Deno.test("queryTargetInstances - finds nodes this node connects to", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const { org, project } = await setupTestGraphData(cv);
+
+    // Find projects that the organization connects to
+    const targets = await org.queryTargetInstances(TestProject);
+
+    assertEquals(targets.length, 1);
+    assertEquals(targets[0].props.title, "Test Project");
+    assertEquals(targets[0].metadata.bfGid, project.metadata.bfGid);
+  });
+});
+
+// Test 5: Empty results when no relationships exist
+Deno.test("queryAncestorsByClassName - returns empty array when no ancestors", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const person = await TestPerson.__DANGEROUS__createUnattached(cv, {
+      name: "Isolated Person",
+      email: "isolated@test.com",
+      age: 30,
+    });
+
+    const ancestors = await person.queryAncestorsByClassName(
+      TestOrganization,
+    );
+
+    assertEquals(ancestors.length, 0);
+  });
+});

--- a/apps/bfDb/storage/registerDefaultAdapter.ts
+++ b/apps/bfDb/storage/registerDefaultAdapter.ts
@@ -14,6 +14,10 @@ const logger = getLogger(import.meta);
 
 let registered = false; // guard so we don't double‑register accidentally
 
+export function resetRegistration() {
+  registered = false;
+}
+
 export function registerDefaultAdapter() {
   if (registered) return; // idempotent
 
@@ -25,7 +29,8 @@ export function registerDefaultAdapter() {
     // fallthrough – nothing registered yet
   }
 
-  const env = getConfigurationVariable("DB_BACKEND_TYPE")?.toLowerCase() ??
+  const env = (getConfigurationVariable("FORCE_DB_BACKEND")?.toLowerCase() ||
+    getConfigurationVariable("DB_BACKEND_TYPE")?.toLowerCase()) ??
     "memory";
   logger.info(`registerDefaultAdapter → selecting '${env}' backend`);
 

--- a/apps/bfDb/storage/storage.ts
+++ b/apps/bfDb/storage/storage.ts
@@ -39,6 +39,14 @@ export const storage = {
     return adapter().getItem<T>(bfOid, bfGid);
   },
 
+  getByBfGid<T extends Props>(bfGid: string, className?: string) {
+    return adapter().getItemByBfGid<T>(bfGid, className);
+  },
+
+  getByBfGids<T extends Props>(bfGids: Array<string>, className?: string) {
+    return adapter().getItemsByBfGid<T>(bfGids, className);
+  },
+
   async put<T extends Props, M extends BfNodeMetadata | BfEdgeMetadata>(
     props: T,
     metadata: M,
@@ -66,7 +74,58 @@ export const storage = {
     );
   },
 
+  queryWithSizeLimit<T extends Props>(
+    metadata: Record<string, unknown>,
+    props: Partial<T> = {},
+    bfGids?: Array<string>,
+    order: "ASC" | "DESC" = "ASC",
+    orderBy?: string,
+    cursorValue?: number | string,
+    maxSizeBytes?: number,
+    batchSize?: number,
+  ): Promise<Array<DbItem<T>>> {
+    return adapter().queryItemsWithSizeLimit<T>(
+      metadata,
+      props,
+      bfGids,
+      order,
+      orderBy,
+      cursorValue,
+      maxSizeBytes,
+      batchSize,
+    );
+  },
+
   async delete(bfOid: BfGid, bfGid: BfGid) {
     await adapter().deleteItem(bfOid, bfGid);
+  },
+
+  // ---- Graph traversal -------------------------------------------------
+  queryAncestorsByClassName<T extends Props>(
+    bfOid: string,
+    targetBfGid: string,
+    sourceBfClassName: string,
+    depth: number = 10,
+  ): Promise<Array<DbItem<T>>> {
+    return adapter().queryAncestorsByClassName<T>(
+      bfOid,
+      targetBfGid,
+      sourceBfClassName,
+      depth,
+    );
+  },
+
+  queryDescendantsByClassName<T extends Props>(
+    bfOid: string,
+    sourceBfGid: string,
+    targetBfClassName: string,
+    depth: number = 10,
+  ): Promise<Array<DbItem<T>>> {
+    return adapter().queryDescendantsByClassName<T>(
+      bfOid,
+      sourceBfGid,
+      targetBfClassName,
+      depth,
+    );
   },
 } as const;

--- a/memos/plans/2025-07-14-restore-node-traversal.md
+++ b/memos/plans/2025-07-14-restore-node-traversal.md
@@ -1,0 +1,249 @@
+# Restore Node Traversal Functionality
+
+**Date**: 2025-07-14\
+**Status**: Draft\
+**Priority**: High\
+**Scope**: Core Infrastructure
+
+## Summary
+
+The current BfNode implementation lacks critical graph traversal capabilities
+that existed in the previous implementation. This memo outlines a plan to
+restore sophisticated node relationship traversal while maintaining the improved
+type safety and architecture of the current system.
+
+## Current State Analysis
+
+### ✅ What Works
+
+- Basic node CRUD operations (`query`, `find`, `findX`, `save`, `delete`)
+- Edge creation via `createTargetNode()`
+- Backend traversal infrastructure (`queryAncestorsByClassName`,
+  `queryDescendantsByClassName`)
+- Strong TypeScript typing with generics
+
+### ❌ Missing Critical Functionality
+
+- Instance-level traversal methods on BfNode
+- Edge-based relationship querying
+- GraphQL connection support for relationships
+- Ancestor/descendant traversal from node instances
+- Smart edge cleanup and cascade deletion
+- Orphan node detection and cleanup
+
+### 🚧 Partially Implemented
+
+- BfEdge has commented-out traversal methods that need completion
+- Backend database functions exist but lack frontend API
+
+## Implementation Plan
+
+### Phase 1: Core Instance Traversal Methods
+
+Add these methods to `BfNode` class:
+
+```typescript
+// Recursive tree traversal
+public async queryAncestorsByClassName<TSourceClass>(
+  BfNodeClass: TSourceClass,
+  limit: number = 10,
+): Promise<Array<InstanceType<TSourceClass>>>
+
+public async queryDescendantsByClassName<TTargetClass>(
+  BfNodeClass: TTargetClass, 
+  limit: number = 10,
+): Promise<Array<InstanceType<TTargetClass>>>
+
+// Direct relationship traversal
+public async querySourceInstances<TSourceClass>(
+  SourceClass: TSourceClass,
+  nodeProps?: Partial<BfNodeProps>,
+  edgeProps?: Partial<BfEdgeProps>
+): Promise<Array<InstanceType<TSourceClass>>>
+
+public async queryTargetInstances<TTargetClass>(
+  TargetClass: TTargetClass,
+  nodeProps?: Partial<BfNodeProps>, 
+  edgeProps?: Partial<BfEdgeProps>
+): Promise<Array<InstanceType<TTargetClass>>>
+```
+
+**Dependencies**:
+
+- Use existing `DatabaseBackend.queryAncestorsByClassName()` and
+  `queryDescendantsByClassName()`
+- Delegate edge-based queries to restored BfEdge methods
+
+### Phase 2: Restore BfEdge Traversal Methods
+
+Uncomment and complete these methods in `BfEdge`:
+
+```typescript
+// Core edge traversal
+static async querySourceInstances<TSourceClass>(
+  currentViewer: BfCurrentViewer,
+  SourceClass: TSourceClass,
+  targetBfGid: string,
+  nodeProps?: Partial<BfNodeProps>
+): Promise<Array<InstanceType<TSourceClass>>>
+
+static async queryTargetInstances<TTargetClass>(
+  currentViewer: BfCurrentViewer,
+  TargetClass: TTargetClass,
+  sourceBfGid: string,
+  nodeProps?: Partial<BfNodeProps>,
+  edgeProps?: Partial<BfEdgeProps>  
+): Promise<Array<InstanceType<TTargetClass>>>
+
+// Edge discovery
+static async querySourceEdgesForNode(bfNode: BfNode): Promise<Array<BfEdge>>
+static async queryTargetEdgesForNode(bfNode: BfNode): Promise<Array<BfEdge>>
+```
+
+**Implementation Pattern**:
+
+1. Query edges using existing `BfEdge.query()` method
+2. Extract node IDs from edge results
+3. Batch query nodes using `TargetClass.query()` with ID filter
+4. Return properly typed node instances
+
+### Phase 3: GraphQL Connection Support
+
+Add GraphQL pagination support for relationship queries:
+
+```typescript
+// On BfNode
+public async queryTargetsConnectionForGraphQL<TTargetClass>(
+  TargetClass: TTargetClass,
+  connectionArgs: ConnectionArguments,
+  nodeProps?: Partial<BfNodeProps>,
+  edgeProps?: Partial<BfEdgeProps>
+): Promise<Connection<InstanceType<TTargetClass>>>
+
+// On BfEdge  
+static async queryTargetsConnectionForGraphQL<TTargetClass>(
+  currentViewer: BfCurrentViewer,
+  TargetClass: TTargetClass,
+  sourceBfGid: string,
+  nodeProps: Partial<BfNodeProps>,
+  connectionArgs: ConnectionArguments,
+  edgeProps?: Partial<BfEdgeProps>
+): Promise<Connection<InstanceType<TTargetClass>>>
+```
+
+**Features**:
+
+- Cursor-based pagination
+- Total count support
+- Proper GraphQL Connection interface compliance
+
+### Phase 4: Smart Deletion and Lifecycle Management
+
+Restore intelligent edge and node cleanup:
+
+```typescript
+// On BfEdge
+static async deleteEdgesTouchingNode(
+  currentViewer: BfCurrentViewer, 
+  bfGid: string
+): Promise<void>
+
+static async deleteAndCheckForNetworkDelete(
+  currentViewer: BfCurrentViewer,
+  edge: BfEdge
+): Promise<void>
+
+// On BfNode - override delete method
+override async delete(): Promise<void> {
+  const bfGid = this.metadata.bfGid;
+  await super.delete();
+  await BfEdge.deleteEdgesTouchingNode(this.currentViewer, bfGid);
+}
+```
+
+**Smart Deletion Logic**:
+
+- When deleting edge, check if target becomes orphaned
+- If target has no remaining incoming edges, delete target node
+- Prevent orphaned nodes in the graph
+- Maintain referential integrity
+
+## Implementation Details
+
+### Type Safety Considerations
+
+All methods must maintain strict TypeScript typing:
+
+- Use generics with proper constraints: `TClass extends Constructor<BfNode>`
+- Return properly typed instances: `Array<InstanceType<TClass>>`
+- Support both required and optional props filtering
+- Maintain compatibility with existing GraphQL schema generation
+
+### Performance Optimizations
+
+- **Default Limits**: All traversal methods default to `limit: 10` to prevent
+  runaway queries
+- **Cycle Detection**: Backend already handles cycles in recursive queries
+- **Batch Queries**: Use efficient two-phase queries (edges first, then nodes)
+- **Organization Scoping**: All queries automatically scoped to current viewer's
+  organization
+
+### Error Handling
+
+- Use consistent error patterns from current codebase
+- Handle edge cases like missing nodes, invalid relationships
+- Provide clear error messages for relationship constraint violations
+
+### Testing Strategy
+
+Create comprehensive test suites covering:
+
+- **Basic Traversal**: Direct parent/child relationships
+- **Deep Traversal**: Multi-level ancestor/descendant queries
+- **Complex Graphs**: Multiple parents, shared children, cycles
+- **Performance**: Large relationship sets, depth limits
+- **Edge Cases**: Orphaned nodes, missing relationships
+- **GraphQL**: Connection pagination, cursor handling
+
+## Migration Strategy
+
+### Backward Compatibility
+
+- All new methods are additive - no breaking changes
+- Existing `createTargetNode()` continues to work unchanged
+- Current test suites remain valid
+
+### Rollout Plan
+
+1. **Phase 1**: Implement and test core traversal methods
+2. **Phase 2**: Restore edge traversal with comprehensive testing
+3. **Phase 3**: Add GraphQL connections (non-breaking)
+4. **Phase 4**: Implement smart deletion (potentially breaking - needs
+   migration)
+
+### Risk Mitigation
+
+- Extensive testing of cycle detection and performance limits
+- Gradual rollout with feature flags if needed
+- Monitor query performance in production
+- Document all traversal patterns and best practices
+
+## Success Criteria
+
+- [ ] All traversal methods from old implementation are restored
+- [ ] Performance meets or exceeds old implementation
+- [ ] Type safety is maintained throughout
+- [ ] GraphQL schema generation works with new relationships
+- [ ] Comprehensive test coverage (>95%) for all traversal scenarios
+- [ ] Production usage validates no performance regressions
+
+## Future Considerations
+
+- **Query Optimization**: Consider adding traversal query planning/optimization
+- **Caching**: Implement relationship caching for frequently accessed paths
+- **Subscriptions**: Add real-time updates for relationship changes
+- **Visual Tools**: Consider relationship visualization and debugging tools
+
+This implementation will restore the sophisticated graph traversal capabilities
+that make BfNode suitable for complex relationship modeling while maintaining
+the improved architecture and type safety of the current system.

--- a/memos/plans/2025-07-14-scratch-graphql-connections.md
+++ b/memos/plans/2025-07-14-scratch-graphql-connections.md
@@ -1,0 +1,254 @@
+# Scratch GraphQL Connections Implementation
+
+**Date:** 2025-07-14\
+**Status:** Planning\
+**Context:** Enabling RLHF pipeline development with basic GraphQL connections
+
+## Problem Statement
+
+The GraphQL connection builder infrastructure exists and works, but cannot be
+used for real relationships because node traversal methods are missing/commented
+out. We need a scratch implementation that:
+
+1. Allows RLHF development to proceed with real data
+2. Provides the GraphQL connection structure frontend expects
+3. Fails gracefully when pagination is attempted
+4. Creates clear pressure to restore traversal when needed
+
+## Current State
+
+**✅ Working:**
+
+- GraphQL connection builder in `makeGqlBuilder.ts`
+- Relay-style schema generation
+- BlogPost example (but uses filesystem, not relationships)
+
+**❌ Missing:**
+
+- `node.queryTargetInstances()` / `node.querySources()` methods
+- All `BfEdge.ts` traversal methods (commented out lines 82-192)
+- API layer between backend traversal and node instances
+
+## Proposed Solution: Option C Implementation
+
+### Core Approach
+
+Add a static `connection()` method to `BfNode` that:
+
+- **Works for basic queries** (no pagination args)
+- **Returns real data** using static queries as fallback
+- **Fails clearly** when cursor-based pagination is attempted
+- **Maintains GraphQL connection structure**
+
+### Implementation Plan
+
+#### 1. Use Existing BfErrorNotImplemented
+
+```typescript
+// Already exists in lib/BfError.ts - no need to create new class
+export class BfError extends Error {}
+export class BfErrorNotImplemented extends BfError {
+  override message = "Not implemented";
+}
+```
+
+#### 2. Add Static Connection Method to BfNode
+
+```typescript
+// In apps/bfDb/classes/BfNode.ts
+import { BfErrorNotImplemented } from '@bfmono/lib/BfError.ts';
+
+static connection<T extends BfNode>(
+  nodes: Array<T>, 
+  args: ConnectionArguments
+): Connection<T> {
+  // Check for pagination args
+  if (args.first || args.last || args.after || args.before) {
+    throw new BfErrorNotImplemented(
+      "Cursor-based pagination requires node traversal methods. Use static queries without pagination args for now."
+    );
+  }
+  
+  // Return basic connection structure
+  return connectionFromArray(nodes, {});
+}
+```
+
+#### 3. Add Relationship Query Fallbacks
+
+For specific relationship patterns needed in RLHF (using proper edge-based
+queries):
+
+```typescript
+// Temporary fallback for deck -> samples (via edges)
+static async querySamplesForDeck(
+  cv: CurrentViewer,
+  deckId: BfGid
+): Promise<Array<BfSample>> {
+  // 1. Query edges from deck to samples
+  const edges = await BfEdge.query(
+    cv,
+    { 
+      bfSid: deckId, // source ID = deck
+      bfTClassName: "BfSample" // target class = samples
+    },
+    {}, // no edge props filter
+    [] // no specific edge IDs
+  );
+  
+  // 2. Extract target IDs (sample IDs)
+  const sampleIds = edges.map(edge => 
+    (edge.metadata as BfEdgeMetadata).bfTid
+  );
+  
+  // 3. Query sample nodes
+  if (sampleIds.length === 0) return [];
+  
+  return BfSample.query(
+    cv,
+    { className: "BfSample" },
+    {}, // no props filter
+    sampleIds
+  );
+}
+
+// Temporary fallback for sample -> results  
+static async queryResultsForSample(
+  cv: CurrentViewer,
+  sampleId: BfGid
+): Promise<Array<BfGraderResult>> {
+  // Similar pattern for sample -> grader results
+  const edges = await BfEdge.query(
+    cv,
+    { 
+      bfSid: sampleId,
+      bfTClassName: "BfGraderResult" // target class = grader results
+    },
+    {},
+    []
+  );
+  
+  const resultIds = edges.map(edge => 
+    (edge.metadata as BfEdgeMetadata).bfTid
+  );
+  
+  if (resultIds.length === 0) return [];
+  
+  return BfGraderResult.query(
+    cv,
+    { className: "BfGraderResult" },
+    {},
+    resultIds
+  );
+}
+```
+
+#### 4. GraphQL Builder Integration
+
+Update connection resolvers to use the new pattern:
+
+```typescript
+.connection("samples", () => BfSample, {
+  resolve: async (deck, args) => {
+    const samples = await BfSample.querySamplesForDeck(deck.id);
+    return BfSample.connection(samples, args);
+  }
+})
+```
+
+### Error Handling Strategy
+
+**Clear Error Messages:**
+
+- Mention exactly what's missing (node traversal methods)
+- Point to the workaround (static queries)
+- Create pressure to implement real solution
+
+**Graceful Degradation:**
+
+- Basic relationship queries work with real data
+- Only pagination fails, not the entire query
+- Frontend gets expected GraphQL connection structure
+
+### Benefits
+
+1. **Unblocks RLHF Development:** Can build with real relationship data
+2. **Progressive Implementation:** Add traversal methods when actually needed
+3. **Clear Failure Boundary:** Only breaks on pagination, not basic queries
+4. **Maintains Type Safety:** Uses existing GraphQL connection types
+5. **Future-Compatible:** Easy to swap in real traversal when restored
+
+### Migration Path
+
+**Phase 1:** Implement scratch connections (this memo) **Phase 2:** Build RLHF
+pipeline with basic relationship queries\
+**Phase 3:** Restore node traversal when pagination needed **Phase 4:** Replace
+scratch methods with real traversal
+
+### Files to Modify
+
+- `apps/bfDb/classes/BfNode.ts` - Add static connection method (import existing
+  BfErrorNotImplemented)
+- RLHF entity classes - Add specific relationship query methods
+- GraphQL resolvers - Update to use new connection pattern
+
+### Success Criteria
+
+- [ ] Can query `deck.samples` without pagination
+- [ ] Returns real BfSample instances from relationships
+- [ ] Clear error when pagination args used
+- [ ] GraphQL schema generates correctly
+- [ ] Frontend receives expected connection structure
+
+## Next Steps
+
+1. Implement static connection method in BfNode
+2. Add relationship fallback methods for RLHF entities
+3. Test with basic GraphQL queries
+4. Proceed with RLHF implementation using this pattern
+
+## Appendix: Related Files
+
+### Core Implementation Files
+
+- `apps/bfDb/classes/BfNode.ts` - Base node class, where static connection
+  method will be added
+- `apps/bfDb/nodeTypes/BfEdge.ts` - Edge class with commented traversal methods
+  (lines 82-192)
+- `apps/bfDb/builders/graphql/makeGqlBuilder.ts` - GraphQL connection builder
+  infrastructure
+
+### GraphQL Infrastructure
+
+- `apps/bfDb/graphql/graphqlServer.ts` - GraphQL server setup
+- `apps/bfDb/graphql/__generated__/schema.graphql` - Generated schema with
+  connection types
+- `apps/bfDb/builders/graphql/gqlSpecToNexus.ts` - Schema generation from specs
+
+### Example Implementation (Filesystem-based)
+
+- `apps/boltFoundry/nodeTypes/BlogPost.ts` - Current working connection example
+- Test: `apps/bfDb/tests/test-blogposts-connection.sh`
+
+### RLHF Entity Files (Target Implementation)
+
+- `apps/boltfoundry-com/nodeTypes/BfDeck.ts` - Deck entity for RLHF
+- `apps/boltfoundry-com/nodeTypes/BfSample.ts` - Sample entity
+- `apps/boltfoundry-com/nodeTypes/BfGrader.ts` - Grader entity
+- `apps/boltfoundry-com/nodeTypes/BfGraderResult.ts` - Grader result entity
+
+### Related Documentation
+
+- `apps/bfDb/memos/feature-gap-analysis.md` - Analysis of missing traversal
+  features
+- `apps/boltfoundry-com/memos/plans/rlhf-pipeline-data-model-implementation.md` -
+  RLHF implementation plan
+- `memos/plans/2025-07-14-restore-node-traversal.md` - Plan for restoring full
+  traversal
+
+### Backend Infrastructure (Working)
+
+- `apps/bfDb/infra/adapters/sqlite.ts` - SQLite adapter with traversal methods
+- `apps/bfDb/infra/adapters/postgresql.ts` - PostgreSQL adapter with traversal
+  methods
+- `apps/bfDb/infra/adapters/neon.ts` - Neon adapter with traversal methods

--- a/memos/plans/2025-07-15-phase-2-tdd-edge-traversal-plan.md
+++ b/memos/plans/2025-07-15-phase-2-tdd-edge-traversal-plan.md
@@ -1,0 +1,1045 @@
+# Phase 2: TDD Implementation Plan for BfEdge Traversal Methods
+
+**Date**: 2025-07-15\
+**Status**: Draft\
+**Priority**: High\
+**Scope**: Core Infrastructure\
+**Depends on**: Phase 1 BfNode Traversal Methods
+
+## Overview
+
+This plan provides a comprehensive Test-Driven Development (TDD) approach for
+implementing Phase 2: Restore BfEdge Traversal Methods. It focuses on
+uncommenting and fixing the four key methods in
+`/Users/randallb/randallb.com/areas/bolt-foundry-monorepo/apps/bfDb/nodeTypes/BfEdge.ts`
+that are currently commented out with type errors.
+
+## Current State Analysis
+
+### ✅ What Exists and Works
+
+- `BfEdge.createBetweenNodes()` - Creates edges between nodes
+- `BfEdge.generateEdgeMetadata()` - Generates proper edge metadata
+- `BfEdge` extends `BfNode` with proper typing
+- Basic edge CRUD operations via inherited `BfNode.query()`
+- Test infrastructure established in BfNode tests
+
+### ❌ Commented-Out Methods (Lines 82-192)
+
+Four critical methods need to be restored and fixed:
+
+1. **`querySourceInstances<TSourceClass>`** (Lines 82-119)
+2. **`queryTargetInstances<TTargetClass>`** (Lines 137-173)
+3. **`querySourceEdgesForNode`** (Lines 121-135)
+4. **`queryTargetEdgesForNode`** (Lines 175-192)
+
+### 🚧 Key Type Issues to Fix
+
+Based on analysis of the commented code:
+
+1. **Import Issues**: Missing imports for `BfGid`, `BfNodeCache`,
+   `BfMetadataEdge`
+2. **Type Inconsistencies**: References to `BfNodeBase` instead of `BfNode`
+3. **Metadata Type Errors**: `BfMetadataEdge` should be `BfEdgeMetadata`
+4. **Parameter Naming**: Inconsistent variable naming (e.g.,
+   `_edgePropsToQuery`)
+5. **Generic Constraints**: Missing proper constraints on type parameters
+
+## Pre-Implementation Setup
+
+### Test File Structure
+
+```
+apps/bfDb/nodeTypes/__tests__/BfEdge.traversal.test.ts
+```
+
+### Required Test Fixtures
+
+```typescript
+// Test classes for edge traversal testing
+class TestUser extends BfNode<InferProps<typeof TestUser>> {
+  static override bfNodeSpec = this.defineBfNode((f) =>
+    f.string("name").string("email").number("role")
+  );
+  static override gqlSpec = this.defineGqlNode((f) =>
+    f.string("name").string("email").int("role")
+  );
+}
+
+class TestCompany extends BfNode<InferProps<typeof TestCompany>> {
+  static override bfNodeSpec = this.defineBfNode((f) =>
+    f.string("companyName").string("industry")
+  );
+  static override gqlSpec = this.defineGqlNode((f) =>
+    f.string("companyName").string("industry")
+  );
+}
+
+class TestProject extends BfNode<InferProps<typeof TestProject>> {
+  static override bfNodeSpec = this.defineBfNode((f) =>
+    f.string("title").string("status").number("priority")
+  );
+  static override gqlSpec = this.defineGqlNode((f) =>
+    f.string("title").string("status").int("priority")
+  );
+}
+```
+
+### Test Graph Data Helper
+
+```typescript
+async function setupEdgeTestGraph(cv: CurrentViewer) {
+  // Create nodes
+  const company = await TestCompany.__DANGEROUS__createUnattached(cv, {
+    companyName: "Tech Corp",
+    industry: "Software",
+  });
+
+  const project = await TestProject.__DANGEROUS__createUnattached(cv, {
+    title: "AI Platform",
+    status: "active",
+    priority: 1,
+  });
+
+  const user1 = await TestUser.__DANGEROUS__createUnattached(cv, {
+    name: "Alice Johnson",
+    email: "alice@techcorp.com",
+    role: 1, // Engineer
+  });
+
+  const user2 = await TestUser.__DANGEROUS__createUnattached(cv, {
+    name: "Bob Smith",
+    email: "bob@techcorp.com",
+    role: 2, // Manager
+  });
+
+  // Create edges with different roles
+  const companyProjectEdge = await BfEdge.createBetweenNodes(
+    cv,
+    company,
+    project,
+    { role: "owns" },
+  );
+
+  const projectUser1Edge = await BfEdge.createBetweenNodes(
+    cv,
+    project,
+    user1,
+    { role: "assignedTo" },
+  );
+
+  const projectUser2Edge = await BfEdge.createBetweenNodes(
+    cv,
+    project,
+    user2,
+    { role: "manages" },
+  );
+
+  return {
+    company,
+    project,
+    user1,
+    user2,
+    edges: {
+      companyProject: companyProjectEdge,
+      projectUser1: projectUser1Edge,
+      projectUser2: projectUser2Edge,
+    },
+  };
+}
+```
+
+## Method 1: `querySourceInstances` Restoration
+
+### 1.1 Current Code Analysis (Lines 82-119)
+
+**Identified Issues:**
+
+- `BfGid` type not imported
+- `BfNodeCache<TSourceProps>` incorrect - should be `BfNodeCache<TSourceProps>`
+- `_edgePropsToQuery` parameter renamed but not used consistently
+- `BfEdgeMetadata` used instead of `BfEdgeMetadata`
+- Missing proper error handling
+
+### 1.2 Corrected Method Signature
+
+```typescript
+static async querySourceInstances<
+  TSourceClass extends typeof BfNode<TSourceProps>,
+  TSourceProps extends PropsBase = PropsBase,
+>(
+  cv: CurrentViewer,
+  SourceClass: TSourceClass,
+  targetId: BfGid,
+  propsToQuery: Partial<TSourceProps> = {},
+  edgePropsToQuery: Partial<BfEdgeBaseProps> = {},
+  cache?: BfNodeCache<TSourceProps>,
+): Promise<Array<InstanceType<TSourceClass>>>
+```
+
+### 1.3 Test Cases (Write First)
+
+#### Test 1: Basic Source Instance Query
+
+```typescript
+Deno.test("BfEdge.querySourceInstances - finds source nodes connected to target", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const { company, project } = await setupEdgeTestGraph(cv);
+
+    // Find all companies that connect to the project
+    const sourceCompanies = await BfEdge.querySourceInstances(
+      cv,
+      TestCompany,
+      project.metadata.bfGid,
+    );
+
+    assertEquals(sourceCompanies.length, 1);
+    assertEquals(sourceCompanies[0].props.companyName, "Tech Corp");
+    assertEquals(sourceCompanies[0].metadata.bfGid, company.metadata.bfGid);
+  });
+});
+```
+
+#### Test 2: Filter by Node Properties
+
+```typescript
+Deno.test("BfEdge.querySourceInstances - filters by source node properties", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const project = await TestProject.__DANGEROUS__createUnattached(cv, {
+      title: "Shared Project",
+      status: "active",
+      priority: 1,
+    });
+
+    // Create multiple companies connecting to same project
+    const techCompany = await TestCompany.__DANGEROUS__createUnattached(cv, {
+      companyName: "Tech Innovators",
+      industry: "Software",
+    });
+
+    const consultingCompany = await TestCompany.__DANGEROUS__createUnattached(
+      cv,
+      {
+        companyName: "Business Solutions",
+        industry: "Consulting",
+      },
+    );
+
+    await BfEdge.createBetweenNodes(cv, techCompany, project, { role: "owns" });
+    await BfEdge.createBetweenNodes(cv, consultingCompany, project, {
+      role: "sponsors",
+    });
+
+    // Filter by industry
+    const techSources = await BfEdge.querySourceInstances(
+      cv,
+      TestCompany,
+      project.metadata.bfGid,
+      { industry: "Software" },
+    );
+
+    assertEquals(techSources.length, 1);
+    assertEquals(techSources[0].props.companyName, "Tech Innovators");
+  });
+});
+```
+
+#### Test 3: Filter by Edge Properties
+
+```typescript
+Deno.test("BfEdge.querySourceInstances - filters by edge properties", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const { project } = await setupEdgeTestGraph(cv);
+
+    // Find only projects that "manage" users (edge role filter)
+    const managingSources = await BfEdge.querySourceInstances(
+      cv,
+      TestProject,
+      project.metadata.bfGid,
+      {}, // No node props filter
+      { role: "owns" }, // Edge props filter
+    );
+
+    assertEquals(managingSources.length, 1);
+    assertEquals(managingSources[0].props.title, "AI Platform");
+  });
+});
+```
+
+#### Test 4: Empty Results
+
+```typescript
+Deno.test("BfEdge.querySourceInstances - returns empty array when no sources", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const orphanProject = await TestProject.__DANGEROUS__createUnattached(cv, {
+      title: "Orphan Project",
+      status: "abandoned",
+      priority: 0,
+    });
+
+    const sources = await BfEdge.querySourceInstances(
+      cv,
+      TestCompany,
+      orphanProject.metadata.bfGid,
+    );
+
+    assertEquals(sources.length, 0);
+  });
+});
+```
+
+#### Test 5: Multiple Sources Same Class
+
+```typescript
+Deno.test("BfEdge.querySourceInstances - returns multiple sources of same class", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const user = await TestUser.__DANGEROUS__createUnattached(cv, {
+      name: "Popular Developer",
+      email: "dev@test.com",
+      role: 1,
+    });
+
+    // Create multiple projects connecting to same user
+    const project1 = await TestProject.__DANGEROUS__createUnattached(cv, {
+      title: "Project Alpha",
+      status: "active",
+      priority: 1,
+    });
+
+    const project2 = await TestProject.__DANGEROUS__createUnattached(cv, {
+      title: "Project Beta",
+      status: "planning",
+      priority: 2,
+    });
+
+    await BfEdge.createBetweenNodes(cv, project1, user, { role: "assignedTo" });
+    await BfEdge.createBetweenNodes(cv, project2, user, { role: "assignedTo" });
+
+    const sourceProjects = await BfEdge.querySourceInstances(
+      cv,
+      TestProject,
+      user.metadata.bfGid,
+    );
+
+    assertEquals(sourceProjects.length, 2);
+    const titles = sourceProjects.map((p) => p.props.title).sort();
+    assertEquals(titles, ["Project Alpha", "Project Beta"]);
+  });
+});
+```
+
+### 1.4 Implementation Steps
+
+1. **Fix Imports**: Add missing type imports
+2. **Fix Parameter Types**: Correct type inconsistencies
+3. **Fix Metadata Queries**: Use correct `BfEdgeMetadata` type
+4. **Add Error Handling**: Handle edge cases gracefully
+5. **Optimize Query Pattern**: Ensure efficient two-step query approach
+
+#### Fixed Implementation
+
+```typescript
+static async querySourceInstances<
+  TSourceClass extends typeof BfNode<TSourceProps>,
+  TSourceProps extends PropsBase = PropsBase,
+>(
+  cv: CurrentViewer,
+  SourceClass: TSourceClass,
+  targetId: BfGid,
+  propsToQuery: Partial<TSourceProps> = {},
+  edgePropsToQuery: Partial<BfEdgeBaseProps> = {},
+  cache?: BfNodeCache<TSourceProps>,
+): Promise<Array<InstanceType<TSourceClass>>> {
+  // Query edges that have this target ID
+  const edgeMetadata: Partial<BfEdgeMetadata> = {
+    bfTid: targetId,
+    className: this.name,
+  };
+
+  // Find all edges that connect to the target node with matching properties
+  const edges = await this.query(cv, edgeMetadata, edgePropsToQuery, []);
+
+  if (edges.length === 0) {
+    return [];
+  }
+
+  // Extract source IDs from the edges
+  const sourceIds = edges.map((edge) => (edge.metadata as BfEdgeMetadata).bfSid);
+
+  // Query the source nodes by their IDs
+  return SourceClass.query(
+    cv,
+    { className: SourceClass.name },
+    propsToQuery,
+    sourceIds,
+    cache,
+  );
+}
+```
+
+## Method 2: `queryTargetInstances` Restoration
+
+### 2.1 Current Code Analysis (Lines 137-173)
+
+**Similar Issues to Method 1:**
+
+- Same import and type issues
+- `BfNodeBaseProps` should be `PropsBase`
+- `BfMetadataEdge` should be `BfEdgeMetadata`
+- Missing error handling
+
+### 2.2 Test Cases (Write First)
+
+#### Test 1: Basic Target Instance Query
+
+```typescript
+Deno.test("BfEdge.queryTargetInstances - finds target nodes connected from source", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const { company, project, user1, user2 } = await setupEdgeTestGraph(cv);
+
+    // Find all projects that the company connects to
+    const targetProjects = await BfEdge.queryTargetInstances(
+      cv,
+      TestProject,
+      company.metadata.bfGid,
+    );
+
+    assertEquals(targetProjects.length, 1);
+    assertEquals(targetProjects[0].props.title, "AI Platform");
+    assertEquals(targetProjects[0].metadata.bfGid, project.metadata.bfGid);
+  });
+});
+```
+
+#### Test 2: Multiple Targets Different Classes
+
+```typescript
+Deno.test("BfEdge.queryTargetInstances - finds targets of specific class only", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const project = await TestProject.__DANGEROUS__createUnattached(cv, {
+      title: "Multi-Target Project",
+      status: "active",
+      priority: 1,
+    });
+
+    // Connect project to users and other projects
+    const user = await project.createTargetNode(TestUser, {
+      name: "Team Member",
+      email: "member@test.com",
+      role: 1,
+    }, { role: "assignedTo" });
+
+    const subProject = await project.createTargetNode(TestProject, {
+      title: "Sub Project",
+      status: "planning",
+      priority: 2,
+    }, { role: "contains" });
+
+    // Query only for User targets
+    const targetUsers = await BfEdge.queryTargetInstances(
+      cv,
+      TestUser,
+      project.metadata.bfGid,
+    );
+
+    assertEquals(targetUsers.length, 1);
+    assertEquals(targetUsers[0].props.name, "Team Member");
+
+    // Query only for Project targets
+    const targetProjects = await BfEdge.queryTargetInstances(
+      cv,
+      TestProject,
+      project.metadata.bfGid,
+    );
+
+    assertEquals(targetProjects.length, 1);
+    assertEquals(targetProjects[0].props.title, "Sub Project");
+  });
+});
+```
+
+#### Test 3: Filter by Edge and Node Properties
+
+```typescript
+Deno.test("BfEdge.queryTargetInstances - filters by edge and node properties", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const { project } = await setupEdgeTestGraph(cv);
+
+    // Query users with specific role filter (node props) and edge role filter
+    const managers = await BfEdge.queryTargetInstances(
+      cv,
+      TestUser,
+      project.metadata.bfGid,
+      { role: 2 }, // Node filter: role = Manager
+      { role: "manages" }, // Edge filter
+    );
+
+    assertEquals(managers.length, 1);
+    assertEquals(managers[0].props.name, "Bob Smith");
+  });
+});
+```
+
+### 2.3 Fixed Implementation
+
+```typescript
+static async queryTargetInstances<
+  TTargetClass extends typeof BfNode<TTargetProps>,
+  TTargetProps extends PropsBase = PropsBase,
+>(
+  cv: CurrentViewer,
+  TargetClass: TTargetClass,
+  sourceId: BfGid,
+  propsToQuery: Partial<TTargetProps> = {},
+  edgePropsToQuery: Partial<BfEdgeBaseProps> = {},
+  cache?: BfNodeCache<TTargetProps>,
+): Promise<Array<InstanceType<TTargetClass>>> {
+  // Query edges that have this source ID
+  const edgeMetadata: Partial<BfEdgeMetadata> = {
+    bfSid: sourceId,
+    className: this.name,
+  };
+
+  // Find all edges that connect from the source node with matching properties
+  const edges = await this.query(cv, edgeMetadata, edgePropsToQuery, []);
+
+  if (edges.length === 0) {
+    return [];
+  }
+
+  // Extract target IDs from the edges
+  const targetIds = edges.map((edge) => (edge.metadata as BfEdgeMetadata).bfTid);
+
+  // Query the target nodes by their IDs
+  return TargetClass.query(
+    cv,
+    { className: TargetClass.name },
+    propsToQuery,
+    targetIds,
+    cache,
+  );
+}
+```
+
+## Method 3: `querySourceEdgesForNode` Restoration
+
+### 3.1 Current Code Analysis (Lines 121-135)
+
+**Issues:**
+
+- `BfNodeBase` should be `BfNode`
+- `BfMetadataEdge` should be `BfEdgeMetadata`
+- Missing proper typing for return value
+- No CurrentViewer parameter needed (can get from node)
+
+### 3.2 Corrected Method Signature
+
+```typescript
+static async querySourceEdgesForNode<TProps extends BfEdgeBaseProps = BfEdgeBaseProps>(
+  node: BfNode,
+  cache?: BfNodeCache<TProps>,
+): Promise<Array<InstanceType<typeof BfEdge<TProps>>>>
+```
+
+### 3.3 Test Cases (Write First)
+
+#### Test 1: Find Incoming Edges
+
+```typescript
+Deno.test("BfEdge.querySourceEdgesForNode - finds edges where node is target", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const { project, edges } = await setupEdgeTestGraph(cv);
+
+    // Find edges where project is the target (company -> project)
+    const incomingEdges = await BfEdge.querySourceEdgesForNode(project);
+
+    assertEquals(incomingEdges.length, 1);
+    assertEquals(incomingEdges[0].props.role, "owns");
+    assertEquals(
+      incomingEdges[0].metadata.bfGid,
+      edges.companyProject.metadata.bfGid,
+    );
+
+    // Verify edge metadata
+    const edgeMetadata = incomingEdges[0].metadata as BfEdgeMetadata;
+    assertEquals(edgeMetadata.bfTid, project.metadata.bfGid);
+  });
+});
+```
+
+#### Test 2: Multiple Incoming Edges
+
+```typescript
+Deno.test("BfEdge.querySourceEdgesForNode - finds multiple incoming edges", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const user = await TestUser.__DANGEROUS__createUnattached(cv, {
+      name: "Popular User",
+      email: "popular@test.com",
+      role: 1,
+    });
+
+    // Create multiple projects connecting to the user
+    const projectA = await TestProject.__DANGEROUS__createUnattached(cv, {
+      title: "Project A",
+      status: "active",
+      priority: 1,
+    });
+
+    const projectB = await TestProject.__DANGEROUS__createUnattached(cv, {
+      title: "Project B",
+      status: "planning",
+      priority: 2,
+    });
+
+    const edgeA = await BfEdge.createBetweenNodes(cv, projectA, user, {
+      role: "assignedTo",
+    });
+    const edgeB = await BfEdge.createBetweenNodes(cv, projectB, user, {
+      role: "reviewing",
+    });
+
+    const incomingEdges = await BfEdge.querySourceEdgesForNode(user);
+
+    assertEquals(incomingEdges.length, 2);
+    const roles = incomingEdges.map((e) => e.props.role).sort();
+    assertEquals(roles, ["assignedTo", "reviewing"]);
+  });
+});
+```
+
+#### Test 3: No Incoming Edges
+
+```typescript
+Deno.test("BfEdge.querySourceEdgesForNode - returns empty array when no incoming edges", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const isolatedNode = await TestUser.__DANGEROUS__createUnattached(cv, {
+      name: "Isolated User",
+      email: "isolated@test.com",
+      role: 1,
+    });
+
+    const incomingEdges = await BfEdge.querySourceEdgesForNode(isolatedNode);
+
+    assertEquals(incomingEdges.length, 0);
+  });
+});
+```
+
+### 3.4 Fixed Implementation
+
+```typescript
+static async querySourceEdgesForNode<TProps extends BfEdgeBaseProps = BfEdgeBaseProps>(
+  node: BfNode,
+  cache?: BfNodeCache<TProps>,
+): Promise<Array<InstanceType<typeof BfEdge<TProps>>>> {
+  // Query edges where the provided node is the target
+  const metadataToQuery: Partial<BfEdgeMetadata> = {
+    bfTid: node.metadata.bfGid,
+    className: this.name,
+  };
+
+  return this.query(
+    node.cv,
+    metadataToQuery,
+    {}, // No specific props filter
+    [], // No specific IDs filter
+    undefined, // No specific options
+    cache,
+  ) as Promise<Array<InstanceType<typeof BfEdge<TProps>>>>;
+}
+```
+
+## Method 4: `queryTargetEdgesForNode` Restoration
+
+### 4.1 Current Code Analysis (Lines 175-192)
+
+**Similar Issues to Method 3:**
+
+- Same type and parameter issues
+- Missing proper return typing
+
+### 4.2 Test Cases (Write First)
+
+#### Test 1: Find Outgoing Edges
+
+```typescript
+Deno.test("BfEdge.queryTargetEdgesForNode - finds edges where node is source", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const { company, edges } = await setupEdgeTestGraph(cv);
+
+    // Find edges where company is the source (company -> project)
+    const outgoingEdges = await BfEdge.queryTargetEdgesForNode(company);
+
+    assertEquals(outgoingEdges.length, 1);
+    assertEquals(outgoingEdges[0].props.role, "owns");
+    assertEquals(
+      outgoingEdges[0].metadata.bfGid,
+      edges.companyProject.metadata.bfGid,
+    );
+
+    // Verify edge metadata
+    const edgeMetadata = outgoingEdges[0].metadata as BfEdgeMetadata;
+    assertEquals(edgeMetadata.bfSid, company.metadata.bfGid);
+  });
+});
+```
+
+#### Test 2: Multiple Outgoing Edges
+
+```typescript
+Deno.test("BfEdge.queryTargetEdgesForNode - finds multiple outgoing edges", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const { project, edges } = await setupEdgeTestGraph(cv);
+
+    // Project connects to 2 users
+    const outgoingEdges = await BfEdge.queryTargetEdgesForNode(project);
+
+    assertEquals(outgoingEdges.length, 2);
+    const roles = outgoingEdges.map((e) => e.props.role).sort();
+    assertEquals(roles, ["assignedTo", "manages"]);
+
+    // Verify all edges have project as source
+    outgoingEdges.forEach((edge) => {
+      const edgeMetadata = edge.metadata as BfEdgeMetadata;
+      assertEquals(edgeMetadata.bfSid, project.metadata.bfGid);
+    });
+  });
+});
+```
+
+### 4.3 Fixed Implementation
+
+```typescript
+static async queryTargetEdgesForNode<TProps extends BfEdgeBaseProps = BfEdgeBaseProps>(
+  node: BfNode,
+  cache?: BfNodeCache<TProps>,
+): Promise<Array<InstanceType<typeof BfEdge<TProps>>>> {
+  // Query edges where the provided node is the source
+  const metadataToQuery: Partial<BfEdgeMetadata> = {
+    bfSid: node.metadata.bfGid,
+    className: this.name,
+  };
+
+  return this.query(
+    node.cv,
+    metadataToQuery,
+    {}, // No specific props filter
+    [], // No specific IDs filter
+    undefined, // No specific options  
+    cache,
+  ) as Promise<Array<InstanceType<typeof BfEdge<TProps>>>>;
+}
+```
+
+## Type Safety Fixes Required
+
+### Import Additions Needed
+
+Add these imports to the top of `BfEdge.ts`:
+
+```typescript
+import type { BfGid } from "@bfmono/lib/types.ts";
+import type { BfNodeCache } from "@bfmono/apps/bfDb/classes/BfNode.ts";
+```
+
+### Type Corrections Summary
+
+1. **Replace**: `BfNodeBase` → `BfNode`
+2. **Replace**: `BfMetadataEdge` → `BfEdgeMetadata`
+3. **Replace**: `BfNodeBaseProps` → `PropsBase`
+4. **Add**: Missing generic constraints
+5. **Fix**: Parameter naming consistency
+
+## Integration with Phase 1
+
+### How BfEdge Methods Support BfNode Methods
+
+The Phase 1 `BfNode` instance methods will delegate to these Phase 2 `BfEdge`
+static methods:
+
+```typescript
+// In BfNode class (Phase 1)
+async querySourceInstances<TSourceClass>(
+  SourceClass: TSourceClass,
+  nodeProps?: Partial<TSourceProps>, 
+  edgeProps?: Partial<BfEdgeBaseProps>
+): Promise<Array<InstanceType<TSourceClass>>> {
+  const { BfEdge } = await import("@bfmono/apps/bfDb/nodeTypes/BfEdge.ts");
+  return BfEdge.querySourceInstances(
+    this.cv,
+    SourceClass,
+    this.metadata.bfGid,
+    nodeProps,
+    edgeProps
+  );
+}
+```
+
+### Integration Tests
+
+```typescript
+Deno.test("BfNode instance methods delegate to BfEdge static methods", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const { company, project } = await setupEdgeTestGraph(cv);
+
+    // Test Phase 1 method calls Phase 2 method
+    const sources = await project.querySourceInstances(TestCompany);
+    assertEquals(sources.length, 1);
+    assertEquals(sources[0].metadata.bfGid, company.metadata.bfGid);
+
+    // Should produce same result as direct BfEdge call
+    const directSources = await BfEdge.querySourceInstances(
+      cv,
+      TestCompany,
+      project.metadata.bfGid,
+    );
+    assertEquals(sources[0].metadata.bfGid, directSources[0].metadata.bfGid);
+  });
+});
+```
+
+## Performance Tests
+
+### Query Performance Validation
+
+```typescript
+Deno.test("BfEdge traversal methods - performance with large datasets", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+
+    // Create large test graph
+    const hub = await TestProject.__DANGEROUS__createUnattached(cv, {
+      title: "Hub Project",
+      status: "active",
+      priority: 1,
+    });
+
+    // Connect 50 users to hub project
+    const users = [];
+    for (let i = 0; i < 50; i++) {
+      const user = await TestUser.__DANGEROUS__createUnattached(cv, {
+        name: `User ${i}`,
+        email: `user${i}@test.com`,
+        role: i % 3, // Vary roles
+      });
+      await BfEdge.createBetweenNodes(cv, hub, user, { role: "assignedTo" });
+      users.push(user);
+    }
+
+    // Test query performance
+    const startTime = performance.now();
+    const targetUsers = await BfEdge.queryTargetInstances(
+      cv,
+      TestUser,
+      hub.metadata.bfGid,
+    );
+    const endTime = performance.now();
+
+    assertEquals(targetUsers.length, 50);
+    assert(
+      (endTime - startTime) < 2000,
+      `Query took ${endTime - startTime}ms, should be < 2000ms`,
+    );
+  });
+});
+```
+
+### Batch Operations Test
+
+```typescript
+Deno.test("BfEdge methods - efficient batch operations", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const { project } = await setupEdgeTestGraph(cv);
+
+    // Test that edge queries batch efficiently
+    const startTime = performance.now();
+
+    const [incomingEdges, outgoingEdges] = await Promise.all([
+      BfEdge.querySourceEdgesForNode(project),
+      BfEdge.queryTargetEdgesForNode(project),
+    ]);
+
+    const endTime = performance.now();
+
+    assertEquals(incomingEdges.length, 1); // Company -> Project
+    assertEquals(outgoingEdges.length, 2); // Project -> Users
+
+    assert(
+      (endTime - startTime) < 500,
+      "Parallel edge queries should complete quickly",
+    );
+  });
+});
+```
+
+## Error Handling and Edge Cases
+
+### Error Test Cases
+
+```typescript
+Deno.test("BfEdge.querySourceInstances - handles invalid target ID", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const invalidId = "invalid-bf-gid" as BfGid;
+
+    const sources = await BfEdge.querySourceInstances(
+      cv,
+      TestCompany,
+      invalidId,
+    );
+
+    assertEquals(sources.length, 0); // Should return empty, not error
+  });
+});
+
+Deno.test("BfEdge.queryTargetInstances - handles missing source node", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const nonExistentId = "00000000-0000-0000-0000-000000000000" as BfGid;
+
+    const targets = await BfEdge.queryTargetInstances(
+      cv,
+      TestUser,
+      nonExistentId,
+    );
+
+    assertEquals(targets.length, 0);
+  });
+});
+
+Deno.test("BfEdge.querySourceEdgesForNode - handles node without edges", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const isolatedNode = await TestUser.__DANGEROUS__createUnattached(cv, {
+      name: "Isolated",
+      email: "isolated@test.com",
+      role: 1,
+    });
+
+    const edges = await BfEdge.querySourceEdgesForNode(isolatedNode);
+    assertEquals(edges.length, 0);
+  });
+});
+```
+
+### Type Safety Tests
+
+```typescript
+Deno.test("BfEdge methods - maintain type safety", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const { company, project } = await setupEdgeTestGraph(cv);
+
+    // TypeScript should enforce correct return types
+    const sources: Array<TestCompany> = await BfEdge.querySourceInstances(
+      cv,
+      TestCompany,
+      project.metadata.bfGid,
+    );
+
+    assertEquals(sources.length, 1);
+    // Verify TypeScript properly typed the result
+    assertEquals(typeof sources[0].props.companyName, "string");
+    assertEquals(typeof sources[0].props.industry, "string");
+  });
+});
+```
+
+## Implementation Order and Steps
+
+### Step-by-Step Implementation
+
+1. **Step 1**: Add missing imports to `BfEdge.ts`
+2. **Step 2**: Uncomment `querySourceInstances` method
+3. **Step 3**: Fix type errors in `querySourceInstances`
+4. **Step 4**: Write and run tests for `querySourceInstances`
+5. **Step 5**: Uncomment and fix `queryTargetInstances`
+6. **Step 6**: Write and run tests for `queryTargetInstances`
+7. **Step 7**: Uncomment and fix `querySourceEdgesForNode`
+8. **Step 8**: Write and run tests for `querySourceEdgesForNode`
+9. **Step 9**: Uncomment and fix `queryTargetEdgesForNode`
+10. **Step 10**: Write and run tests for `queryTargetEdgesForNode`
+11. **Step 11**: Run integration tests with Phase 1 methods
+12. **Step 12**: Run performance and error handling tests
+
+### TDD Validation Commands
+
+```bash
+# Run specific BfEdge traversal tests
+bft test apps/bfDb/nodeTypes/__tests__/BfEdge.traversal.test.ts
+
+# Run all BfDb tests to ensure no regressions
+bft test apps/bfDb/
+
+# Run performance tests
+bft test apps/bfDb/ --filter="performance"
+
+# Run integration tests
+bft test apps/bfDb/ --filter="integration"
+```
+
+## Success Criteria
+
+### Phase 2 Completion Checklist
+
+- [ ] All four BfEdge methods are uncommented and functional
+- [ ] All type errors are resolved
+- [ ] All new tests pass with `bft test`
+- [ ] No regressions in existing BfNode tests
+- [ ] Performance tests meet requirements (< 2s for 50 node queries)
+- [ ] Integration tests pass with Phase 1 methods
+- [ ] Error handling covers all edge cases
+- [ ] TypeScript compilation succeeds with no errors
+- [ ] Code follows existing patterns and conventions
+
+### Quality Assurance
+
+- [ ] Proper JSDoc documentation added to all public methods
+- [ ] Consistent error handling with existing codebase patterns
+- [ ] Uses `Array<T>` syntax per project guidelines
+- [ ] Cache parameter usage follows established patterns
+- [ ] Methods support future pagination features (design-wise)
+
+## Future Phase 3 Considerations
+
+### GraphQL Connection Preparation
+
+The restored methods should support future GraphQL connections:
+
+```typescript
+// Future Phase 3 method signatures
+static async querySourceConnectionForGraphQL<TSourceClass>(
+  cv: CurrentViewer,
+  SourceClass: TSourceClass,
+  targetId: BfGid,
+  connectionArgs: ConnectionArguments,
+  nodeProps?: Partial<TSourceProps>,
+  edgeProps?: Partial<BfEdgeBaseProps>
+): Promise<Connection<InstanceType<TSourceClass>>>
+```
+
+### Performance Optimization Opportunities
+
+- Connection pooling for high-frequency traversals
+- Query result caching for complex graph patterns
+- Batch optimization for multiple concurrent edge queries
+- Pagination support for large relationship sets
+
+This comprehensive plan provides a systematic approach to restoring the BfEdge
+traversal methods while maintaining strict TDD practices, ensuring type safety,
+and preparing for future phases of the node traversal implementation.

--- a/memos/plans/2025-07-15-tdd-traversal-methods-plan.md
+++ b/memos/plans/2025-07-15-tdd-traversal-methods-plan.md
@@ -1,0 +1,721 @@
+# TDD Implementation Plan: Phase 1 Core Instance Traversal Methods
+
+## Overview
+
+This plan provides a comprehensive Test-Driven Development (TDD) approach for
+implementing the four core instance traversal methods in `BfNode.ts`:
+
+1. `queryAncestorsByClassName<TSourceClass>(BfNodeClass, limit?: number)`
+2. `queryDescendantsByClassName<TTargetClass>(BfNodeClass, limit?: number)`
+3. `querySourceInstances<TSourceClass>(SourceClass, nodeProps?, edgeProps?)`
+4. `queryTargetInstances<TTargetClass>(TargetClass, nodeProps?, edgeProps?)`
+
+Based on analysis of existing patterns in
+`/Users/randallb/randallb.com/areas/bolt-foundry-monorepo/apps/bfDb/`, this plan
+follows established conventions and leverages existing backend infrastructure.
+
+## Pre-Implementation Setup
+
+### Test File Structure
+
+```
+apps/bfDb/classes/__tests__/BfNode.traversal.test.ts
+```
+
+### Required Test Fixtures
+
+Create test node classes that mirror the existing pattern:
+
+```typescript
+// Test node classes for graph traversal testing
+class TestPerson extends BfNode<InferProps<typeof TestPerson>> {
+  static override bfNodeSpec = this.defineBfNode((f) =>
+    f.string("name").string("email").number("age")
+  );
+  static override gqlSpec = this.defineGqlNode((f) =>
+    f.string("name").string("email").int("age")
+  );
+}
+
+class TestOrganization extends BfNode<InferProps<typeof TestOrganization>> {
+  static override bfNodeSpec = this.defineBfNode((f) =>
+    f.string("orgName").string("domain")
+  );
+  static override gqlSpec = this.defineGqlNode((f) =>
+    f.string("orgName").string("domain")
+  );
+}
+
+class TestProject extends BfNode<InferProps<typeof TestProject>> {
+  static override bfNodeSpec = this.defineBfNode((f) =>
+    f.string("title").string("status")
+  );
+  static override gqlSpec = this.defineGqlNode((f) =>
+    f.string("title").string("status")
+  );
+}
+```
+
+### Test Data Setup Helper
+
+```typescript
+async function setupTestGraphData(cv: CurrentViewer) {
+  // Create hierarchy: Org -> Project -> Person
+  const org = await TestOrganization.__DANGEROUS__createUnattached(cv, {
+    orgName: "Test Corp",
+    domain: "testcorp.com",
+  });
+
+  const project = await org.createTargetNode(TestProject, {
+    title: "Test Project",
+    status: "active",
+  }, { role: "owns" });
+
+  const person = await project.createTargetNode(TestPerson, {
+    name: "John Doe",
+    email: "john@testcorp.com",
+    age: 30,
+  }, { role: "assignedTo" });
+
+  return { org, project, person };
+}
+```
+
+## Method 1: `queryAncestorsByClassName`
+
+### 1.1 Method Signature Definition
+
+```typescript
+static async queryAncestorsByClassName<
+  TSourceClass extends typeof BfNode<TSourceProps>,
+  TSourceProps extends PropsBase = PropsBase,
+>(
+  this: typeof BfNode,
+  cv: CurrentViewer,
+  SourceClass: TSourceClass,
+  limit?: number,
+  cache?: BfNodeCache<TSourceProps>,
+): Promise<Array<InstanceType<TSourceClass>>> {
+  // Implementation follows
+}
+```
+
+### 1.2 Test Cases (Write First)
+
+#### Test 1: Basic Ancestor Query
+
+```typescript
+Deno.test("queryAncestorsByClassName - finds direct ancestors", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const { org, project, person } = await setupTestGraphData(cv);
+
+    // Query ancestors of person, looking for organizations
+    const ancestors = await person.queryAncestorsByClassName(
+      cv,
+      TestOrganization,
+    );
+
+    assertEquals(ancestors.length, 1);
+    assertEquals(ancestors[0].props.orgName, "Test Corp");
+    assertEquals(ancestors[0].metadata.bfGid, org.metadata.bfGid);
+  });
+});
+```
+
+#### Test 2: Multiple Level Traversal
+
+```typescript
+Deno.test("queryAncestorsByClassName - traverses multiple levels", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+
+    // Create deeper hierarchy: Org -> Div -> Project -> Person
+    const org = await TestOrganization.__DANGEROUS__createUnattached(cv, {
+      orgName: "Parent Corp",
+      domain: "parent.com",
+    });
+    const div = await org.createTargetNode(TestOrganization, {
+      orgName: "Engineering Div",
+      domain: "eng.parent.com",
+    }, { role: "contains" });
+    const project = await div.createTargetNode(TestProject, {
+      title: "Deep Project",
+      status: "active",
+    }, { role: "owns" });
+    const person = await project.createTargetNode(TestPerson, {
+      name: "Deep Dev",
+      email: "dev@parent.com",
+      age: 25,
+    }, { role: "assignedTo" });
+
+    const ancestors = await person.queryAncestorsByClassName(
+      cv,
+      TestOrganization,
+    );
+
+    assertEquals(ancestors.length, 2);
+    const orgNames = ancestors.map((a) => a.props.orgName).sort();
+    assertEquals(orgNames, ["Engineering Div", "Parent Corp"]);
+  });
+});
+```
+
+#### Test 3: Limit Parameter
+
+```typescript
+Deno.test("queryAncestorsByClassName - respects limit parameter", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    // Setup multi-level hierarchy
+    const { person } = await setupDeepHierarchy(cv);
+
+    const limitedAncestors = await person.queryAncestorsByClassName(
+      cv,
+      TestOrganization,
+      1,
+    );
+
+    assertEquals(limitedAncestors.length, 1);
+  });
+});
+```
+
+#### Test 4: No Ancestors Found
+
+```typescript
+Deno.test("queryAncestorsByClassName - returns empty array when no ancestors", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const person = await TestPerson.__DANGEROUS__createUnattached(cv, {
+      name: "Isolated Person",
+      email: "isolated@test.com",
+      age: 30,
+    });
+
+    const ancestors = await person.queryAncestorsByClassName(
+      cv,
+      TestOrganization,
+    );
+
+    assertEquals(ancestors.length, 0);
+  });
+});
+```
+
+#### Test 5: Cycle Detection
+
+```typescript
+Deno.test("queryAncestorsByClassName - handles cycles gracefully", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const { org, project } = await setupTestGraphData(cv);
+
+    // Create cycle: Project -> Org (backwards edge)
+    await project.createTargetNode(TestOrganization, {
+      orgName: org.props.orgName,
+      domain: org.props.domain,
+    }, { role: "cyclicRef", metadata: { bfGid: org.metadata.bfGid } });
+
+    // Should not infinite loop or crash
+    const ancestors = await project.queryAncestorsByClassName(
+      cv,
+      TestOrganization,
+    );
+
+    // Should return org only once despite cycle
+    assertEquals(ancestors.length, 1);
+  });
+});
+```
+
+### 1.3 Implementation Steps
+
+1. **Leverage Existing Backend Method**: Use
+   `DatabaseBackend.queryAncestorsByClassName`
+2. **Add Method to BfNode Class**: Place after existing static methods
+3. **Type Safety**: Ensure proper TypeScript generics and return types
+4. **Error Handling**: Use existing error patterns from codebase
+5. **Caching**: Support optional cache parameter following existing patterns
+
+```typescript
+static async queryAncestorsByClassName<
+  TSourceClass extends typeof BfNode<TSourceProps>,
+  TSourceProps extends PropsBase = PropsBase,
+>(
+  this: typeof BfNode,
+  cv: CurrentViewer,
+  SourceClass: TSourceClass,
+  limit?: number,
+  cache?: BfNodeCache<TSourceProps>,
+): Promise<Array<InstanceType<TSourceClass>>> {
+  const results = await storage.queryAncestorsByClassName<TSourceProps>(
+    cv.orgBfOid,
+    this.prototype.metadata.bfGid,
+    SourceClass.name,
+    limit
+  );
+
+  return results.map((item) => {
+    const Ctor = SourceClass as unknown as ConcreteBfNodeBaseCtor<TSourceProps>;
+    const instance = new Ctor(cv, item.props, item.metadata);
+    cache?.set(item.metadata.bfGid, instance);
+    return instance as InstanceType<TSourceClass>;
+  });
+}
+```
+
+## Method 2: `queryDescendantsByClassName`
+
+### 2.1 Method Signature
+
+```typescript
+static async queryDescendantsByClassName<
+  TTargetClass extends typeof BfNode<TTargetProps>,
+  TTargetProps extends PropsBase = PropsBase,
+>(
+  this: typeof BfNode,
+  cv: CurrentViewer,
+  TargetClass: TTargetClass,
+  limit?: number,
+  cache?: BfNodeCache<TTargetProps>,
+): Promise<Array<InstanceType<TTargetClass>>> {
+  // Implementation follows
+}
+```
+
+### 2.2 Test Cases (Write First)
+
+#### Test 1: Basic Descendant Query
+
+```typescript
+Deno.test("queryDescendantsByClassName - finds direct descendants", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const { org, project, person } = await setupTestGraphData(cv);
+
+    const descendants = await org.queryDescendantsByClassName(
+      cv,
+      TestPerson,
+    );
+
+    assertEquals(descendants.length, 1);
+    assertEquals(descendants[0].props.name, "John Doe");
+    assertEquals(descendants[0].metadata.bfGid, person.metadata.bfGid);
+  });
+});
+```
+
+#### Test 2: Multi-Level Descendants
+
+```typescript
+Deno.test("queryDescendantsByClassName - finds descendants at all levels", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const org = await TestOrganization.__DANGEROUS__createUnattached(cv, {
+      orgName: "Multi Corp",
+      domain: "multi.com",
+    });
+
+    // Create multiple projects
+    const project1 = await org.createTargetNode(TestProject, {
+      title: "Project Alpha",
+      status: "active",
+    }, { role: "owns" });
+
+    const project2 = await org.createTargetNode(TestProject, {
+      title: "Project Beta",
+      status: "active",
+    }, { role: "owns" });
+
+    // Add people to each project
+    await project1.createTargetNode(TestPerson, {
+      name: "Alice",
+      email: "alice@multi.com",
+      age: 28,
+    }, { role: "assignedTo" });
+
+    await project2.createTargetNode(TestPerson, {
+      name: "Bob",
+      email: "bob@multi.com",
+      age: 32,
+    }, { role: "assignedTo" });
+
+    const descendants = await org.queryDescendantsByClassName(
+      cv,
+      TestPerson,
+    );
+
+    assertEquals(descendants.length, 2);
+    const names = descendants.map((d) => d.props.name).sort();
+    assertEquals(names, ["Alice", "Bob"]);
+  });
+});
+```
+
+#### Test 3: Limit and Empty Results
+
+Similar pattern as ancestors tests but for descendants.
+
+### 2.3 Implementation
+
+Similar structure to `queryAncestorsByClassName` but using
+`storage.queryDescendantsByClassName`.
+
+## Method 3: `querySourceInstances`
+
+### 3.1 Method Signature
+
+```typescript
+async querySourceInstances<
+  TSourceClass extends typeof BfNode<TSourceProps>,
+  TSourceProps extends PropsBase = PropsBase,
+>(
+  SourceClass: TSourceClass,
+  nodeProps?: Partial<TSourceProps>,
+  edgeProps?: Partial<PropsBase>,
+  cache?: BfNodeCache<TSourceProps>,
+): Promise<Array<InstanceType<TSourceClass>>> {
+  // Implementation follows
+}
+```
+
+### 3.2 Test Cases (Write First)
+
+#### Test 1: Basic Source Query
+
+```typescript
+Deno.test("querySourceInstances - finds nodes that connect to this node", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const { org, project, person } = await setupTestGraphData(cv);
+
+    // Find organizations that connect to the project
+    const sources = await project.querySourceInstances(TestOrganization);
+
+    assertEquals(sources.length, 1);
+    assertEquals(sources[0].props.orgName, "Test Corp");
+    assertEquals(sources[0].metadata.bfGid, org.metadata.bfGid);
+  });
+});
+```
+
+#### Test 2: Filter by Node Properties
+
+```typescript
+Deno.test("querySourceInstances - filters by node properties", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const project = await TestProject.__DANGEROUS__createUnattached(cv, {
+      title: "Shared Project",
+      status: "active",
+    });
+
+    // Create multiple orgs connecting to same project
+    await TestOrganization.__DANGEROUS__createUnattached(cv, {
+      orgName: "Big Corp",
+      domain: "big.com",
+    }).then((org) =>
+      org.createTargetNode(TestProject, {
+        title: project.props.title,
+        status: project.props.status,
+      }, { role: "owns", metadata: { bfGid: project.metadata.bfGid } })
+    );
+
+    await TestOrganization.__DANGEROUS__createUnattached(cv, {
+      orgName: "Small LLC",
+      domain: "small.com",
+    }).then((org) =>
+      org.createTargetNode(TestProject, {
+        title: project.props.title,
+        status: project.props.status,
+      }, { role: "owns", metadata: { bfGid: project.metadata.bfGid } })
+    );
+
+    // Filter by specific org name
+    const filteredSources = await project.querySourceInstances(
+      TestOrganization,
+      { orgName: "Big Corp" },
+    );
+
+    assertEquals(filteredSources.length, 1);
+    assertEquals(filteredSources[0].props.orgName, "Big Corp");
+  });
+});
+```
+
+#### Test 3: Filter by Edge Properties
+
+```typescript
+Deno.test("querySourceInstances - filters by edge properties", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const person = await TestPerson.__DANGEROUS__createUnattached(cv, {
+      name: "Popular Person",
+      email: "popular@test.com",
+      age: 25,
+    });
+
+    // Create multiple projects with different edge roles
+    const activeProject = await TestProject.__DANGEROUS__createUnattached(cv, {
+      title: "Active Work",
+      status: "active",
+    });
+    await activeProject.createTargetNode(TestPerson, {
+      name: person.props.name,
+      email: person.props.email,
+      age: person.props.age,
+    }, { role: "assignedTo", metadata: { bfGid: person.metadata.bfGid } });
+
+    const consultingProject = await TestProject.__DANGEROUS__createUnattached(
+      cv,
+      {
+        title: "Consulting Work",
+        status: "consulting",
+      },
+    );
+    await consultingProject.createTargetNode(TestPerson, {
+      name: person.props.name,
+      email: person.props.email,
+      age: person.props.age,
+    }, { role: "consultingFor", metadata: { bfGid: person.metadata.bfGid } });
+
+    // Filter by edge role
+    const assignedSources = await person.querySourceInstances(
+      TestProject,
+      {},
+      { role: "assignedTo" },
+    );
+
+    assertEquals(assignedSources.length, 1);
+    assertEquals(assignedSources[0].props.title, "Active Work");
+  });
+});
+```
+
+### 3.3 Implementation Steps
+
+1. **Use BfEdge Query Pattern**: Leverage existing edge querying infrastructure
+2. **Two-Step Process**: First query edges, then query source nodes
+3. **Property Filtering**: Apply both node and edge property filters
+4. **Performance Consideration**: Ensure efficient queries to backend
+
+```typescript
+async querySourceInstances<
+  TSourceClass extends typeof BfNode<TSourceProps>,
+  TSourceProps extends PropsBase = PropsBase,
+>(
+  SourceClass: TSourceClass,
+  nodeProps: Partial<TSourceProps> = {},
+  edgeProps: Partial<PropsBase> = {},
+  cache?: BfNodeCache<TSourceProps>,
+): Promise<Array<InstanceType<TSourceClass>>> {
+  // Step 1: Query edges where this node is the target
+  const { BfEdge } = await import("@bfmono/apps/bfDb/nodeTypes/BfEdge.ts");
+  const edgeMetadata: Partial<BfEdgeMetadata> = {
+    bfTid: this.metadata.bfGid,
+    bfOid: this.cv.orgBfOid,
+  };
+
+  const edges = await BfEdge.query(
+    this.cv,
+    edgeMetadata,
+    edgeProps,
+    []
+  );
+
+  if (edges.length === 0) {
+    return [];
+  }
+
+  // Step 2: Extract source IDs and query source nodes
+  const sourceIds = edges.map(edge => 
+    (edge.metadata as BfEdgeMetadata).bfSid
+  );
+
+  const sourceMetadata: Partial<BfNodeMetadata> = {
+    className: SourceClass.name,
+    bfOid: this.cv.orgBfOid,
+  };
+
+  return SourceClass.query(
+    this.cv,
+    sourceMetadata,
+    nodeProps,
+    sourceIds,
+    cache
+  );
+}
+```
+
+## Method 4: `queryTargetInstances`
+
+### 4.1 Method Signature
+
+```typescript
+async queryTargetInstances<
+  TTargetClass extends typeof BfNode<TTargetProps>,
+  TTargetProps extends PropsBase = PropsBase,
+>(
+  TargetClass: TTargetClass,
+  nodeProps?: Partial<TTargetProps>,
+  edgeProps?: Partial<PropsBase>,
+  cache?: BfNodeCache<TTargetProps>,
+): Promise<Array<InstanceType<TTargetClass>>> {
+  // Implementation follows
+}
+```
+
+### 4.2 Test Cases
+
+Mirror the `querySourceInstances` tests but for target relationships.
+
+### 4.3 Implementation
+
+Similar to `querySourceInstances` but query edges where this node is the source
+(`bfSid`).
+
+## Error Handling Strategy
+
+### Error Types to Test and Handle
+
+1. **BfErrorNodeNotFound**: When querying non-existent nodes
+2. **BfErrorNotImplemented**: For unsupported operations
+3. **Database Connection Errors**: Backend connectivity issues
+4. **Invalid Parameters**: Null/undefined class parameters
+
+### Error Test Examples
+
+```typescript
+Deno.test("queryAncestorsByClassName - handles invalid class parameter", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const person = await TestPerson.__DANGEROUS__createUnattached(cv, {
+      name: "Test",
+      email: "test@test.com",
+      age: 30,
+    });
+
+    await assertRejects(
+      () => person.queryAncestorsByClassName(cv, null as any),
+      Error,
+      "Invalid class parameter",
+    );
+  });
+});
+```
+
+## Performance Testing Strategy
+
+### Performance Test Cases
+
+```typescript
+Deno.test("queryDescendantsByClassName - performance with large dataset", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const org = await createLargeTestHierarchy(cv, 100); // 100 nodes
+
+    const startTime = performance.now();
+    const descendants = await org.queryDescendantsByClassName(
+      cv,
+      TestPerson,
+      10, // Limit for reasonable performance
+    );
+    const endTime = performance.now();
+
+    assertEquals(descendants.length, 10);
+    assert(
+      (endTime - startTime) < 1000,
+      "Query should complete within 1 second",
+    );
+  });
+});
+```
+
+## Integration Testing
+
+### Integration with Existing BfNode Features
+
+```typescript
+Deno.test("traversal methods integrate with existing BfNode methods", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const { org, project, person } = await setupTestGraphData(cv);
+
+    // Test that traversal works with existing find methods
+    const foundPerson = await TestPerson.findX(cv, person.metadata.bfGid);
+    assertEquals(foundPerson.metadata.bfGid, person.metadata.bfGid);
+
+    // Test traversal from found node
+    const ancestors = await foundPerson.queryAncestorsByClassName(
+      cv,
+      TestOrganization,
+    );
+    assertEquals(ancestors.length, 1);
+    assertEquals(ancestors[0].metadata.bfGid, org.metadata.bfGid);
+  });
+});
+```
+
+### GraphQL Connection Integration
+
+```typescript
+Deno.test("traversal methods work with connection wrapper", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+    const { org } = await setupTestGraphData(cv);
+
+    const descendants = await org.queryDescendantsByClassName(cv, TestPerson);
+
+    // Should work with existing connection method
+    const connection = BfNode.connection(descendants, {});
+    assertEquals(connection.edges.length, descendants.length);
+  });
+});
+```
+
+## Implementation Order
+
+1. **Phase 1a**: Implement and test `queryAncestorsByClassName`
+2. **Phase 1b**: Implement and test `queryDescendantsByClassName`
+3. **Phase 1c**: Implement and test `querySourceInstances`
+4. **Phase 1d**: Implement and test `queryTargetInstances`
+5. **Phase 1e**: Integration testing and performance validation
+6. **Phase 1f**: Error handling and edge case coverage
+
+## Validation Criteria
+
+### Success Criteria
+
+- [ ] All tests pass using `bft test`
+- [ ] Type safety maintained (no TypeScript errors)
+- [ ] Performance meets requirements (< 1s for reasonable datasets)
+- [ ] Memory usage stays within bounds (no memory leaks)
+- [ ] Error handling covers all edge cases
+- [ ] Integration with existing BfNode methods works seamlessly
+
+### Code Quality Checks
+
+- [ ] Follows existing codebase patterns and conventions
+- [ ] Uses `Array<T>` syntax instead of `T[]` per project guidelines
+- [ ] Proper JSDoc documentation for public methods
+- [ ] Consistent error handling with existing methods
+- [ ] Cache parameter usage follows established patterns
+
+## Future Considerations
+
+### Phase 2 Preparation
+
+- Methods should be designed to support future pagination features
+- Consider how these methods will integrate with GraphQL subscriptions
+- Ensure the API design can accommodate future permission framework
+
+### Performance Optimization Opportunities
+
+- Connection pooling and query optimization
+- Caching strategies for frequently traversed paths
+- Batch operations for multiple traversal requests
+
+This comprehensive TDD plan provides a step-by-step approach to implementing the
+core traversal methods while maintaining consistency with the existing codebase
+patterns and ensuring robust test coverage.


### PR DESCRIPTION

Re-implement instance-level graph traversal methods and add temporary GraphQL
connection support to enable development while full pagination is being restored.

Changes:
- Add queryAncestorsByClassName() and queryDescendantsByClassName() instance methods
- Add querySourceInstances() and queryTargetInstances() for edge-based queries
- Implement scratch BfNode.connection() with pagination error handling
- Fix GraphQLNode constructor validation for id getter implementation
- Add comprehensive test suite for connection and traversal functionality

Test plan:
1. Run node tests: `bft test apps/bfDb/classes/__tests__/BfNode.connection.test.ts`
2. Run traversal tests: `bft test apps/bfDb/classes/__tests__/BfNode.traversal.test.ts`
3. Verify GraphQL connections work without pagination args
4. Test edge-based node queries and hierarchical traversal

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
