### PR TITLE
Add MVP telemetry endpoint for markdown deck sample collection

### DIFF
--- a/apps/bfDb/graphql/__generated__/_nexustypes.ts
+++ b/apps/bfDb/graphql/__generated__/_nexustypes.ts
@@ -97,35 +97,43 @@ export type NexusGenAllTypes = NexusGenRootTypes & NexusGenScalars
 export interface NexusGenFieldTypes {
   BfDeck: { // field return type
     description: string | null; // String
+    id: string; // ID!
     name: string | null; // String
     systemPrompt: string | null; // String
   }
   BfEdge: { // field return type
+    id: string; // ID!
     role: string | null; // String
   }
   BfGrader: { // field return type
     graderText: string | null; // String
+    id: string; // ID!
   }
   BfGraderResult: { // field return type
     explanation: string | null; // String
+    id: string; // ID!
     reasoningProcess: string | null; // String
     score: number | null; // Int
   }
   BfOrganization: { // field return type
     domain: string | null; // String
+    id: string; // ID!
     name: string | null; // String
   }
   BfPerson: { // field return type
     email: string | null; // String
+    id: string; // ID!
     memberOf: NexusGenRootTypes['BfOrganization'] | null; // BfOrganization
     name: string | null; // String
   }
   BfSample: { // field return type
     collectionMethod: string | null; // String
     completionData: NexusGenScalars['JSON'] | null; // JSON
+    id: string; // ID!
   }
   BfSampleFeedback: { // field return type
     explanation: string | null; // String
+    id: string; // ID!
     score: number | null; // Int
   }
   BlogPost: { // field return type
@@ -158,7 +166,9 @@ export interface NexusGenFieldTypes {
     success: boolean; // Boolean!
   }
   Mutation: { // field return type
+    createDeck: NexusGenRootTypes['BfDeck'] | null; // BfDeck
     joinWaitlist: NexusGenRootTypes['JoinWaitlistPayload'] | null; // JoinWaitlistPayload
+    submitSample: NexusGenRootTypes['BfSample'] | null; // BfSample
   }
   PageInfo: { // field return type
     endCursor: string | null; // String
@@ -176,6 +186,7 @@ export interface NexusGenFieldTypes {
     currentViewer: NexusGenRootTypes['CurrentViewer'] | null; // CurrentViewer
     documentsBySlug: NexusGenRootTypes['PublishedDocument'] | null; // PublishedDocument
     githubRepoStats: NexusGenRootTypes['GithubRepoStats'] | null; // GithubRepoStats
+    id: string | null; // ID
     ok: boolean | null; // Boolean
   }
   Waitlist: { // field return type
@@ -197,35 +208,43 @@ export interface NexusGenFieldTypes {
 export interface NexusGenFieldTypeNames {
   BfDeck: { // field return type name
     description: 'String'
+    id: 'ID'
     name: 'String'
     systemPrompt: 'String'
   }
   BfEdge: { // field return type name
+    id: 'ID'
     role: 'String'
   }
   BfGrader: { // field return type name
     graderText: 'String'
+    id: 'ID'
   }
   BfGraderResult: { // field return type name
     explanation: 'String'
+    id: 'ID'
     reasoningProcess: 'String'
     score: 'Int'
   }
   BfOrganization: { // field return type name
     domain: 'String'
+    id: 'ID'
     name: 'String'
   }
   BfPerson: { // field return type name
     email: 'String'
+    id: 'ID'
     memberOf: 'BfOrganization'
     name: 'String'
   }
   BfSample: { // field return type name
     collectionMethod: 'String'
     completionData: 'JSON'
+    id: 'ID'
   }
   BfSampleFeedback: { // field return type name
     explanation: 'String'
+    id: 'ID'
     score: 'Int'
   }
   BlogPost: { // field return type name
@@ -258,7 +277,9 @@ export interface NexusGenFieldTypeNames {
     success: 'Boolean'
   }
   Mutation: { // field return type name
+    createDeck: 'BfDeck'
     joinWaitlist: 'JoinWaitlistPayload'
+    submitSample: 'BfSample'
   }
   PageInfo: { // field return type name
     endCursor: 'String'
@@ -276,6 +297,7 @@ export interface NexusGenFieldTypeNames {
     currentViewer: 'CurrentViewer'
     documentsBySlug: 'PublishedDocument'
     githubRepoStats: 'GithubRepoStats'
+    id: 'ID'
     ok: 'Boolean'
   }
   Waitlist: { // field return type name
@@ -296,10 +318,20 @@ export interface NexusGenFieldTypeNames {
 
 export interface NexusGenArgTypes {
   Mutation: {
+    createDeck: { // args
+      description?: string | null; // String
+      name: string; // String!
+      systemPrompt: string; // String!
+    }
     joinWaitlist: { // args
       company?: string | null; // String
       email: string; // String!
       name: string; // String!
+    }
+    submitSample: { // args
+      collectionMethod?: string | null; // String
+      completionData: string; // String!
+      deckId: string; // String!
     }
   }
   Query: {

--- a/apps/bfDb/graphql/__generated__/schema.graphql
+++ b/apps/bfDb/graphql/__generated__/schema.graphql
@@ -5,20 +5,24 @@
 
 type BfDeck {
   description: String
+  id: ID!
   name: String
   systemPrompt: String
 }
 
 type BfEdge {
+  id: ID!
   role: String
 }
 
 type BfGrader {
   graderText: String
+  id: ID!
 }
 
 type BfGraderResult {
   explanation: String
+  id: ID!
   reasoningProcess: String
   score: Int
 }
@@ -30,11 +34,13 @@ interface BfNode {
 
 type BfOrganization {
   domain: String
+  id: ID!
   name: String
 }
 
 type BfPerson {
   email: String
+  id: ID!
   memberOf: BfOrganization
   name: String
 }
@@ -42,10 +48,12 @@ type BfPerson {
 type BfSample {
   collectionMethod: String
   completionData: JSON
+  id: ID!
 }
 
 type BfSampleFeedback {
   explanation: String
+  id: ID!
   score: Int
 }
 
@@ -110,7 +118,9 @@ type JoinWaitlistPayload {
 }
 
 type Mutation {
+  createDeck(description: String, name: String!, systemPrompt: String!): BfDeck
   joinWaitlist(company: String, email: String!, name: String!): JoinWaitlistPayload
+  submitSample(collectionMethod: String, completionData: String!, deckId: String!): BfSample
 }
 
 """An object with a unique identifier"""
@@ -168,6 +178,7 @@ type Query {
   currentViewer: CurrentViewer
   documentsBySlug(slug: String): PublishedDocument
   githubRepoStats: GithubRepoStats
+  id: ID
   ok: Boolean
 }
 

--- a/apps/boltFoundry/__generated__/__isograph/Query/EntrypointBlog/normalization_ast.ts
+++ b/apps/boltFoundry/__generated__/__isograph/Query/EntrypointBlog/normalization_ast.ts
@@ -3,6 +3,11 @@ const normalizationAst: NormalizationAst = {
   kind: "NormalizationAst",
   selections: [
     {
+      kind: "Scalar",
+      fieldName: "id",
+      arguments: null,
+    },
+    {
       kind: "Linked",
       fieldName: "blogPost",
       arguments: [

--- a/apps/boltFoundry/__generated__/__isograph/Query/EntrypointBlog/query_text.ts
+++ b/apps/boltFoundry/__generated__/__isograph/Query/EntrypointBlog/query_text.ts
@@ -1,4 +1,5 @@
 export default 'query EntrypointBlog ($slug: String) {\
+  id,\
   blogPost____slug___v_slug: blogPost(slug: $slug) {\
     id,\
     author,\

--- a/apps/boltFoundry/__generated__/__isograph/Query/EntrypointDocs/normalization_ast.ts
+++ b/apps/boltFoundry/__generated__/__isograph/Query/EntrypointDocs/normalization_ast.ts
@@ -3,6 +3,11 @@ const normalizationAst: NormalizationAst = {
   kind: "NormalizationAst",
   selections: [
     {
+      kind: "Scalar",
+      fieldName: "id",
+      arguments: null,
+    },
+    {
       kind: "Linked",
       fieldName: "documentsBySlug",
       arguments: [

--- a/apps/boltFoundry/__generated__/__isograph/Query/EntrypointDocs/query_text.ts
+++ b/apps/boltFoundry/__generated__/__isograph/Query/EntrypointDocs/query_text.ts
@@ -1,4 +1,5 @@
 export default 'query EntrypointDocs ($slug: String) {\
+  id,\
   documentsBySlug____slug___v_slug: documentsBySlug(slug: $slug) {\
     id,\
     content,\

--- a/apps/boltFoundry/__generated__/__isograph/Query/EntrypointFormatter/normalization_ast.ts
+++ b/apps/boltFoundry/__generated__/__isograph/Query/EntrypointFormatter/normalization_ast.ts
@@ -4,6 +4,11 @@ const normalizationAst: NormalizationAst = {
   selections: [
     {
       kind: "Scalar",
+      fieldName: "id",
+      arguments: null,
+    },
+    {
+      kind: "Scalar",
       fieldName: "__typename",
       arguments: null,
     },

--- a/apps/boltFoundry/__generated__/__isograph/Query/EntrypointFormatter/query_text.ts
+++ b/apps/boltFoundry/__generated__/__isograph/Query/EntrypointFormatter/query_text.ts
@@ -1,3 +1,4 @@
 export default 'query EntrypointFormatter  {\
+  id,\
   __typename,\
 }';

--- a/apps/boltFoundry/__generated__/__isograph/Query/EntrypointHome/normalization_ast.ts
+++ b/apps/boltFoundry/__generated__/__isograph/Query/EntrypointHome/normalization_ast.ts
@@ -4,6 +4,11 @@ const normalizationAst: NormalizationAst = {
   selections: [
     {
       kind: "Scalar",
+      fieldName: "id",
+      arguments: null,
+    },
+    {
+      kind: "Scalar",
       fieldName: "__typename",
       arguments: null,
     },

--- a/apps/boltFoundry/__generated__/__isograph/Query/EntrypointHome/query_text.ts
+++ b/apps/boltFoundry/__generated__/__isograph/Query/EntrypointHome/query_text.ts
@@ -1,4 +1,5 @@
 export default 'query EntrypointHome  {\
+  id,\
   __typename,\
   githubRepoStats {\
     id,\

--- a/apps/boltFoundry/__generated__/__isograph/Query/EntrypointLogin/normalization_ast.ts
+++ b/apps/boltFoundry/__generated__/__isograph/Query/EntrypointLogin/normalization_ast.ts
@@ -4,6 +4,11 @@ const normalizationAst: NormalizationAst = {
   selections: [
     {
       kind: "Scalar",
+      fieldName: "id",
+      arguments: null,
+    },
+    {
+      kind: "Scalar",
       fieldName: "__typename",
       arguments: null,
     },

--- a/apps/boltFoundry/__generated__/__isograph/Query/EntrypointLogin/query_text.ts
+++ b/apps/boltFoundry/__generated__/__isograph/Query/EntrypointLogin/query_text.ts
@@ -1,3 +1,4 @@
 export default 'query EntrypointLogin  {\
+  id,\
   __typename,\
 }';

--- a/apps/boltfoundry-com/ClientRoot.tsx
+++ b/apps/boltfoundry-com/ClientRoot.tsx
@@ -2,6 +2,7 @@ import { hydrateRoot } from "react-dom/client";
 import { getLogger } from "@bolt-foundry/logger";
 import App from "./src/App.tsx";
 import "./src/index.css";
+import "../../static/bfDsStyle.css";
 
 const logger = getLogger(import.meta);
 

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointHome/normalization_ast.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointHome/normalization_ast.ts
@@ -4,6 +4,11 @@ const normalizationAst: NormalizationAst = {
   selections: [
     {
       kind: "Scalar",
+      fieldName: "id",
+      arguments: null,
+    },
+    {
+      kind: "Scalar",
       fieldName: "__typename",
       arguments: null,
     },

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointHome/query_text.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointHome/query_text.ts
@@ -1,3 +1,4 @@
 export default 'query EntrypointHome  {\
+  id,\
   __typename,\
 }';

--- a/apps/boltfoundry-com/__tests__/telemetry.integration.test.ts
+++ b/apps/boltfoundry-com/__tests__/telemetry.integration.test.ts
@@ -1,0 +1,232 @@
+import { assertEquals, assertExists } from "@std/assert";
+import { withIsolatedDb } from "@bfmono/apps/bfDb/bfDb.ts";
+import { makeLoggedInCv } from "@bfmono/apps/bfDb/utils/testUtils.ts";
+import { BfOrganization } from "@bfmono/apps/bfDb/nodeTypes/BfOrganization.ts";
+import { handleTelemetryRequest } from "../handlers/telemetry.ts";
+
+// Helper function to setup test data
+async function setupTestData() {
+  const cv = await makeLoggedInCv();
+
+  // Create the organization that the CurrentViewer references
+  // The CurrentViewer's orgBfOid should match this organization's bfGid
+  const org = await BfOrganization.__DANGEROUS__createUnattached(cv, {
+    name: "Test Organization",
+    domain: "test.com",
+  }, {
+    bfGid: cv.orgBfOid, // Use the same ID that CurrentViewer expects
+  });
+
+  return { cv, org };
+}
+
+// Mock telemetry data that would come from connectBoltFoundry
+const createMockTelemetryData = (overrides = {}) => ({
+  timestamp: new Date().toISOString(),
+  duration: 1500,
+  provider: "openai",
+  providerApiVersion: "v1",
+  sessionId: "test-session-123",
+  userId: "user-456",
+  request: {
+    url: "https://api.openai.com/v1/chat/completions",
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "authorization": "Bearer [REDACTED]",
+    },
+    body: {
+      model: "gpt-4",
+      messages: [
+        { role: "system", content: "You are a helpful assistant." },
+        { role: "user", content: "Hello!" },
+      ],
+    },
+  },
+  response: {
+    status: 200,
+    headers: {
+      "content-type": "application/json",
+    },
+    body: {
+      id: "chatcmpl-123",
+      object: "chat.completion",
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: "Hello! How can I help you today?",
+          },
+          finish_reason: "stop",
+        },
+      ],
+    },
+  },
+  // Basic deck metadata for MVP (no hashing)
+  bfMetadata: {
+    deckName: "customer-service",
+    deckContent:
+      "# Customer Service\n\nYou are a helpful customer service agent.",
+    contextVariables: { userId: "user-456", feature: "chat" },
+  },
+  ...overrides,
+});
+
+Deno.test("Telemetry endpoint - successful sample creation", async () => {
+  await withIsolatedDb(async () => {
+    const { cv } = await setupTestData();
+
+    const mockRequest = new Request("http://localhost:3000/api/telemetry", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-bf-api-key": `bf+${cv.orgBfOid}`,
+      },
+      body: JSON.stringify(createMockTelemetryData()),
+    });
+
+    const response = await handleTelemetryRequest(mockRequest);
+
+    assertEquals(response.status, 200);
+    const responseData = await response.json();
+    assertEquals(responseData.success, true);
+    assertExists(responseData.sampleId);
+  });
+});
+
+Deno.test("Telemetry endpoint - missing API key", async () => {
+  await withIsolatedDb(async () => {
+    const mockRequest = new Request("http://localhost:3000/api/telemetry", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(createMockTelemetryData()),
+    });
+
+    const response = await handleTelemetryRequest(mockRequest);
+
+    assertEquals(response.status, 401);
+    const responseData = await response.json();
+    assertEquals(responseData.error, "API key required");
+  });
+});
+
+Deno.test("Telemetry endpoint - invalid API key", async () => {
+  await withIsolatedDb(async () => {
+    const mockRequest = new Request("http://localhost:3000/api/telemetry", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-bf-api-key": "invalid-key",
+      },
+      body: JSON.stringify(createMockTelemetryData()),
+    });
+
+    const response = await handleTelemetryRequest(mockRequest);
+
+    assertEquals(response.status, 401);
+    const responseData = await response.json();
+    assertEquals(responseData.error, "Invalid API key");
+  });
+});
+
+Deno.test("Telemetry endpoint - creates deck if not exists", async () => {
+  await withIsolatedDb(async () => {
+    const { cv } = await setupTestData();
+
+    const telemetryData = createMockTelemetryData({
+      bfMetadata: {
+        deckName: "new-deck",
+        deckContent: "# New Deck\n\nThis is a new deck.",
+        contextVariables: { feature: "test" },
+      },
+    });
+
+    const mockRequest = new Request("http://localhost:3000/api/telemetry", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-bf-api-key": `bf+${cv.orgBfOid}`,
+      },
+      body: JSON.stringify(telemetryData),
+    });
+
+    const response = await handleTelemetryRequest(mockRequest);
+
+    assertEquals(response.status, 200);
+    const responseData = await response.json();
+    assertEquals(responseData.success, true);
+    assertExists(responseData.deckId);
+    assertExists(responseData.sampleId);
+  });
+});
+
+Deno.test("Telemetry endpoint - handles missing bfMetadata", async () => {
+  await withIsolatedDb(async () => {
+    const cv = await makeLoggedInCv();
+
+    const telemetryDataWithoutMetadata = createMockTelemetryData();
+    // @ts-expect-error - Deleting optional property
+    delete telemetryDataWithoutMetadata.bfMetadata;
+
+    const mockRequest = new Request("http://localhost:3000/api/telemetry", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-bf-api-key": `bf+${cv.orgBfOid}`,
+      },
+      body: JSON.stringify(telemetryDataWithoutMetadata),
+    });
+
+    const response = await handleTelemetryRequest(mockRequest);
+
+    assertEquals(response.status, 200);
+    const responseData = await response.json();
+    assertEquals(responseData.success, true);
+    assertEquals(
+      responseData.message,
+      "Telemetry processed without deck metadata",
+    );
+  });
+});
+
+Deno.test("Telemetry endpoint - invalid JSON", async () => {
+  await withIsolatedDb(async () => {
+    const cv = await makeLoggedInCv();
+
+    const mockRequest = new Request("http://localhost:3000/api/telemetry", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-bf-api-key": `bf+${cv.orgBfOid}`,
+      },
+      body: "invalid json",
+    });
+
+    const response = await handleTelemetryRequest(mockRequest);
+
+    assertEquals(response.status, 400);
+    const responseData = await response.json();
+    assertEquals(responseData.error, "Invalid JSON");
+  });
+});
+
+Deno.test("Telemetry endpoint - wrong HTTP method", async () => {
+  await withIsolatedDb(async () => {
+    const cv = await makeLoggedInCv();
+
+    const mockRequest = new Request("http://localhost:3000/api/telemetry", {
+      method: "GET",
+      headers: {
+        "x-bf-api-key": `bf+${cv.orgBfOid}`,
+      },
+    });
+
+    const response = await handleTelemetryRequest(mockRequest);
+
+    assertEquals(response.status, 405);
+    const responseData = await response.json();
+    assertEquals(responseData.error, "Method not allowed");
+  });
+});

--- a/apps/boltfoundry-com/apiRoutes.ts
+++ b/apps/boltfoundry-com/apiRoutes.ts
@@ -1,0 +1,33 @@
+import { handleTelemetryRequest } from "./handlers/telemetry.ts";
+
+export interface ApiRoute {
+  pattern: URLPattern;
+  handler: (request: Request) => Response | Promise<Response>;
+}
+
+export function createApiRoutes(
+  serverInfo: { isDev: boolean; port: number },
+): Array<ApiRoute> {
+  return [
+    {
+      pattern: new URLPattern({ pathname: "/health" }),
+      handler: () => {
+        const healthInfo = {
+          status: "OK",
+          timestamp: new Date().toISOString(),
+          mode: serverInfo.isDev ? "development" : "production",
+          port: serverInfo.port,
+          uptime: Math.floor(performance.now() / 1000) + " seconds",
+        };
+        return new Response(JSON.stringify(healthInfo, null, 2), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      },
+    },
+    {
+      pattern: new URLPattern({ pathname: "/api/telemetry" }),
+      handler: handleTelemetryRequest,
+    },
+  ];
+}

--- a/apps/boltfoundry-com/handlers/telemetry.ts
+++ b/apps/boltfoundry-com/handlers/telemetry.ts
@@ -1,0 +1,171 @@
+import { CurrentViewer } from "@bfmono/apps/bfDb/classes/CurrentViewer.ts";
+import { BfDeck } from "@bfmono/apps/bfDb/nodeTypes/rlhf/BfDeck.ts";
+import { BfSample } from "@bfmono/apps/bfDb/nodeTypes/rlhf/BfSample.ts";
+import { BfOrganization } from "@bfmono/apps/bfDb/nodeTypes/BfOrganization.ts";
+import { getLogger } from "@bfmono/packages/logger/logger.ts";
+
+const logger = getLogger(import.meta);
+
+interface TelemetryData {
+  timestamp: string;
+  duration: number;
+  provider: string;
+  providerApiVersion: string;
+  sessionId?: string;
+  userId?: string;
+  request: {
+    url: string;
+    method: string;
+    headers: Record<string, string>;
+    body: unknown;
+  };
+  response: {
+    status: number;
+    headers: Record<string, string>;
+    body: unknown;
+  };
+  bfMetadata?: {
+    deckName: string;
+    deckContent: string;
+    contextVariables: Record<string, unknown>;
+  };
+}
+
+export async function handleTelemetryRequest(
+  request: Request,
+): Promise<Response> {
+  // Only allow POST requests
+  if (request.method !== "POST") {
+    return new Response(
+      JSON.stringify({ error: "Method not allowed" }),
+      {
+        status: 405,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  try {
+    // Authenticate via API key header
+    const apiKey = request.headers.get("x-bf-api-key");
+    if (!apiKey) {
+      return new Response(
+        JSON.stringify({ error: "API key required" }),
+        {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    // For MVP, use simple API key format: "bf+{orgId}"
+    if (!apiKey.startsWith("bf+")) {
+      return new Response(
+        JSON.stringify({ error: "Invalid API key" }),
+        {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    const orgId = apiKey.replace("bf+", "");
+
+    // Create a CurrentViewer for this organization
+    const currentViewer = CurrentViewer
+      .__DANGEROUS_USE_IN_SCRIPTS_ONLY__createLoggedIn(
+        import.meta,
+        "telemetry@boltfoundry.com",
+        orgId,
+      );
+
+    // Parse the telemetry data
+    let telemetryData: TelemetryData;
+    try {
+      telemetryData = await request.json();
+    } catch {
+      return new Response(
+        JSON.stringify({ error: "Invalid JSON" }),
+        {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    // If no bfMetadata, just acknowledge the telemetry
+    if (!telemetryData.bfMetadata) {
+      logger.info("Telemetry received without deck metadata");
+      return new Response(
+        JSON.stringify({
+          success: true,
+          message: "Telemetry processed without deck metadata",
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    const { deckName, deckContent, contextVariables } = telemetryData
+      .bfMetadata;
+
+    // Get the organization node
+    const org = await BfOrganization.findX(
+      currentViewer,
+      currentViewer.orgBfOid,
+    );
+
+    // For MVP, let's just create a new deck each time
+    // TODO: Query for existing deck by name
+    const deck = await org.createTargetNode(BfDeck, {
+      name: deckName,
+      systemPrompt: deckContent,
+      description: `Auto-created from telemetry for ${deckName}`,
+    });
+    logger.info(`Created new deck: ${deckName}`);
+
+    // Create the sample
+    const completionData = {
+      request: telemetryData.request,
+      response: telemetryData.response,
+      provider: telemetryData.provider,
+      duration: telemetryData.duration,
+      contextVariables,
+    };
+
+    const sample = await deck.createTargetNode(BfSample, {
+      completionData: JSON.stringify(completionData),
+      collectionMethod: "telemetry",
+    });
+
+    logger.info(
+      `Created sample ${sample.metadata.bfGid} for deck ${deck.props.name}`,
+    );
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        deckId: deck.metadata.bfGid,
+        sampleId: sample.metadata.bfGid,
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  } catch (error) {
+    logger.error("Error processing telemetry:", error);
+    return new Response(
+      JSON.stringify({
+        error: "Internal server error",
+        details: error instanceof Error ? error.message : "Unknown error",
+      }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+}

--- a/apps/boltfoundry-com/memos/plans/markdown-deck-sample-collection.md
+++ b/apps/boltfoundry-com/memos/plans/markdown-deck-sample-collection.md
@@ -14,6 +14,57 @@ automatically collect samples when AI APIs are called.
 (`readLocalDeck()`) and remote deck retrieval (`fetchDeck()`). The MVP focuses
 on local markdown files, with remote deck management as a future enhancement.
 
+## Implementation Status
+
+### ✅ **MVP Telemetry Endpoint Complete** (July 2025)
+
+**What's Built:**
+
+- **Telemetry Handler** (`apps/boltfoundry-com/handlers/telemetry.ts`) -
+  Processes telemetry data and creates BfDeck/BfSample records
+- **API Routes Structure** (`apps/boltfoundry-com/apiRoutes.ts`) - Clean
+  separation of API routes from React routes
+- **Integration Tests**
+  (`apps/boltfoundry-com/__tests__/telemetry.integration.test.ts`) - Full test
+  suite with 7 passing tests
+- **Server Integration** - Added `/api/telemetry` endpoint to boltfoundry-com
+  server
+
+**What's Working:**
+
+- ✅ API key authentication (`bf+{orgId}` format)
+- ✅ JSON parsing and validation
+- ✅ Error handling (missing API key, invalid JSON, wrong HTTP method)
+- ✅ Deck creation from telemetry metadata (simplified - creates new deck each
+  time)
+- ✅ Sample creation with telemetry data stored as JSON
+- ✅ Proper HTTP responses and status codes
+- ✅ Database integration with BfOrganization, BfDeck, and BfSample nodes
+
+**Simplified for MVP:**
+
+- **No content-addressable hashing** - Skipped positional hash generation for
+  now
+- **No BfDeckVersion entity** - Using simplified deck creation pattern
+- **No deck deduplication** - Creates new deck for each telemetry request
+- **Basic authentication** - Simple `bf+{orgId}` API key format
+
+**Current Limitations:**
+
+- Organizations must exist in database (normal for production, but requires
+  setup for testing)
+- No deck versioning or content-addressable identification
+- No deck deduplication or conflict resolution
+
+### 🔄 **Next Steps for Full Implementation:**
+
+1. **Enhanced Telemetry Integration** - Update
+   `packages/bolt-foundry/bolt-foundry.ts` to support `bfMetadata`
+2. **Deck Loading Functions** - Implement `readLocalDeck()` and `fetchDeck()`
+3. **Content-Addressable Hashing** - Add positional hash generation system
+4. **BfDeckVersion Entity** - Implement proper versioning system
+5. **Provider Updates** - Remove Mistral, add OpenRouter support
+
 ## Architecture Overview
 
 ### Markdown-First Approach


### PR DESCRIPTION

Implement automatic sample collection from telemetry data with deck metadata support.
This enables the markdown-first approach for RLHF workflows where developers work with
.deck.md files locally and samples are automatically collected via API calls.

Changes:
- Add telemetry handler that processes AI API telemetry and creates BfDeck/BfSample records
- Create API routes structure for clean separation of API endpoints from React routes
- Add comprehensive integration tests covering authentication, validation, and error handling
- Update server to support new API routes with proper request handling
- Update implementation documentation with MVP status and next steps

Test plan:
1. Run integration tests: `bft test apps/boltfoundry-com/__tests__/telemetry.integration.test.ts`
2. Start server: `deno run --allow-all apps/boltfoundry-com/server.tsx --port 4000`
3. Test health endpoint: `curl http://localhost:4000/health`
4. Test telemetry endpoint: `curl -X POST http://localhost:4000/api/telemetry -H "Content-Type: application/json" -H "x-bf-api-key: bf+dev-org" -d '{"timestamp":"2025-07-17T12:00:00.000Z","duration":1500,"provider":"openai","request":{"url":"test","method":"POST","headers":{},"body":{}},"response":{"status":200,"headers":{},"body":{}}}'`

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/1477).
* #1478
* __->__ #1477
* #1476