### PR TITLE
Add bfMetadata support to connectBoltFoundry

### DIFF
--- a/apps/bfDb/builders/graphql/gqlSpecToNexus.ts
+++ b/apps/bfDb/builders/graphql/gqlSpecToNexus.ts
@@ -488,11 +488,16 @@ export async function gqlSpecToNexus(
   // Create the main object type definition
   const mainType = {
     name: typeName,
-    // Add implements if there's an interface to implement
+    // Keep backwards compatibility by including implements property
+    // even though the actual implementation is done via t.implements()
     ...(interfaceName ? { implements: interfaceName } : {}),
     // Keep the parameter as any to maintain compatibility with Nexus types
     // deno-lint-ignore no-explicit-any
     definition(t: any) {
+      // Add interface implementation if there's an interface to implement
+      if (interfaceName) {
+        t.implements(interfaceName);
+      }
       // Process fields
       for (const [fieldName, fieldDef] of Object.entries(spec.fields)) {
         const field = fieldDef as GqlFieldDef;

--- a/apps/bfDb/classes/__tests__/CurrentViewer.test.ts
+++ b/apps/bfDb/classes/__tests__/CurrentViewer.test.ts
@@ -138,7 +138,7 @@ Deno.test("loginWithGoogleToken verifies token and returns LoggedIn viewer", asy
   });
 });
 
-Deno.test.ignore(
+Deno.test(
   "GraphQL mutation loginWithGoogle issues cookies + returns LoggedIn",
   async () => {
     await withIsolatedDb(async () => {
@@ -168,7 +168,7 @@ Deno.test.ignore(
       try {
         const body = {
           query:
-            `mutation Login($token:String!){\n  loginWithGoogleCurrentViewer (idToken:$token){ currentViewer { __typename } }\n}`,
+            `mutation Login($token:String!){\n  loginWithGoogle (idToken:$token){ __typename }\n}`,
           variables: { token: "fake_graph_token" },
         };
         const gqlReq = new Request("https://bolt.test/graphql", {
@@ -189,7 +189,7 @@ Deno.test.ignore(
         assertEquals(errors, undefined, "Expected no errors");
 
         assertEquals(
-          data.loginWithGoogleCurrentViewer.currentViewer.__typename,
+          data.loginWithGoogle.__typename,
           "CurrentViewerLoggedIn",
         );
 

--- a/apps/bfDb/graphql/__generated__/_nexustypes.ts
+++ b/apps/bfDb/graphql/__generated__/_nexustypes.ts
@@ -97,35 +97,43 @@ export type NexusGenAllTypes = NexusGenRootTypes & NexusGenScalars
 export interface NexusGenFieldTypes {
   BfDeck: { // field return type
     description: string | null; // String
+    id: string; // ID!
     name: string | null; // String
     systemPrompt: string | null; // String
   }
   BfEdge: { // field return type
+    id: string; // ID!
     role: string | null; // String
   }
   BfGrader: { // field return type
     graderText: string | null; // String
+    id: string; // ID!
   }
   BfGraderResult: { // field return type
     explanation: string | null; // String
+    id: string; // ID!
     reasoningProcess: string | null; // String
     score: number | null; // Int
   }
   BfOrganization: { // field return type
     domain: string | null; // String
+    id: string; // ID!
     name: string | null; // String
   }
   BfPerson: { // field return type
     email: string | null; // String
+    id: string; // ID!
     memberOf: NexusGenRootTypes['BfOrganization'] | null; // BfOrganization
     name: string | null; // String
   }
   BfSample: { // field return type
     collectionMethod: string | null; // String
     completionData: NexusGenScalars['JSON'] | null; // JSON
+    id: string; // ID!
   }
   BfSampleFeedback: { // field return type
     explanation: string | null; // String
+    id: string; // ID!
     score: number | null; // Int
   }
   BlogPost: { // field return type
@@ -158,7 +166,9 @@ export interface NexusGenFieldTypes {
     success: boolean; // Boolean!
   }
   Mutation: { // field return type
+    createDeck: NexusGenRootTypes['BfDeck'] | null; // BfDeck
     joinWaitlist: NexusGenRootTypes['JoinWaitlistPayload'] | null; // JoinWaitlistPayload
+    submitSample: NexusGenRootTypes['BfSample'] | null; // BfSample
   }
   PageInfo: { // field return type
     endCursor: string | null; // String
@@ -176,6 +186,7 @@ export interface NexusGenFieldTypes {
     currentViewer: NexusGenRootTypes['CurrentViewer'] | null; // CurrentViewer
     documentsBySlug: NexusGenRootTypes['PublishedDocument'] | null; // PublishedDocument
     githubRepoStats: NexusGenRootTypes['GithubRepoStats'] | null; // GithubRepoStats
+    id: string | null; // ID
     ok: boolean | null; // Boolean
   }
   Waitlist: { // field return type
@@ -197,35 +208,43 @@ export interface NexusGenFieldTypes {
 export interface NexusGenFieldTypeNames {
   BfDeck: { // field return type name
     description: 'String'
+    id: 'ID'
     name: 'String'
     systemPrompt: 'String'
   }
   BfEdge: { // field return type name
+    id: 'ID'
     role: 'String'
   }
   BfGrader: { // field return type name
     graderText: 'String'
+    id: 'ID'
   }
   BfGraderResult: { // field return type name
     explanation: 'String'
+    id: 'ID'
     reasoningProcess: 'String'
     score: 'Int'
   }
   BfOrganization: { // field return type name
     domain: 'String'
+    id: 'ID'
     name: 'String'
   }
   BfPerson: { // field return type name
     email: 'String'
+    id: 'ID'
     memberOf: 'BfOrganization'
     name: 'String'
   }
   BfSample: { // field return type name
     collectionMethod: 'String'
     completionData: 'JSON'
+    id: 'ID'
   }
   BfSampleFeedback: { // field return type name
     explanation: 'String'
+    id: 'ID'
     score: 'Int'
   }
   BlogPost: { // field return type name
@@ -258,7 +277,9 @@ export interface NexusGenFieldTypeNames {
     success: 'Boolean'
   }
   Mutation: { // field return type name
+    createDeck: 'BfDeck'
     joinWaitlist: 'JoinWaitlistPayload'
+    submitSample: 'BfSample'
   }
   PageInfo: { // field return type name
     endCursor: 'String'
@@ -276,6 +297,7 @@ export interface NexusGenFieldTypeNames {
     currentViewer: 'CurrentViewer'
     documentsBySlug: 'PublishedDocument'
     githubRepoStats: 'GithubRepoStats'
+    id: 'ID'
     ok: 'Boolean'
   }
   Waitlist: { // field return type name
@@ -296,10 +318,20 @@ export interface NexusGenFieldTypeNames {
 
 export interface NexusGenArgTypes {
   Mutation: {
+    createDeck: { // args
+      description?: string | null; // String
+      name: string; // String!
+      systemPrompt: string; // String!
+    }
     joinWaitlist: { // args
       company?: string | null; // String
       email: string; // String!
       name: string; // String!
+    }
+    submitSample: { // args
+      collectionMethod?: string | null; // String
+      completionData: string; // String!
+      deckId: string; // String!
     }
   }
   Query: {

--- a/apps/bfDb/graphql/__generated__/_nexustypes.ts
+++ b/apps/bfDb/graphql/__generated__/_nexustypes.ts
@@ -64,6 +64,8 @@ export interface NexusGenObjects {
     cursor: string; // String!
     node?: NexusGenRootTypes['BlogPost'] | null; // BlogPost
   }
+  CurrentViewerLoggedIn: {};
+  CurrentViewerLoggedOut: {};
   GithubRepoStats: {};
   JoinWaitlistPayload: { // root type
     message?: string | null; // String
@@ -82,9 +84,9 @@ export interface NexusGenObjects {
 }
 
 export interface NexusGenInterfaces {
-  BfNode: any;
-  CurrentViewer: any;
-  Node: any;
+  BfNode: core.Discriminate<'BfDeck', 'optional'> | core.Discriminate<'BfEdge', 'optional'> | core.Discriminate<'BfGrader', 'optional'> | core.Discriminate<'BfGraderResult', 'optional'> | core.Discriminate<'BfOrganization', 'optional'> | core.Discriminate<'BfPerson', 'optional'> | core.Discriminate<'BfSample', 'optional'> | core.Discriminate<'BfSampleFeedback', 'optional'>;
+  CurrentViewer: core.Discriminate<'CurrentViewerLoggedIn', 'optional'> | core.Discriminate<'CurrentViewerLoggedOut', 'optional'>;
+  Node: core.Discriminate<'BlogPost', 'optional'> | core.Discriminate<'GithubRepoStats', 'optional'> | core.Discriminate<'PublishedDocument', 'optional'>;
 }
 
 export interface NexusGenUnions {
@@ -99,6 +101,7 @@ export interface NexusGenFieldTypes {
     description: string | null; // String
     id: string; // ID!
     name: string | null; // String
+    slug: string; // String!
     systemPrompt: string | null; // String
   }
   BfEdge: { // field return type
@@ -157,6 +160,16 @@ export interface NexusGenFieldTypes {
     cursor: string; // String!
     node: NexusGenRootTypes['BlogPost'] | null; // BlogPost
   }
+  CurrentViewerLoggedIn: { // field return type
+    id: string | null; // ID
+    orgBfOid: string | null; // String
+    personBfGid: string | null; // String
+  }
+  CurrentViewerLoggedOut: { // field return type
+    id: string | null; // ID
+    orgBfOid: string | null; // String
+    personBfGid: string | null; // String
+  }
   GithubRepoStats: { // field return type
     id: string; // ID!
     stars: number; // Int!
@@ -168,6 +181,7 @@ export interface NexusGenFieldTypes {
   Mutation: { // field return type
     createDeck: NexusGenRootTypes['BfDeck'] | null; // BfDeck
     joinWaitlist: NexusGenRootTypes['JoinWaitlistPayload'] | null; // JoinWaitlistPayload
+    loginWithGoogle: NexusGenRootTypes['CurrentViewer'] | null; // CurrentViewer
     submitSample: NexusGenRootTypes['BfSample'] | null; // BfSample
   }
   PageInfo: { // field return type
@@ -184,6 +198,7 @@ export interface NexusGenFieldTypes {
     blogPost: NexusGenRootTypes['BlogPost'] | null; // BlogPost
     blogPosts: NexusGenRootTypes['BlogPostConnection'] | null; // BlogPostConnection
     currentViewer: NexusGenRootTypes['CurrentViewer'] | null; // CurrentViewer
+    deck: NexusGenRootTypes['BfDeck'] | null; // BfDeck
     documentsBySlug: NexusGenRootTypes['PublishedDocument'] | null; // PublishedDocument
     githubRepoStats: NexusGenRootTypes['GithubRepoStats'] | null; // GithubRepoStats
     id: string | null; // ID
@@ -210,6 +225,7 @@ export interface NexusGenFieldTypeNames {
     description: 'String'
     id: 'ID'
     name: 'String'
+    slug: 'String'
     systemPrompt: 'String'
   }
   BfEdge: { // field return type name
@@ -268,6 +284,16 @@ export interface NexusGenFieldTypeNames {
     cursor: 'String'
     node: 'BlogPost'
   }
+  CurrentViewerLoggedIn: { // field return type name
+    id: 'ID'
+    orgBfOid: 'String'
+    personBfGid: 'String'
+  }
+  CurrentViewerLoggedOut: { // field return type name
+    id: 'ID'
+    orgBfOid: 'String'
+    personBfGid: 'String'
+  }
   GithubRepoStats: { // field return type name
     id: 'ID'
     stars: 'Int'
@@ -279,6 +305,7 @@ export interface NexusGenFieldTypeNames {
   Mutation: { // field return type name
     createDeck: 'BfDeck'
     joinWaitlist: 'JoinWaitlistPayload'
+    loginWithGoogle: 'CurrentViewer'
     submitSample: 'BfSample'
   }
   PageInfo: { // field return type name
@@ -295,6 +322,7 @@ export interface NexusGenFieldTypeNames {
     blogPost: 'BlogPost'
     blogPosts: 'BlogPostConnection'
     currentViewer: 'CurrentViewer'
+    deck: 'BfDeck'
     documentsBySlug: 'PublishedDocument'
     githubRepoStats: 'GithubRepoStats'
     id: 'ID'
@@ -321,12 +349,16 @@ export interface NexusGenArgTypes {
     createDeck: { // args
       description?: string | null; // String
       name: string; // String!
+      slug: string; // String!
       systemPrompt: string; // String!
     }
     joinWaitlist: { // args
       company?: string | null; // String
       email: string; // String!
       name: string; // String!
+    }
+    loginWithGoogle: { // args
+      idToken: string; // String!
     }
     submitSample: { // args
       collectionMethod?: string | null; // String
@@ -346,6 +378,9 @@ export interface NexusGenArgTypes {
       last?: number | null; // Int
       sortDirection?: string | null; // String
     }
+    deck: { // args
+      slug?: string | null; // String
+    }
     documentsBySlug: { // args
       slug?: string | null; // String
     }
@@ -353,9 +388,25 @@ export interface NexusGenArgTypes {
 }
 
 export interface NexusGenAbstractTypeMembers {
+  BfNode: "BfDeck" | "BfEdge" | "BfGrader" | "BfGraderResult" | "BfOrganization" | "BfPerson" | "BfSample" | "BfSampleFeedback"
+  CurrentViewer: "CurrentViewerLoggedIn" | "CurrentViewerLoggedOut"
+  Node: "BlogPost" | "GithubRepoStats" | "PublishedDocument"
 }
 
 export interface NexusGenTypeInterfaces {
+  BfDeck: "BfNode"
+  BfEdge: "BfNode"
+  BfGrader: "BfNode"
+  BfGraderResult: "BfNode"
+  BfOrganization: "BfNode"
+  BfPerson: "BfNode"
+  BfSample: "BfNode"
+  BfSampleFeedback: "BfNode"
+  BlogPost: "Node"
+  CurrentViewerLoggedIn: "CurrentViewer"
+  CurrentViewerLoggedOut: "CurrentViewer"
+  GithubRepoStats: "Node"
+  PublishedDocument: "Node"
 }
 
 export type NexusGenObjectNames = keyof NexusGenObjects;

--- a/apps/bfDb/graphql/__generated__/schema.graphql
+++ b/apps/bfDb/graphql/__generated__/schema.graphql
@@ -5,20 +5,24 @@
 
 type BfDeck {
   description: String
+  id: ID!
   name: String
   systemPrompt: String
 }
 
 type BfEdge {
+  id: ID!
   role: String
 }
 
 type BfGrader {
   graderText: String
+  id: ID!
 }
 
 type BfGraderResult {
   explanation: String
+  id: ID!
   reasoningProcess: String
   score: Int
 }
@@ -30,11 +34,13 @@ interface BfNode {
 
 type BfOrganization {
   domain: String
+  id: ID!
   name: String
 }
 
 type BfPerson {
   email: String
+  id: ID!
   memberOf: BfOrganization
   name: String
 }
@@ -42,10 +48,12 @@ type BfPerson {
 type BfSample {
   collectionMethod: String
   completionData: JSON
+  id: ID!
 }
 
 type BfSampleFeedback {
   explanation: String
+  id: ID!
   score: Int
 }
 
@@ -110,7 +118,9 @@ type JoinWaitlistPayload {
 }
 
 type Mutation {
+  createDeck(description: String, name: String!, systemPrompt: String!): BfDeck
   joinWaitlist(company: String, email: String!, name: String!): JoinWaitlistPayload
+  submitSample(collectionMethod: String, completionData: String!, deckId: String!): BfSample
 }
 
 """An object with a unique identifier"""
@@ -168,6 +178,7 @@ type Query {
   currentViewer: CurrentViewer
   documentsBySlug(slug: String): PublishedDocument
   githubRepoStats: GithubRepoStats
+  id: ID
   ok: Boolean
 }
 

--- a/apps/bfDb/graphql/__generated__/schema.graphql
+++ b/apps/bfDb/graphql/__generated__/schema.graphql
@@ -3,24 +3,25 @@
 ### Do not make changes to this file directly
 
 
-type BfDeck {
+type BfDeck implements BfNode {
   description: String
   id: ID!
   name: String
+  slug: String!
   systemPrompt: String
 }
 
-type BfEdge {
+type BfEdge implements BfNode {
   id: ID!
   role: String
 }
 
-type BfGrader {
+type BfGrader implements BfNode {
   graderText: String
   id: ID!
 }
 
-type BfGraderResult {
+type BfGraderResult implements BfNode {
   explanation: String
   id: ID!
   reasoningProcess: String
@@ -32,32 +33,32 @@ interface BfNode {
   id: ID!
 }
 
-type BfOrganization {
+type BfOrganization implements BfNode {
   domain: String
   id: ID!
   name: String
 }
 
-type BfPerson {
+type BfPerson implements BfNode {
   email: String
   id: ID!
   memberOf: BfOrganization
   name: String
 }
 
-type BfSample {
+type BfSample implements BfNode {
   collectionMethod: String
   completionData: JSON
   id: ID!
 }
 
-type BfSampleFeedback {
+type BfSampleFeedback implements BfNode {
   explanation: String
   id: ID!
   score: Int
 }
 
-type BlogPost {
+type BlogPost implements Node {
   author: String
   content: String!
   excerpt: String!
@@ -101,7 +102,19 @@ interface CurrentViewer {
   personBfGid: String
 }
 
-type GithubRepoStats {
+type CurrentViewerLoggedIn implements CurrentViewer {
+  id: ID
+  orgBfOid: String
+  personBfGid: String
+}
+
+type CurrentViewerLoggedOut implements CurrentViewer {
+  id: ID
+  orgBfOid: String
+  personBfGid: String
+}
+
+type GithubRepoStats implements Node {
   id: ID!
   stars: Int!
 }
@@ -118,8 +131,9 @@ type JoinWaitlistPayload {
 }
 
 type Mutation {
-  createDeck(description: String, name: String!, systemPrompt: String!): BfDeck
+  createDeck(description: String, name: String!, slug: String!, systemPrompt: String!): BfDeck
   joinWaitlist(company: String, email: String!, name: String!): JoinWaitlistPayload
+  loginWithGoogle(idToken: String!): CurrentViewer
   submitSample(collectionMethod: String, completionData: String!, deckId: String!): BfSample
 }
 
@@ -153,7 +167,7 @@ type PageInfo {
   startCursor: String
 }
 
-type PublishedDocument {
+type PublishedDocument implements Node {
   content: String!
   id: ID!
 }
@@ -176,6 +190,7 @@ type Query {
     sortDirection: String
   ): BlogPostConnection
   currentViewer: CurrentViewer
+  deck(slug: String): BfDeck
   documentsBySlug(slug: String): PublishedDocument
   githubRepoStats: GithubRepoStats
   id: ID

--- a/apps/bfDb/graphql/__tests__/GraphQLInterface.test.ts
+++ b/apps/bfDb/graphql/__tests__/GraphQLInterface.test.ts
@@ -137,10 +137,20 @@ Deno.test("determineInterface detects parent classes with @GraphQLInterface", as
     resolveType: () => null,
   });
 
+  // Also need the Node interface since TestGraphQLNode implements it
+  const nodeInterface = interfaceType({
+    name: "Node",
+    definition(t) {
+      t.nonNull.id("id");
+    },
+    resolveType: () => null,
+  });
+
   // Build schema with all types - we create our own list to avoid
   // duplicating any interface definitions
   const types = [
-    // Add only our custom interface for this test
+    // Add our interfaces
+    nodeInterface,
     customInterface,
     // Then add our object types that implement these interfaces
     objectType(testNodeNexusTypes.mainType),

--- a/apps/bfDb/nodeTypes/rlhf/BfDeck.ts
+++ b/apps/bfDb/nodeTypes/rlhf/BfDeck.ts
@@ -21,12 +21,14 @@ export class BfDeck extends BfNode<InferProps<typeof BfDeck>> {
       .string("name")
       .string("systemPrompt")
       .string("description")
+      .nonNull.string("slug")
       .typedMutation("createDeck", {
         args: (a) =>
           a
             .nonNull.string("name")
             .nonNull.string("systemPrompt")
-            .string("description"),
+            .string("description")
+            .nonNull.string("slug"),
         returns: "BfDeck",
         resolve: async (_src, args, ctx) => {
           const cv = ctx.getCurrentViewer();
@@ -45,6 +47,7 @@ export class BfDeck extends BfNode<InferProps<typeof BfDeck>> {
             name: args.name, // No casting needed! TypeScript knows this is string
             systemPrompt: args.systemPrompt, // No casting needed! TypeScript knows this is string
             description: args.description || "", // No casting needed! TypeScript knows this is string | undefined
+            slug: args.slug, // No casting needed! TypeScript knows this is string
           }) as BfDeck;
           await deck.afterCreate();
           const result = deck.toGraphql();
@@ -62,6 +65,7 @@ export class BfDeck extends BfNode<InferProps<typeof BfDeck>> {
       .string("name")
       .string("systemPrompt")
       .string("description")
+      .string("slug")
   );
 
   /**

--- a/apps/bfDb/nodeTypes/rlhf/__tests__/RlhfMutations.integration.test.ts
+++ b/apps/bfDb/nodeTypes/rlhf/__tests__/RlhfMutations.integration.test.ts
@@ -75,9 +75,11 @@ Deno.test("createDeck mutation creates deck and auto-generates graders", async (
           name: "Test Code Review Deck"
           systemPrompt: "Evaluate code review responses for accuracy and helpfulness."
           description: "A test deck for code review evaluation"
+          slug: "test-org_test-code-review-deck"
         ) {
           id
           name
+          slug
         }
       }
     `;
@@ -99,10 +101,12 @@ Deno.test("createDeck mutation creates deck and auto-generates graders", async (
     const deck = result.data?.createDeck as {
       id: string;
       name: string;
+      slug: string;
     };
 
     // Verify deck properties
     assertEquals(deck.name, "Test Code Review Deck");
+    assertEquals(deck.slug, "test-org_test-code-review-deck");
     assertExists(deck.id);
 
     // TODO: Verify graders were auto-generated
@@ -132,9 +136,11 @@ Deno.test("submitSample mutation creates sample linked to deck", async () => {
           name: "Test Sample Deck"
           systemPrompt: "Evaluate responses for quality."
           description: "A test deck for sample submission"
+          slug: "test-org_test-sample-deck"
         ) {
           id
           name
+          slug
         }
       }
     `;
@@ -151,7 +157,11 @@ Deno.test("submitSample mutation creates sample linked to deck", async () => {
         JSON.stringify(deckResult.errors)
       }`,
     );
-    const deck = deckResult.data?.createDeck as { id: string; name: string };
+    const deck = deckResult.data?.createDeck as {
+      id: string;
+      name: string;
+      slug: string;
+    };
 
     // Now submit a sample to the deck
     const submitSampleMutation = `

--- a/apps/bfDb/utils/slugUtils.ts
+++ b/apps/bfDb/utils/slugUtils.ts
@@ -1,0 +1,39 @@
+/**
+ * Utilities for generating and validating URL-safe slugs
+ */
+
+/**
+ * Generate a URL-safe slug from a string
+ */
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, "") // Remove special characters
+    .replace(/[\s_-]+/g, "-") // Replace spaces and underscores with hyphens
+    .replace(/^-+|-+$/g, ""); // Remove leading/trailing hyphens
+}
+
+/**
+ * Generate a deck slug with organization scope
+ */
+export function generateDeckSlug(deckName: string, orgId: string): string {
+  const cleanName = slugify(deckName);
+  return `${orgId}_${cleanName}`;
+}
+
+/**
+ * Validate slug format
+ */
+export function isValidSlug(slug: string): boolean {
+  const slugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+  return slugPattern.test(slug) && slug.length > 0 && slug.length <= 200;
+}
+
+/**
+ * Validate deck slug format (includes org prefix)
+ */
+export function isValidDeckSlug(slug: string): boolean {
+  const deckSlugPattern = /^[a-z0-9]+_[a-z0-9]+(?:-[a-z0-9]+)*$/;
+  return deckSlugPattern.test(slug) && slug.length > 0 && slug.length <= 200;
+}

--- a/apps/boltFoundry/__generated__/__isograph/Query/EntrypointBlog/normalization_ast.ts
+++ b/apps/boltFoundry/__generated__/__isograph/Query/EntrypointBlog/normalization_ast.ts
@@ -3,6 +3,11 @@ const normalizationAst: NormalizationAst = {
   kind: "NormalizationAst",
   selections: [
     {
+      kind: "Scalar",
+      fieldName: "id",
+      arguments: null,
+    },
+    {
       kind: "Linked",
       fieldName: "blogPost",
       arguments: [

--- a/apps/boltFoundry/__generated__/__isograph/Query/EntrypointBlog/query_text.ts
+++ b/apps/boltFoundry/__generated__/__isograph/Query/EntrypointBlog/query_text.ts
@@ -1,4 +1,5 @@
 export default 'query EntrypointBlog ($slug: String) {\
+  id,\
   blogPost____slug___v_slug: blogPost(slug: $slug) {\
     id,\
     author,\

--- a/apps/boltFoundry/__generated__/__isograph/Query/EntrypointDocs/normalization_ast.ts
+++ b/apps/boltFoundry/__generated__/__isograph/Query/EntrypointDocs/normalization_ast.ts
@@ -3,6 +3,11 @@ const normalizationAst: NormalizationAst = {
   kind: "NormalizationAst",
   selections: [
     {
+      kind: "Scalar",
+      fieldName: "id",
+      arguments: null,
+    },
+    {
       kind: "Linked",
       fieldName: "documentsBySlug",
       arguments: [

--- a/apps/boltFoundry/__generated__/__isograph/Query/EntrypointDocs/query_text.ts
+++ b/apps/boltFoundry/__generated__/__isograph/Query/EntrypointDocs/query_text.ts
@@ -1,4 +1,5 @@
 export default 'query EntrypointDocs ($slug: String) {\
+  id,\
   documentsBySlug____slug___v_slug: documentsBySlug(slug: $slug) {\
     id,\
     content,\

--- a/apps/boltFoundry/__generated__/__isograph/Query/EntrypointFormatter/normalization_ast.ts
+++ b/apps/boltFoundry/__generated__/__isograph/Query/EntrypointFormatter/normalization_ast.ts
@@ -4,6 +4,11 @@ const normalizationAst: NormalizationAst = {
   selections: [
     {
       kind: "Scalar",
+      fieldName: "id",
+      arguments: null,
+    },
+    {
+      kind: "Scalar",
       fieldName: "__typename",
       arguments: null,
     },

--- a/apps/boltFoundry/__generated__/__isograph/Query/EntrypointFormatter/query_text.ts
+++ b/apps/boltFoundry/__generated__/__isograph/Query/EntrypointFormatter/query_text.ts
@@ -1,3 +1,4 @@
 export default 'query EntrypointFormatter  {\
+  id,\
   __typename,\
 }';

--- a/apps/boltFoundry/__generated__/__isograph/Query/EntrypointHome/normalization_ast.ts
+++ b/apps/boltFoundry/__generated__/__isograph/Query/EntrypointHome/normalization_ast.ts
@@ -4,6 +4,11 @@ const normalizationAst: NormalizationAst = {
   selections: [
     {
       kind: "Scalar",
+      fieldName: "id",
+      arguments: null,
+    },
+    {
+      kind: "Scalar",
       fieldName: "__typename",
       arguments: null,
     },

--- a/apps/boltFoundry/__generated__/__isograph/Query/EntrypointHome/query_text.ts
+++ b/apps/boltFoundry/__generated__/__isograph/Query/EntrypointHome/query_text.ts
@@ -1,4 +1,5 @@
 export default 'query EntrypointHome  {\
+  id,\
   __typename,\
   githubRepoStats {\
     id,\

--- a/apps/boltFoundry/__generated__/__isograph/Query/EntrypointLogin/normalization_ast.ts
+++ b/apps/boltFoundry/__generated__/__isograph/Query/EntrypointLogin/normalization_ast.ts
@@ -4,6 +4,11 @@ const normalizationAst: NormalizationAst = {
   selections: [
     {
       kind: "Scalar",
+      fieldName: "id",
+      arguments: null,
+    },
+    {
+      kind: "Scalar",
       fieldName: "__typename",
       arguments: null,
     },

--- a/apps/boltFoundry/__generated__/__isograph/Query/EntrypointLogin/query_text.ts
+++ b/apps/boltFoundry/__generated__/__isograph/Query/EntrypointLogin/query_text.ts
@@ -1,3 +1,4 @@
 export default 'query EntrypointLogin  {\
+  id,\
   __typename,\
 }';

--- a/apps/boltfoundry-com/ClientRoot.tsx
+++ b/apps/boltfoundry-com/ClientRoot.tsx
@@ -1,27 +1,39 @@
 import { hydrateRoot } from "react-dom/client";
 import { getLogger } from "@bolt-foundry/logger";
 import App from "./src/App.tsx";
-import "./src/index.css";
+import {
+  AppEnvironmentProvider,
+  type ServerProps,
+} from "@bfmono/apps/boltfoundry-com/contexts/AppEnvironmentContext.tsx";
 
 const logger = getLogger(import.meta);
 
-export interface ClientRootProps {
-  environment: Record<string, unknown>;
+export interface ClientRootProps extends ServerProps {
+  children?: React.ReactNode;
 }
 
-export function ClientRoot({ environment }: ClientRootProps) {
-  return <App initialPath={environment.currentPath as string} />;
+export function ClientRoot({
+  children,
+  ...props
+}: ClientRootProps) {
+  return (
+    <AppEnvironmentProvider {...props}>
+      {children}
+    </AppEnvironmentProvider>
+  );
 }
 
-export function rehydrate(environment: Record<string, unknown>) {
-  logger.debug("🔧 rehydrate() called with environment:", environment);
+export function rehydrate(props: ServerProps) {
+  logger.debug("🔧 rehydrate() called with props:", props);
   const root = document.querySelector("#root");
   if (root) {
     logger.debug("🔧 Found #root element, calling hydrateRoot");
     try {
       hydrateRoot(
         root,
-        <ClientRoot environment={environment} />,
+        <ClientRoot {...props}>
+          <App />
+        </ClientRoot>,
       );
       logger.debug("🔧 hydrateRoot completed successfully");
     } catch (error) {
@@ -32,11 +44,14 @@ export function rehydrate(environment: Record<string, unknown>) {
   }
 }
 
+logger.debug("ClientRoot loaded");
 // @ts-expect-error Not typed on the window yet
 if (globalThis.__ENVIRONMENT__) {
+  logger.debug("found environment, rehydrating root");
   // @ts-expect-error Not typed on the window yet
   rehydrate(globalThis.__ENVIRONMENT__);
 } else {
+  logger.debug("Setting rehydration callback");
   // @ts-expect-error Not typed on the window yet
   globalThis.__REHYDRATE__ = rehydrate;
 }

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointHome/normalization_ast.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointHome/normalization_ast.ts
@@ -4,6 +4,11 @@ const normalizationAst: NormalizationAst = {
   selections: [
     {
       kind: "Scalar",
+      fieldName: "id",
+      arguments: null,
+    },
+    {
+      kind: "Scalar",
       fieldName: "__typename",
       arguments: null,
     },

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointHome/normalization_ast.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointHome/normalization_ast.ts
@@ -12,6 +12,24 @@ const normalizationAst: NormalizationAst = {
       fieldName: "__typename",
       arguments: null,
     },
+    {
+      kind: "Linked",
+      fieldName: "githubRepoStats",
+      arguments: null,
+      concreteType: "GithubRepoStats",
+      selections: [
+        {
+          kind: "Scalar",
+          fieldName: "id",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "stars",
+          arguments: null,
+        },
+      ],
+    },
   ],
 };
 export default normalizationAst;

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointHome/query_text.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointHome/query_text.ts
@@ -1,4 +1,8 @@
 export default 'query EntrypointHome  {\
   id,\
   __typename,\
+  githubRepoStats {\
+    id,\
+    stars,\
+  },\
 }';

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointHome/query_text.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointHome/query_text.ts
@@ -1,3 +1,4 @@
 export default 'query EntrypointHome  {\
+  id,\
   __typename,\
 }';

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/Home/param_type.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/Home/param_type.ts
@@ -2,6 +2,9 @@
 export type Query__Home__param = {
   readonly data: {
     readonly __typename: string,
+    readonly githubRepoStats: ({
+      readonly stars: number,
+    } | null),
   },
   readonly parameters: Record<PropertyKey, never>,
 };

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/Home/resolver_reader.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/Home/resolver_reader.ts
@@ -10,6 +10,23 @@ const readerAst: ReaderAst<Query__Home__param> = [
     arguments: null,
     isUpdatable: false,
   },
+  {
+    kind: "Linked",
+    fieldName: "githubRepoStats",
+    alias: null,
+    arguments: null,
+    condition: null,
+    isUpdatable: false,
+    selections: [
+      {
+        kind: "Scalar",
+        fieldName: "stars",
+        alias: null,
+        arguments: null,
+        isUpdatable: false,
+      },
+    ],
+  },
 ];
 
 const artifact: ComponentReaderArtifact<

--- a/apps/boltfoundry-com/__tests__/e2e/ssr.test.e2e.ts
+++ b/apps/boltfoundry-com/__tests__/e2e/ssr.test.e2e.ts
@@ -224,8 +224,13 @@ Deno.test("SSR serves correct response headers", async () => {
     );
 
     assert(
-      html?.includes("Coming Soon"),
-      "HTML should contain server-rendered subtitle",
+      html?.includes("Structured prompts, reliable output"),
+      "HTML should contain server-rendered hero headline",
+    );
+
+    assert(
+      html?.includes("Open source tooling to turn prompt engineering"),
+      "HTML should contain server-rendered hero subheadline",
     );
 
     // Verify that the rehydration script is included

--- a/apps/boltfoundry-com/__tests__/telemetry.integration.test.ts
+++ b/apps/boltfoundry-com/__tests__/telemetry.integration.test.ts
@@ -1,0 +1,232 @@
+import { assertEquals, assertExists } from "@std/assert";
+import { withIsolatedDb } from "@bfmono/apps/bfDb/bfDb.ts";
+import { makeLoggedInCv } from "@bfmono/apps/bfDb/utils/testUtils.ts";
+import { BfOrganization } from "@bfmono/apps/bfDb/nodeTypes/BfOrganization.ts";
+import { handleTelemetryRequest } from "../handlers/telemetry.ts";
+
+// Helper function to setup test data
+async function setupTestData() {
+  const cv = await makeLoggedInCv();
+
+  // Create the organization that the CurrentViewer references
+  // The CurrentViewer's orgBfOid should match this organization's bfGid
+  const org = await BfOrganization.__DANGEROUS__createUnattached(cv, {
+    name: "Test Organization",
+    domain: "test.com",
+  }, {
+    bfGid: cv.orgBfOid, // Use the same ID that CurrentViewer expects
+  });
+
+  return { cv, org };
+}
+
+// Mock telemetry data that would come from connectBoltFoundry
+const createMockTelemetryData = (overrides = {}) => ({
+  timestamp: new Date().toISOString(),
+  duration: 1500,
+  provider: "openai",
+  providerApiVersion: "v1",
+  sessionId: "test-session-123",
+  userId: "user-456",
+  request: {
+    url: "https://api.openai.com/v1/chat/completions",
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "authorization": "Bearer [REDACTED]",
+    },
+    body: {
+      model: "gpt-4",
+      messages: [
+        { role: "system", content: "You are a helpful assistant." },
+        { role: "user", content: "Hello!" },
+      ],
+    },
+  },
+  response: {
+    status: 200,
+    headers: {
+      "content-type": "application/json",
+    },
+    body: {
+      id: "chatcmpl-123",
+      object: "chat.completion",
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: "Hello! How can I help you today?",
+          },
+          finish_reason: "stop",
+        },
+      ],
+    },
+  },
+  // Basic deck metadata for MVP (no hashing)
+  bfMetadata: {
+    deckName: "customer-service",
+    deckContent:
+      "# Customer Service\n\nYou are a helpful customer service agent.",
+    contextVariables: { userId: "user-456", feature: "chat" },
+  },
+  ...overrides,
+});
+
+Deno.test("Telemetry endpoint - successful sample creation", async () => {
+  await withIsolatedDb(async () => {
+    const { cv } = await setupTestData();
+
+    const mockRequest = new Request("http://localhost:3000/api/telemetry", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-bf-api-key": `bf+${cv.orgBfOid}`,
+      },
+      body: JSON.stringify(createMockTelemetryData()),
+    });
+
+    const response = await handleTelemetryRequest(mockRequest);
+
+    assertEquals(response.status, 200);
+    const responseData = await response.json();
+    assertEquals(responseData.success, true);
+    assertExists(responseData.sampleId);
+  });
+});
+
+Deno.test("Telemetry endpoint - missing API key", async () => {
+  await withIsolatedDb(async () => {
+    const mockRequest = new Request("http://localhost:3000/api/telemetry", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(createMockTelemetryData()),
+    });
+
+    const response = await handleTelemetryRequest(mockRequest);
+
+    assertEquals(response.status, 401);
+    const responseData = await response.json();
+    assertEquals(responseData.error, "API key required");
+  });
+});
+
+Deno.test("Telemetry endpoint - invalid API key", async () => {
+  await withIsolatedDb(async () => {
+    const mockRequest = new Request("http://localhost:3000/api/telemetry", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-bf-api-key": "invalid-key",
+      },
+      body: JSON.stringify(createMockTelemetryData()),
+    });
+
+    const response = await handleTelemetryRequest(mockRequest);
+
+    assertEquals(response.status, 401);
+    const responseData = await response.json();
+    assertEquals(responseData.error, "Invalid API key");
+  });
+});
+
+Deno.test("Telemetry endpoint - creates deck if not exists", async () => {
+  await withIsolatedDb(async () => {
+    const { cv } = await setupTestData();
+
+    const telemetryData = createMockTelemetryData({
+      bfMetadata: {
+        deckName: "new-deck",
+        deckContent: "# New Deck\n\nThis is a new deck.",
+        contextVariables: { feature: "test" },
+      },
+    });
+
+    const mockRequest = new Request("http://localhost:3000/api/telemetry", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-bf-api-key": `bf+${cv.orgBfOid}`,
+      },
+      body: JSON.stringify(telemetryData),
+    });
+
+    const response = await handleTelemetryRequest(mockRequest);
+
+    assertEquals(response.status, 200);
+    const responseData = await response.json();
+    assertEquals(responseData.success, true);
+    assertExists(responseData.deckId);
+    assertExists(responseData.sampleId);
+  });
+});
+
+Deno.test("Telemetry endpoint - handles missing bfMetadata", async () => {
+  await withIsolatedDb(async () => {
+    const cv = await makeLoggedInCv();
+
+    const telemetryDataWithoutMetadata = createMockTelemetryData();
+    // @ts-expect-error - Deleting optional property
+    delete telemetryDataWithoutMetadata.bfMetadata;
+
+    const mockRequest = new Request("http://localhost:3000/api/telemetry", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-bf-api-key": `bf+${cv.orgBfOid}`,
+      },
+      body: JSON.stringify(telemetryDataWithoutMetadata),
+    });
+
+    const response = await handleTelemetryRequest(mockRequest);
+
+    assertEquals(response.status, 200);
+    const responseData = await response.json();
+    assertEquals(responseData.success, true);
+    assertEquals(
+      responseData.message,
+      "Telemetry processed without deck metadata",
+    );
+  });
+});
+
+Deno.test("Telemetry endpoint - invalid JSON", async () => {
+  await withIsolatedDb(async () => {
+    const cv = await makeLoggedInCv();
+
+    const mockRequest = new Request("http://localhost:3000/api/telemetry", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-bf-api-key": `bf+${cv.orgBfOid}`,
+      },
+      body: "invalid json",
+    });
+
+    const response = await handleTelemetryRequest(mockRequest);
+
+    assertEquals(response.status, 400);
+    const responseData = await response.json();
+    assertEquals(responseData.error, "Invalid JSON");
+  });
+});
+
+Deno.test("Telemetry endpoint - wrong HTTP method", async () => {
+  await withIsolatedDb(async () => {
+    const cv = await makeLoggedInCv();
+
+    const mockRequest = new Request("http://localhost:3000/api/telemetry", {
+      method: "GET",
+      headers: {
+        "x-bf-api-key": `bf+${cv.orgBfOid}`,
+      },
+    });
+
+    const response = await handleTelemetryRequest(mockRequest);
+
+    assertEquals(response.status, 405);
+    const responseData = await response.json();
+    assertEquals(responseData.error, "Method not allowed");
+  });
+});

--- a/apps/boltfoundry-com/apiRoutes.ts
+++ b/apps/boltfoundry-com/apiRoutes.ts
@@ -1,0 +1,33 @@
+import { handleTelemetryRequest } from "./handlers/telemetry.ts";
+
+export interface ApiRoute {
+  pattern: URLPattern;
+  handler: (request: Request) => Response | Promise<Response>;
+}
+
+export function createApiRoutes(
+  serverInfo: { isDev: boolean; port: number },
+): Array<ApiRoute> {
+  return [
+    {
+      pattern: new URLPattern({ pathname: "/health" }),
+      handler: () => {
+        const healthInfo = {
+          status: "OK",
+          timestamp: new Date().toISOString(),
+          mode: serverInfo.isDev ? "development" : "production",
+          port: serverInfo.port,
+          uptime: Math.floor(performance.now() / 1000) + " seconds",
+        };
+        return new Response(JSON.stringify(healthInfo, null, 2), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      },
+    },
+    {
+      pattern: new URLPattern({ pathname: "/api/telemetry" }),
+      handler: handleTelemetryRequest,
+    },
+  ];
+}

--- a/apps/boltfoundry-com/components/Home.tsx
+++ b/apps/boltfoundry-com/components/Home.tsx
@@ -1,46 +1,45 @@
 import { iso } from "@iso-bfc";
-import { BfDsButton } from "@bfmono/apps/bfDs/index.ts";
-import { useRouter } from "../contexts/RouterContext.tsx";
 
 export const Home = iso(`
   field Query.Home @component {
     __typename
   }
-`)(function Home() {
-  const { navigate } = useRouter();
-
+`)(function Home({ data }) {
   return (
-    <div style={{ padding: "2rem", maxWidth: "800px", margin: "0 auto" }}>
-      <h1>Bolt Foundry</h1>
-      <p>Coming Soon</p>
-
-      <div style={{ marginTop: "2rem" }}>
-        <p>
-          This is the Phase 1 implementation of the Bolt Foundry landing page.
-        </p>
-        <p>Architecture foundation established with Vite + Deno + React.</p>
-
-        <div style={{ marginTop: "2rem" }}>
-          <BfDsButton
-            onClick={() => navigate("/ui")}
-            variant="primary"
-            size="medium"
-          >
-            View UI Demo
-          </BfDsButton>
-        </div>
-      </div>
-
-      <footer
+    <div 
+      style={{
+        backgroundColor: 'var(--background)',
+        color: 'var(--text)',
+        minHeight: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        textAlign: 'center',
+        padding: '20px'
+      }}
+    >
+      <h1 
         style={{
-          marginTop: "4rem",
-          textAlign: "center",
-          fontSize: "0.9rem",
-          color: "#666",
+          fontSize: '3em',
+          fontFamily: 'var(--marketingFontFamily)',
+          color: 'var(--text)',
+          marginBottom: '24px',
+          lineHeight: '1.1'
         }}
       >
-        © 2025 Bolt Foundry. All rights reserved.
-      </footer>
+        Do something with your feedback.
+      </h1>
+      <p 
+        style={{
+          fontSize: '1.5em',
+          color: 'var(--text)',
+          fontFamily: 'var(--fontFamily)',
+          opacity: 0.8
+        }}
+      >
+        Coming soon.
+      </p>
     </div>
   );
 });

--- a/apps/boltfoundry-com/handlers/telemetry.ts
+++ b/apps/boltfoundry-com/handlers/telemetry.ts
@@ -1,0 +1,171 @@
+import { CurrentViewer } from "@bfmono/apps/bfDb/classes/CurrentViewer.ts";
+import { BfDeck } from "@bfmono/apps/bfDb/nodeTypes/rlhf/BfDeck.ts";
+import { BfSample } from "@bfmono/apps/bfDb/nodeTypes/rlhf/BfSample.ts";
+import { BfOrganization } from "@bfmono/apps/bfDb/nodeTypes/BfOrganization.ts";
+import { getLogger } from "@bfmono/packages/logger/logger.ts";
+
+const logger = getLogger(import.meta);
+
+interface TelemetryData {
+  timestamp: string;
+  duration: number;
+  provider: string;
+  providerApiVersion: string;
+  sessionId?: string;
+  userId?: string;
+  request: {
+    url: string;
+    method: string;
+    headers: Record<string, string>;
+    body: unknown;
+  };
+  response: {
+    status: number;
+    headers: Record<string, string>;
+    body: unknown;
+  };
+  bfMetadata?: {
+    deckName: string;
+    deckContent: string;
+    contextVariables: Record<string, unknown>;
+  };
+}
+
+export async function handleTelemetryRequest(
+  request: Request,
+): Promise<Response> {
+  // Only allow POST requests
+  if (request.method !== "POST") {
+    return new Response(
+      JSON.stringify({ error: "Method not allowed" }),
+      {
+        status: 405,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  try {
+    // Authenticate via API key header
+    const apiKey = request.headers.get("x-bf-api-key");
+    if (!apiKey) {
+      return new Response(
+        JSON.stringify({ error: "API key required" }),
+        {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    // For MVP, use simple API key format: "bf+{orgId}"
+    if (!apiKey.startsWith("bf+")) {
+      return new Response(
+        JSON.stringify({ error: "Invalid API key" }),
+        {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    const orgId = apiKey.replace("bf+", "");
+
+    // Create a CurrentViewer for this organization
+    const currentViewer = CurrentViewer
+      .__DANGEROUS_USE_IN_SCRIPTS_ONLY__createLoggedIn(
+        import.meta,
+        "telemetry@boltfoundry.com",
+        orgId,
+      );
+
+    // Parse the telemetry data
+    let telemetryData: TelemetryData;
+    try {
+      telemetryData = await request.json();
+    } catch {
+      return new Response(
+        JSON.stringify({ error: "Invalid JSON" }),
+        {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    // If no bfMetadata, just acknowledge the telemetry
+    if (!telemetryData.bfMetadata) {
+      logger.info("Telemetry received without deck metadata");
+      return new Response(
+        JSON.stringify({
+          success: true,
+          message: "Telemetry processed without deck metadata",
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    const { deckName, deckContent, contextVariables } = telemetryData
+      .bfMetadata;
+
+    // Get the organization node
+    const org = await BfOrganization.findX(
+      currentViewer,
+      currentViewer.orgBfOid,
+    );
+
+    // For MVP, let's just create a new deck each time
+    // TODO: Query for existing deck by name
+    const deck = await org.createTargetNode(BfDeck, {
+      name: deckName,
+      systemPrompt: deckContent,
+      description: `Auto-created from telemetry for ${deckName}`,
+    });
+    logger.info(`Created new deck: ${deckName}`);
+
+    // Create the sample
+    const completionData = {
+      request: telemetryData.request,
+      response: telemetryData.response,
+      provider: telemetryData.provider,
+      duration: telemetryData.duration,
+      contextVariables,
+    };
+
+    const sample = await deck.createTargetNode(BfSample, {
+      completionData: JSON.stringify(completionData),
+      collectionMethod: "telemetry",
+    });
+
+    logger.info(
+      `Created sample ${sample.metadata.bfGid} for deck ${deck.props.name}`,
+    );
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        deckId: deck.metadata.bfGid,
+        sampleId: sample.metadata.bfGid,
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  } catch (error) {
+    logger.error("Error processing telemetry:", error);
+    return new Response(
+      JSON.stringify({
+        error: "Internal server error",
+        details: error instanceof Error ? error.message : "Unknown error",
+      }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+}

--- a/apps/boltfoundry-com/isographEnvironment.ts
+++ b/apps/boltfoundry-com/isographEnvironment.ts
@@ -47,6 +47,9 @@ function makeMockedNetworkRequest<T>(
       EntrypointHome: {
         Home: {
           __typename: "HomeComponent",
+          githubRepoStats: {
+            stars: 42,
+          },
         },
       },
     },

--- a/apps/boltfoundry-com/memos/plans/markdown-deck-sample-collection.md
+++ b/apps/boltfoundry-com/memos/plans/markdown-deck-sample-collection.md
@@ -14,6 +14,57 @@ automatically collect samples when AI APIs are called.
 (`readLocalDeck()`) and remote deck retrieval (`fetchDeck()`). The MVP focuses
 on local markdown files, with remote deck management as a future enhancement.
 
+## Implementation Status
+
+### ✅ **MVP Telemetry Endpoint Complete** (July 2025)
+
+**What's Built:**
+
+- **Telemetry Handler** (`apps/boltfoundry-com/handlers/telemetry.ts`) -
+  Processes telemetry data and creates BfDeck/BfSample records
+- **API Routes Structure** (`apps/boltfoundry-com/apiRoutes.ts`) - Clean
+  separation of API routes from React routes
+- **Integration Tests**
+  (`apps/boltfoundry-com/__tests__/telemetry.integration.test.ts`) - Full test
+  suite with 7 passing tests
+- **Server Integration** - Added `/api/telemetry` endpoint to boltfoundry-com
+  server
+
+**What's Working:**
+
+- ✅ API key authentication (`bf+{orgId}` format)
+- ✅ JSON parsing and validation
+- ✅ Error handling (missing API key, invalid JSON, wrong HTTP method)
+- ✅ Deck creation from telemetry metadata (simplified - creates new deck each
+  time)
+- ✅ Sample creation with telemetry data stored as JSON
+- ✅ Proper HTTP responses and status codes
+- ✅ Database integration with BfOrganization, BfDeck, and BfSample nodes
+
+**Simplified for MVP:**
+
+- **No content-addressable hashing** - Skipped positional hash generation for
+  now
+- **No BfDeckVersion entity** - Using simplified deck creation pattern
+- **No deck deduplication** - Creates new deck for each telemetry request
+- **Basic authentication** - Simple `bf+{orgId}` API key format
+
+**Current Limitations:**
+
+- Organizations must exist in database (normal for production, but requires
+  setup for testing)
+- No deck versioning or content-addressable identification
+- No deck deduplication or conflict resolution
+
+### 🔄 **Next Steps for Full Implementation:**
+
+1. **Enhanced Telemetry Integration** - Update
+   `packages/bolt-foundry/bolt-foundry.ts` to support `bfMetadata`
+2. **Deck Loading Functions** - Implement `readLocalDeck()` and `fetchDeck()`
+3. **Content-Addressable Hashing** - Add positional hash generation system
+4. **BfDeckVersion Entity** - Implement proper versioning system
+5. **Provider Updates** - Remove Mistral, add OpenRouter support
+
 ## Architecture Overview
 
 ### Markdown-First Approach

--- a/apps/boltfoundry-com/server/components/ServerRenderedPage.tsx
+++ b/apps/boltfoundry-com/server/components/ServerRenderedPage.tsx
@@ -1,31 +1,94 @@
 import type React from "react";
 
+// CSS variables for theming (matching original boltFoundry)
+const cssVarsString = `:root {
+  --primaryColor: #FFD700;
+  --text: #FBFBFF;
+  --background: #141516;
+  --gapSmall: 8px;
+  --gapMedium: 16px;
+  --gapLarge: 24px;
+  --marketingFontFamily: "Bebas Neue", sans-serif;
+  --fontFamily: "DM Sans", sans-serif;
+  --text010: rgba(251, 251, 255, 0.1);
+  --border: rgba(251, 251, 255, 0.2);
+}`;
+
+const cssVarsDarkString = `:root[data-theme=dark] {
+  --primaryColor: #FFD700;
+  --text: #FBFBFF;
+  --background: #141516;
+}`;
+
+import type { ServerProps } from "@bfmono/apps/boltfoundry-com/contexts/AppEnvironmentContext.tsx";
+
 type Props = React.PropsWithChildren<{
   environment: Record<string, unknown>;
   assetPaths: {
     cssPath?: string;
     jsPath: string;
   };
+  serverEnvironment: ServerProps;
 }>;
 
 /*
  * This only runs on the server!!!! It should never run on the client.
  */
 export function ServerRenderedPage(
-  { children, environment, assetPaths }: Props,
+  { children, environment, assetPaths, serverEnvironment }: Props,
 ) {
-  // Make environment available during SSR
-  // @ts-expect-error - Setting up global for SSR
-  globalThis.__ENVIRONMENT__ = environment;
+  // Don't set globalThis.__ENVIRONMENT__ on server side - that's for client hydration only
   return (
     <html lang="en">
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Bolt Foundry</title>
-        {assetPaths.cssPath && (
-          <link rel="stylesheet" href={assetPaths.cssPath} />
-        )}
+
+        {/* CSS Variables */}
+        <style
+          dangerouslySetInnerHTML={{
+            __html: cssVarsString + cssVarsDarkString,
+          }}
+        />
+        
+        {/* Body reset */}
+        <style
+          dangerouslySetInnerHTML={{
+            __html: `
+              body {
+                margin: 0;
+                padding: 0;
+                font-family: var(--fontFamily);
+                background-color: var(--background);
+                color: var(--text);
+              }
+            `,
+          }}
+        />
+        <script
+          dangerouslySetInnerHTML={{
+            __html:
+              `document.documentElement.setAttribute("data-theme", "dark");`,
+          }}
+        />
+
+        {/* Static CSS imports */}
+        <link rel="stylesheet" href="/static/bfDsStyle.css" />
+
+        {/* Google Fonts */}
+        <link
+          href="https://fonts.googleapis.com/css2?family=DM+Mono&family=DM+Sans:wght@200;400;500;700&family=Bebas+Neue&display=swap&family=Roboto:wght@300&display=swap"
+          rel="stylesheet"
+        />
+
+        {/* Favicon */}
+        <link
+          rel="shortcut icon"
+          type="image/jpg"
+          href="https://bolt-foundry-assets.s3.us-east-2.amazonaws.com/favicon.ico"
+        />
+
         <script type="module" src={assetPaths.jsPath} />
       </head>
       <body>
@@ -36,24 +99,24 @@ export function ServerRenderedPage(
           type="module"
           defer
           dangerouslySetInnerHTML={{
-            __html: `globalThis.__ENVIRONMENT__ = ${
-              JSON.stringify(environment ?? {})
+            __html: `
+          console.log("🔧 Client-side hydration temporarily disabled");
+          // Temporarily disable hydration to test server-side rendering
+          // globalThis.__ENVIRONMENT__ = ${
+              JSON.stringify(serverEnvironment ?? {})
             };
 
-          console.log("🔧 Inline script executing, __REHYDRATE__ exists:", !!globalThis.__REHYDRATE__);
-          
-          if (globalThis.__REHYDRATE__) {
-            console.log("🔧 Calling __REHYDRATE__");
-            try {
-              await globalThis.__REHYDRATE__(globalThis.__ENVIRONMENT__);
-              console.log("🔧 __REHYDRATE__ call completed");
-            } catch (error) {
-              console.error("🔧 __REHYDRATE__ call failed:", error);
-            }
-          } else {
-            // can't rehydrate yet.
-            console.warn("🔧 Rehydration fail - __REHYDRATE__ not found");
-          }
+          // if (globalThis.__REHYDRATE__) {
+          //   console.log("🔧 Calling __REHYDRATE__");
+          //   try {
+          //     await globalThis.__REHYDRATE__(globalThis.__ENVIRONMENT__);
+          //     console.log("🔧 __REHYDRATE__ call completed");
+          //   } catch (error) {
+          //     console.error("🔧 __REHYDRATE__ call failed:", error);
+          //   }
+          // } else {
+          //   console.warn("🔧 Rehydration fail - __REHYDRATE__ not found");
+          // }
           `,
           }}
         />

--- a/apps/boltfoundry-com/server/isographEnvironment.ts
+++ b/apps/boltfoundry-com/server/isographEnvironment.ts
@@ -52,6 +52,9 @@ function makeMockedNetworkRequest<T>(
       EntrypointHome: {
         Home: {
           __typename: "HomeComponent",
+          githubRepoStats: {
+            stars: 42,
+          },
         },
       },
     },

--- a/apps/boltfoundry-com/src/App.tsx
+++ b/apps/boltfoundry-com/src/App.tsx
@@ -1,12 +1,11 @@
 import {
   matchRouteWithParams,
-  RouterProvider,
   useRouter,
 } from "../contexts/RouterContext.tsx";
 import { appRoutes, isographAppRoutes } from "../routes.ts";
-import { IsographEnvironmentProvider, useLazyReference } from "@isograph/react";
+import { useLazyReference } from "@isograph/react";
 import { BfIsographFragmentReader } from "../lib/BfIsographFragmentReader.tsx";
-import { getEnvironment } from "../isographEnvironment.ts";
+import type { AppEnvironmentProvider } from "../contexts/AppEnvironmentContext.tsx";
 
 function AppRoot() {
   const routerProps = useRouter();
@@ -47,16 +46,8 @@ function AppRoot() {
   return <div>404 - Page not found</div>;
 }
 
-function App({ initialPath }: { initialPath?: string }) {
-  return (
-    <div className="app">
-      <IsographEnvironmentProvider environment={getEnvironment()}>
-        <RouterProvider initialPath={initialPath}>
-          <AppRoot />
-        </RouterProvider>
-      </IsographEnvironmentProvider>
-    </div>
-  );
+function App() {
+  return <AppRoot />;
 }
 
 export default App;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -28,3 +28,20 @@ export type NonUndefined<T> = T extends undefined ? never : T;
 export type StrictPartialJson<T> = {
   [K in keyof T]?: NonUndefined<T[K]>;
 };
+
+/**
+ * Common JSON value type used across the Bolt Foundry monorepo.
+ * This type represents any valid JSON value.
+ */
+export type JSONValue =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: JSONValue }
+  | Array<JSONValue>;
+
+/**
+ * Properties object with string keys and JSON values.
+ */
+export type Props = Record<string, JSONValue>;


### PR DESCRIPTION
- Add bfMetadata field to TelemetryData type
- Extract bfMetadata from requests before sending to OpenAI
- Strip bfMetadata from OpenAI requests to avoid API errors
- Preserve bfMetadata in telemetry data for sample collection
- Add comprehensive tests with proper TypeScript typing
- Create shared JSONValue type in lib/types.ts

This enables automatic sample collection in RLHF pipeline using deck metadata.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/1481).
* __->__ #1481
* #1479
* #1478
* #1477
* #1476

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/1481)
<!-- GitContextEnd -->