### PR TITLE
Migrate renderDeck to async deck system with enhanced processing

### DIFF
--- a/apps/aibff/commands/__tests__/render_context_injection.test.ts
+++ b/apps/aibff/commands/__tests__/render_context_injection.test.ts
@@ -298,7 +298,7 @@ default = "value"`,
   await Deno.writeTextFile(textPath, "These are some notes");
 
   try {
-    const result = renderDeck(deckPath, {});
+    const result = await renderDeck(deckPath, {});
 
     // System message should not contain ![...] embeds
     const systemMsg = result.messages[0];
@@ -318,7 +318,7 @@ default = "value"`,
 
 Deno.test("renderDeck function - should add context Q&A in correct format", async () => {
   const deckPath = await createTempDeckFile("# Test");
-  const result = renderDeck(deckPath, {
+  const result = await renderDeck(deckPath, {
     userName: "Alice",
     apiKey: "sk-123",
   });
@@ -339,7 +339,7 @@ Deno.test("renderDeck function - should skip context values without definitions"
   Object.assign(ui, captureUI);
 
   try {
-    const result = renderDeck(deckPath, {
+    const result = await renderDeck(deckPath, {
       unknownVar: "should be ignored",
     });
 
@@ -363,7 +363,7 @@ Deno.test("renderDeck function - should skip context values without definitions"
 
 Deno.test("renderDeck function - should return complete OpenAI request object", async () => {
   const deckPath = await createTempDeckFile("# Test Deck");
-  const result = renderDeck(deckPath, {});
+  const result = await renderDeck(deckPath, {});
 
   assert("messages" in result, "Should have messages property");
   assert(Array.isArray(result.messages), "Messages should be an array");
@@ -380,7 +380,7 @@ Deno.test("renderDeck function - should spread openAiCompletionOptions last", as
     custom_field: "test",
   };
 
-  const result = renderDeck(deckPath, {}, customOptions);
+  const result = await renderDeck(deckPath, {}, customOptions);
 
   assertEquals(result.temperature, 0.7);
   assertEquals(result.max_tokens, 1000);
@@ -400,7 +400,7 @@ This is a simple deck with no external references.
 
 Some content here.`);
 
-  const result = renderDeck(deckPath, {});
+  const result = await renderDeck(deckPath, {});
 
   assertEquals(result.messages.length, 1);
   assertEquals(result.messages[0].role, "system");
@@ -451,7 +451,7 @@ default = "https://api.example.com"`,
   );
 
   try {
-    const result = renderDeck(deckPath, {
+    const result = await renderDeck(deckPath, {
       userName: "Bob",
       userRole: "admin",
       apiKey: "sk-custom",

--- a/apps/aibff/commands/__tests__/render_deck_includes.test.ts
+++ b/apps/aibff/commands/__tests__/render_deck_includes.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertThrows } from "@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 import { renderDeck } from "../render.ts";
 
 Deno.test("processMarkdownIncludes - should include basic markdown deck file", async () => {
@@ -19,7 +19,7 @@ This is included content.`;
   await Deno.writeTextFile(includedDeckPath, includedContent);
 
   try {
-    const result = renderDeck(mainDeckPath, {}, {});
+    const result = await renderDeck(mainDeckPath, {}, {});
 
     // The system message should contain both contents combined
     const expectedContent = `# Main Deck
@@ -58,7 +58,7 @@ This is the deepest level.`;
   await Deno.writeTextFile(deckCPath, deckC);
 
   try {
-    const result = renderDeck(deckAPath, {}, {});
+    const result = await renderDeck(deckAPath, {}, {});
 
     const expectedContent = `# Deck A
 # Deck B
@@ -92,7 +92,7 @@ Deno.test("processMarkdownIncludes - should resolve relative paths correctly in 
   await Deno.writeTextFile(includedDeckPath, includedContent);
 
   try {
-    const result = renderDeck(mainDeckPath, {}, {});
+    const result = await renderDeck(mainDeckPath, {}, {});
 
     const expectedContent = `# Main
 # Included from dirB`;
@@ -128,12 +128,11 @@ default = "Alice"`;
   await Deno.writeTextFile(configPath, configContent);
 
   try {
-    const result = renderDeck(mainDeckPath, { userName: "Bob" }, {});
+    const result = await renderDeck(mainDeckPath, { userName: "Bob" }, {});
 
     // System message should have markdown content but no file references
     const expectedSystemContent = `# Main Deck
 # Base Deck
-
 
 Base content here.
 
@@ -160,8 +159,8 @@ Deno.test("processMarkdownIncludes - should throw error for missing deck include
   await Deno.writeTextFile(mainDeckPath, mainContent);
 
   try {
-    assertThrows(
-      () => renderDeck(mainDeckPath, {}, {}),
+    await assertRejects(
+      async () => await renderDeck(mainDeckPath, {}, {}),
       Error,
       "File not found",
     );
@@ -186,7 +185,7 @@ This should be included`;
   await Deno.writeTextFile(readmePath, readmeContent);
 
   try {
-    const result = renderDeck(mainDeckPath, {}, {});
+    const result = await renderDeck(mainDeckPath, {}, {});
 
     // Should include readme.md content
     assertEquals(
@@ -224,7 +223,7 @@ default = "value"`;
   await Deno.writeTextFile(configPath, configContent);
 
   try {
-    const result = renderDeck(mainDeckPath, { test: "custom" }, {});
+    const result = await renderDeck(mainDeckPath, { test: "custom" }, {});
 
     // Should successfully load config.toml relative to base.deck.md
     assertEquals(result.messages.length, 3);
@@ -277,7 +276,7 @@ assistantQuestion = "What is your API key?"`;
       apiKey: "sk-123",
     };
 
-    const result = renderDeck(appDeckPath, context, {});
+    const result = await renderDeck(appDeckPath, context, {});
 
     // Should have all three context variables
     assertEquals(result.messages.length, 7); // system + 3 Q&A pairs

--- a/apps/aibff/commands/calibrate.ts
+++ b/apps/aibff/commands/calibrate.ts
@@ -226,7 +226,7 @@ async function runEvaluationWithConcurrency(
             );
 
             // Render the deck with the sample context
-            const sampleRequest = renderDeck(
+            const sampleRequest = await renderDeck(
               deckPath,
               sampleContext,
               openAiCompletionOptions,

--- a/apps/aibff/commands/repl.ts
+++ b/apps/aibff/commands/repl.ts
@@ -34,7 +34,7 @@ async function runRepl(_args: Array<string>): Promise<void> {
   await Deno.writeTextFile(tempFile, pirateDeck);
 
   // Use renderDeck to create the initial messages with the pirate deck
-  const rendered = renderDeck(tempFile, {}, {
+  const rendered = await renderDeck(tempFile, {}, {
     model: "openai/gpt-4o-mini",
     temperature: 0.7,
     stream: true,

--- a/apps/aibff/gui/guiServer.ts
+++ b/apps/aibff/gui/guiServer.ts
@@ -272,7 +272,7 @@ const routes = [
 
       try {
         // Get the OpenAI request from renderDeck to get the system message
-        const baseRequest = renderDeck(deckPath, {}, {
+        const baseRequest = await renderDeck(deckPath, {}, {
           model: "openai/gpt-4o",
           stream: true,
         });

--- a/apps/boltfoundry-com/memos/plans/rlhf-pipeline-data-model-implementation.md
+++ b/apps/boltfoundry-com/memos/plans/rlhf-pipeline-data-model-implementation.md
@@ -443,25 +443,28 @@ All five RLHF node types are properly registered and exposed:
 - Type relationships and connections functional
 - Ready for mutation addition
 
-#### 🔄 **IN PROGRESS: GraphQL Mutation Implementation**
+#### 🔄 **APPROACH UPDATED: Telemetry-Driven Deck Discovery**
 
-**Current Approach**:
+**New Approach** (No manual deck creation):
 
-1. **Model-Centric Mutations**: Add `.mutation()` calls directly to BfDeck,
-   BfSample classes
-2. **Thin Controllers**: Mutation resolvers call simple model methods
-3. **Mock Integration**: Use mock analyzer for immediate testing
-4. **Incremental Replacement**: Replace mock with real LLM service later
+1. **Markdown-Based Decks**: Developers use local `.deck.md` files with
+   `readLocalDeck()`
+2. **Automatic Discovery**: Telemetry creates BfDeck and BfDeckVersion
+   automatically on API usage
+3. **Content Addressing**: Deck versions identified by content-derived hashes
+4. **Sample Collection**: Automatic linking to specific deck versions via
+   telemetry
 
-**Updated Phase 1 Tasks**:
+**Updated Phase 1 Tasks** (Telemetry-Driven):
 
 - [x] ✅ Data model implementation (all 5 node types)
 - [x] ✅ GraphQL schema registration
 - [x] ✅ Mock system prompt analyzer
-- [ ] 🔄 Add mutations to BfDeck class for deck creation
-- [ ] 📋 Add mutations to BfSample class for sample submission
-- [ ] 📋 Test end-to-end workflow via GraphQL
-- [ ] 📋 Setup hardcoded authentication for testing
+- [ ] 📋 Implement `BfDeckVersion` node type for content addressing
+- [ ] 📋 Integrate with markdown-based deck system
+      (`packages/bolt-foundry/deck.ts`)
+- [ ] 📋 Setup telemetry endpoint for automatic deck/sample creation
+- [ ] 📋 Test end-to-end: local markdown → telemetry → BfDeck creation
 
 ### Technical Architecture Corrections
 

--- a/packages/team-status-analyzer/ai-summarizer.ts
+++ b/packages/team-status-analyzer/ai-summarizer.ts
@@ -4,7 +4,7 @@
  */
 
 import { getLogger } from "@bfmono/packages/logger/logger.ts";
-import { renderDeck } from "@bfmono/apps/aibff/index.ts";
+import { readLocalDeck } from "@bfmono/packages/bolt-foundry/bolt-foundry.ts";
 import type { CompanyContext, WorkItem } from "./types.ts";
 import { getSecret } from "@bfmono/packages/get-configuration-var/get-configuration-var.ts";
 
@@ -161,14 +161,15 @@ CRITICAL: Your response must be ONLY valid JSON in exactly this format:
 Do not include any text before or after the JSON. Start with { and end with }.`,
       };
 
-      // Render the deck with work context
-      const chatCompletionParams = renderDeck(
-        this.deckPath,
-        contextWithInstructions,
-        {
-          model: "gpt-4o-mini", // Fast model for summarization
-        },
-      );
+      // Render the deck with work context using the new deck system
+      const deck = await readLocalDeck(this.deckPath);
+      const result = deck.render({}, { context: contextWithInstructions });
+
+      // Convert to the expected format
+      const chatCompletionParams = {
+        messages: result.messages,
+        model: "gpt-4o-mini", // Fast model for summarization
+      };
 
       // Log the rendered deck for debugging
       logger.debug("Deck rendered for AI summarization:", {


### PR DESCRIPTION

Refactor renderDeck function to use the new readLocalDeck() system instead of direct markdown processing, making it async throughout the codebase. This unifies deck handling and improves path resolution for markdown includes.

Changes:
- Convert renderDeck() to async function using readLocalDeck()
- Update all renderDeck() call sites to use await
- Fix test assertions to use assertRejects for async error testing
- Enhance deck.ts with proper path resolution using @std/path
- Add recursive markdown include processing with nested context merging
- Update RLHF implementation plan to reflect telemetry-driven approach
- Fix whitespace cleanup logic for TOML reference removal

Test plan:
1. Run aibff tests: `bft test apps/aibff/`
2. Test deck rendering: `bft aibff render path/to/test.deck.md`
3. Verify markdown includes work with nested paths
4. Check that context variables are properly extracted and validated

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/1509).
* #1514
* #1513
* #1512
* #1511
* #1510
* #1506
* __->__ #1509