### PR TITLE
Add ID fields to GraphQL schema and regenerate Isograph types

### DIFF
--- a/apps/bfDb/graphql/__generated__/_nexustypes.ts
+++ b/apps/bfDb/graphql/__generated__/_nexustypes.ts
@@ -97,35 +97,43 @@ export type NexusGenAllTypes = NexusGenRootTypes & NexusGenScalars
 export interface NexusGenFieldTypes {
   BfDeck: { // field return type
     description: string | null; // String
+    id: string; // ID!
     name: string | null; // String
     systemPrompt: string | null; // String
   }
   BfEdge: { // field return type
+    id: string; // ID!
     role: string | null; // String
   }
   BfGrader: { // field return type
     graderText: string | null; // String
+    id: string; // ID!
   }
   BfGraderResult: { // field return type
     explanation: string | null; // String
+    id: string; // ID!
     reasoningProcess: string | null; // String
     score: number | null; // Int
   }
   BfOrganization: { // field return type
     domain: string | null; // String
+    id: string; // ID!
     name: string | null; // String
   }
   BfPerson: { // field return type
     email: string | null; // String
+    id: string; // ID!
     memberOf: NexusGenRootTypes['BfOrganization'] | null; // BfOrganization
     name: string | null; // String
   }
   BfSample: { // field return type
     collectionMethod: string | null; // String
     completionData: NexusGenScalars['JSON'] | null; // JSON
+    id: string; // ID!
   }
   BfSampleFeedback: { // field return type
     explanation: string | null; // String
+    id: string; // ID!
     score: number | null; // Int
   }
   BlogPost: { // field return type
@@ -158,7 +166,9 @@ export interface NexusGenFieldTypes {
     success: boolean; // Boolean!
   }
   Mutation: { // field return type
+    createDeck: NexusGenRootTypes['BfDeck'] | null; // BfDeck
     joinWaitlist: NexusGenRootTypes['JoinWaitlistPayload'] | null; // JoinWaitlistPayload
+    submitSample: NexusGenRootTypes['BfSample'] | null; // BfSample
   }
   PageInfo: { // field return type
     endCursor: string | null; // String
@@ -176,6 +186,7 @@ export interface NexusGenFieldTypes {
     currentViewer: NexusGenRootTypes['CurrentViewer'] | null; // CurrentViewer
     documentsBySlug: NexusGenRootTypes['PublishedDocument'] | null; // PublishedDocument
     githubRepoStats: NexusGenRootTypes['GithubRepoStats'] | null; // GithubRepoStats
+    id: string | null; // ID
     ok: boolean | null; // Boolean
   }
   Waitlist: { // field return type
@@ -197,35 +208,43 @@ export interface NexusGenFieldTypes {
 export interface NexusGenFieldTypeNames {
   BfDeck: { // field return type name
     description: 'String'
+    id: 'ID'
     name: 'String'
     systemPrompt: 'String'
   }
   BfEdge: { // field return type name
+    id: 'ID'
     role: 'String'
   }
   BfGrader: { // field return type name
     graderText: 'String'
+    id: 'ID'
   }
   BfGraderResult: { // field return type name
     explanation: 'String'
+    id: 'ID'
     reasoningProcess: 'String'
     score: 'Int'
   }
   BfOrganization: { // field return type name
     domain: 'String'
+    id: 'ID'
     name: 'String'
   }
   BfPerson: { // field return type name
     email: 'String'
+    id: 'ID'
     memberOf: 'BfOrganization'
     name: 'String'
   }
   BfSample: { // field return type name
     collectionMethod: 'String'
     completionData: 'JSON'
+    id: 'ID'
   }
   BfSampleFeedback: { // field return type name
     explanation: 'String'
+    id: 'ID'
     score: 'Int'
   }
   BlogPost: { // field return type name
@@ -258,7 +277,9 @@ export interface NexusGenFieldTypeNames {
     success: 'Boolean'
   }
   Mutation: { // field return type name
+    createDeck: 'BfDeck'
     joinWaitlist: 'JoinWaitlistPayload'
+    submitSample: 'BfSample'
   }
   PageInfo: { // field return type name
     endCursor: 'String'
@@ -276,6 +297,7 @@ export interface NexusGenFieldTypeNames {
     currentViewer: 'CurrentViewer'
     documentsBySlug: 'PublishedDocument'
     githubRepoStats: 'GithubRepoStats'
+    id: 'ID'
     ok: 'Boolean'
   }
   Waitlist: { // field return type name
@@ -296,10 +318,20 @@ export interface NexusGenFieldTypeNames {
 
 export interface NexusGenArgTypes {
   Mutation: {
+    createDeck: { // args
+      description?: string | null; // String
+      name: string; // String!
+      systemPrompt: string; // String!
+    }
     joinWaitlist: { // args
       company?: string | null; // String
       email: string; // String!
       name: string; // String!
+    }
+    submitSample: { // args
+      collectionMethod?: string | null; // String
+      completionData: string; // String!
+      deckId: string; // String!
     }
   }
   Query: {

--- a/apps/bfDb/graphql/__generated__/schema.graphql
+++ b/apps/bfDb/graphql/__generated__/schema.graphql
@@ -5,20 +5,24 @@
 
 type BfDeck {
   description: String
+  id: ID!
   name: String
   systemPrompt: String
 }
 
 type BfEdge {
+  id: ID!
   role: String
 }
 
 type BfGrader {
   graderText: String
+  id: ID!
 }
 
 type BfGraderResult {
   explanation: String
+  id: ID!
   reasoningProcess: String
   score: Int
 }
@@ -30,11 +34,13 @@ interface BfNode {
 
 type BfOrganization {
   domain: String
+  id: ID!
   name: String
 }
 
 type BfPerson {
   email: String
+  id: ID!
   memberOf: BfOrganization
   name: String
 }
@@ -42,10 +48,12 @@ type BfPerson {
 type BfSample {
   collectionMethod: String
   completionData: JSON
+  id: ID!
 }
 
 type BfSampleFeedback {
   explanation: String
+  id: ID!
   score: Int
 }
 
@@ -110,7 +118,9 @@ type JoinWaitlistPayload {
 }
 
 type Mutation {
+  createDeck(description: String, name: String!, systemPrompt: String!): BfDeck
   joinWaitlist(company: String, email: String!, name: String!): JoinWaitlistPayload
+  submitSample(collectionMethod: String, completionData: String!, deckId: String!): BfSample
 }
 
 """An object with a unique identifier"""
@@ -168,6 +178,7 @@ type Query {
   currentViewer: CurrentViewer
   documentsBySlug(slug: String): PublishedDocument
   githubRepoStats: GithubRepoStats
+  id: ID
   ok: Boolean
 }
 

--- a/apps/boltFoundry/__generated__/__isograph/Query/EntrypointBlog/normalization_ast.ts
+++ b/apps/boltFoundry/__generated__/__isograph/Query/EntrypointBlog/normalization_ast.ts
@@ -3,6 +3,11 @@ const normalizationAst: NormalizationAst = {
   kind: "NormalizationAst",
   selections: [
     {
+      kind: "Scalar",
+      fieldName: "id",
+      arguments: null,
+    },
+    {
       kind: "Linked",
       fieldName: "blogPost",
       arguments: [

--- a/apps/boltFoundry/__generated__/__isograph/Query/EntrypointBlog/query_text.ts
+++ b/apps/boltFoundry/__generated__/__isograph/Query/EntrypointBlog/query_text.ts
@@ -1,4 +1,5 @@
 export default 'query EntrypointBlog ($slug: String) {\
+  id,\
   blogPost____slug___v_slug: blogPost(slug: $slug) {\
     id,\
     author,\

--- a/apps/boltFoundry/__generated__/__isograph/Query/EntrypointDocs/normalization_ast.ts
+++ b/apps/boltFoundry/__generated__/__isograph/Query/EntrypointDocs/normalization_ast.ts
@@ -3,6 +3,11 @@ const normalizationAst: NormalizationAst = {
   kind: "NormalizationAst",
   selections: [
     {
+      kind: "Scalar",
+      fieldName: "id",
+      arguments: null,
+    },
+    {
       kind: "Linked",
       fieldName: "documentsBySlug",
       arguments: [

--- a/apps/boltFoundry/__generated__/__isograph/Query/EntrypointDocs/query_text.ts
+++ b/apps/boltFoundry/__generated__/__isograph/Query/EntrypointDocs/query_text.ts
@@ -1,4 +1,5 @@
 export default 'query EntrypointDocs ($slug: String) {\
+  id,\
   documentsBySlug____slug___v_slug: documentsBySlug(slug: $slug) {\
     id,\
     content,\

--- a/apps/boltFoundry/__generated__/__isograph/Query/EntrypointFormatter/normalization_ast.ts
+++ b/apps/boltFoundry/__generated__/__isograph/Query/EntrypointFormatter/normalization_ast.ts
@@ -4,6 +4,11 @@ const normalizationAst: NormalizationAst = {
   selections: [
     {
       kind: "Scalar",
+      fieldName: "id",
+      arguments: null,
+    },
+    {
+      kind: "Scalar",
       fieldName: "__typename",
       arguments: null,
     },

--- a/apps/boltFoundry/__generated__/__isograph/Query/EntrypointFormatter/query_text.ts
+++ b/apps/boltFoundry/__generated__/__isograph/Query/EntrypointFormatter/query_text.ts
@@ -1,3 +1,4 @@
 export default 'query EntrypointFormatter  {\
+  id,\
   __typename,\
 }';

--- a/apps/boltFoundry/__generated__/__isograph/Query/EntrypointHome/normalization_ast.ts
+++ b/apps/boltFoundry/__generated__/__isograph/Query/EntrypointHome/normalization_ast.ts
@@ -4,6 +4,11 @@ const normalizationAst: NormalizationAst = {
   selections: [
     {
       kind: "Scalar",
+      fieldName: "id",
+      arguments: null,
+    },
+    {
+      kind: "Scalar",
       fieldName: "__typename",
       arguments: null,
     },

--- a/apps/boltFoundry/__generated__/__isograph/Query/EntrypointHome/query_text.ts
+++ b/apps/boltFoundry/__generated__/__isograph/Query/EntrypointHome/query_text.ts
@@ -1,4 +1,5 @@
 export default 'query EntrypointHome  {\
+  id,\
   __typename,\
   githubRepoStats {\
     id,\

--- a/apps/boltFoundry/__generated__/__isograph/Query/EntrypointLogin/normalization_ast.ts
+++ b/apps/boltFoundry/__generated__/__isograph/Query/EntrypointLogin/normalization_ast.ts
@@ -4,6 +4,11 @@ const normalizationAst: NormalizationAst = {
   selections: [
     {
       kind: "Scalar",
+      fieldName: "id",
+      arguments: null,
+    },
+    {
+      kind: "Scalar",
       fieldName: "__typename",
       arguments: null,
     },

--- a/apps/boltFoundry/__generated__/__isograph/Query/EntrypointLogin/query_text.ts
+++ b/apps/boltFoundry/__generated__/__isograph/Query/EntrypointLogin/query_text.ts
@@ -1,3 +1,4 @@
 export default 'query EntrypointLogin  {\
+  id,\
   __typename,\
 }';

--- a/apps/boltfoundry-com/ClientRoot.tsx
+++ b/apps/boltfoundry-com/ClientRoot.tsx
@@ -2,6 +2,7 @@ import { hydrateRoot } from "react-dom/client";
 import { getLogger } from "@bolt-foundry/logger";
 import App from "./src/App.tsx";
 import "./src/index.css";
+import "../../static/bfDsStyle.css";
 
 const logger = getLogger(import.meta);
 

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointHome/normalization_ast.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointHome/normalization_ast.ts
@@ -4,6 +4,11 @@ const normalizationAst: NormalizationAst = {
   selections: [
     {
       kind: "Scalar",
+      fieldName: "id",
+      arguments: null,
+    },
+    {
+      kind: "Scalar",
       fieldName: "__typename",
       arguments: null,
     },

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointHome/query_text.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointHome/query_text.ts
@@ -1,3 +1,4 @@
 export default 'query EntrypointHome  {\
+  id,\
   __typename,\
 }';


### PR DESCRIPTION

- Add id field to all BfNode types (BfDeck, BfEdge, BfGrader, etc.)
- Add createDeck and submitSample mutations
- Regenerate Isograph query types with new id field
- Update boltfoundry-com to include bfDsStyle.css
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/1476).
* #1478
* #1477
* __->__ #1476