### PR TITLE
Update all tests for new BfDeck/BfSample schema, Implement BfOrganization demo data auto-creation, Update telemetry hand

### DIFF
--- a/apps/bfDb/graphql/__generated__/schema.graphql
+++ b/apps/bfDb/graphql/__generated__/schema.graphql
@@ -46,6 +46,7 @@ type BfSample implements BfNode {
   collectionMethod: String
   completionData: JSON
   id: ID!
+  name: String
 }
 
 type BfSampleFeedback implements BfNode {
@@ -105,7 +106,7 @@ type Mutation {
   createDeck(description: String, name: String!, slug: String!, systemPrompt: String!): BfDeck
   joinWaitlist(company: String, email: String!, name: String!): JoinWaitlistPayload
   loginWithGoogle(idToken: String!): CurrentViewer
-  submitSample(collectionMethod: String, completionData: String!, deckId: String!): BfSample
+  submitSample(collectionMethod: String, completionData: String!, deckId: String!, name: String): BfSample
 }
 
 """An object with a unique identifier"""

--- a/apps/bfDb/graphql/__tests__/gqlSpec.inheritance.test.ts
+++ b/apps/bfDb/graphql/__tests__/gqlSpec.inheritance.test.ts
@@ -185,8 +185,8 @@ Deno.test("GraphQL spec inheritance - BfDeck should inherit id field from BfNode
   );
   assert(deckSpec.fields.name, "BfDeck should have its own name field");
   assert(
-    deckSpec.fields.systemPrompt,
-    "BfDeck should have its own systemPrompt field",
+    deckSpec.fields.content,
+    "BfDeck should have its own content field",
   );
 });
 

--- a/apps/bfDb/nodeTypes/BfOrganization.ts
+++ b/apps/bfDb/nodeTypes/BfOrganization.ts
@@ -1,4 +1,5 @@
 import { BfNode, type InferProps } from "@bfmono/apps/bfDb/classes/BfNode.ts";
+import { BfDeck } from "@bfmono/apps/bfDb/nodeTypes/rlhf/BfDeck.ts";
 
 export class BfOrganization extends BfNode<InferProps<typeof BfOrganization>> {
   static override gqlSpec = this.defineGqlNode((node) =>
@@ -12,4 +13,22 @@ export class BfOrganization extends BfNode<InferProps<typeof BfOrganization>> {
       .string("name")
       .string("domain")
   );
+
+  /**
+   * Lifecycle hook: Auto-create demo RLHF content for new organizations
+   */
+  protected override async afterCreate(): Promise<void> {
+    await this.addDemoDeck();
+  }
+
+  /**
+   * Create demo RLHF deck for this organization
+   */
+  async addDemoDeck(): Promise<void> {
+    const deckPath = new URL(
+      import.meta.resolve("./rlhf/demo-decks/customer-support-demo.deck.md"),
+    ).pathname;
+    const deckProps = await BfDeck.readPropsFromFile(deckPath);
+    await this.createTargetNode(BfDeck, deckProps);
+  }
 }

--- a/apps/bfDb/nodeTypes/__tests__/BfOrganization.test.ts
+++ b/apps/bfDb/nodeTypes/__tests__/BfOrganization.test.ts
@@ -17,13 +17,14 @@ Deno.test("BfOrganization - Organization isolation", async () => {
     const sharedProps = {
       deck: {
         name: "Shared Deck",
-        systemPrompt: "Shared system prompt",
+        content: "Shared system prompt",
         description: "Shared description",
       },
       grader: {
         graderText: "Shared grader text",
       },
       sample: {
+        name: "Shared Sample",
         completionData: {
           id: "shared-completion",
           object: "chat.completion" as const,

--- a/apps/bfDb/nodeTypes/rlhf/BfSample.ts
+++ b/apps/bfDb/nodeTypes/rlhf/BfSample.ts
@@ -57,12 +57,14 @@ export class BfSample extends BfNode<InferProps<typeof BfSample>> {
     gql
       .json("completionData")
       .string("collectionMethod")
+      .string("name")
       .typedMutation("submitSample", {
         args: (a) =>
           a
             .nonNull.string("deckId")
             .nonNull.string("completionData")
-            .string("collectionMethod"),
+            .string("collectionMethod")
+            .string("name"),
         returns: "BfSample",
         resolve: async (_src, args, ctx) => {
           const cv = ctx.getCurrentViewer();
@@ -71,6 +73,7 @@ export class BfSample extends BfNode<InferProps<typeof BfSample>> {
             completionData: JSON.parse(args.completionData),
             collectionMethod: (args.collectionMethod ||
               "manual") as BfSampleCollectionMethod,
+            name: args.name || "",
           });
 
           return sample.toGraphql();
@@ -86,5 +89,6 @@ export class BfSample extends BfNode<InferProps<typeof BfSample>> {
     node
       .json("completionData") // Native JSON storage
       .string("collectionMethod") // "manual" | "telemetry"
+      .string("name") // Optional human-readable name for the sample
   );
 }

--- a/apps/bfDb/nodeTypes/rlhf/__tests__/GraphQLConnections.integration.test.ts
+++ b/apps/bfDb/nodeTypes/rlhf/__tests__/GraphQLConnections.integration.test.ts
@@ -31,12 +31,13 @@ Deno.test("GraphQL Connection Integration - BfDeck.samples connection without pa
 
     const deck = await org.createTargetNode(BfDeck, {
       name: "Integration Test Deck",
-      systemPrompt: "Test GraphQL connections",
+      content: "Test GraphQL connections",
       description: "Deck for testing connection resolvers",
       slug: "integration-test-deck",
     });
 
     const sample1 = await deck.createTargetNode(BfSample, {
+      name: "Sample 1",
       completionData: {
         id: "sample-1",
         model: "gpt-4",
@@ -51,6 +52,7 @@ Deno.test("GraphQL Connection Integration - BfDeck.samples connection without pa
     });
 
     const sample2 = await deck.createTargetNode(BfSample, {
+      name: "Sample 2",
       completionData: {
         id: "sample-2",
         model: "gpt-4",
@@ -100,12 +102,13 @@ Deno.test("GraphQL Connection Integration - BfDeck.samples connection with pagin
 
     const deck = await org.createTargetNode(BfDeck, {
       name: "Pagination Test Deck",
-      systemPrompt: "Test pagination errors",
+      content: "Test pagination errors",
       description: "Deck for testing pagination error handling",
       slug: "pagination-test-deck",
     });
 
     await deck.createTargetNode(BfSample, {
+      name: "Pagination Test Sample",
       completionData: {
         id: "sample-1",
         model: "gpt-4",
@@ -158,13 +161,14 @@ Deno.test("GraphQL Connection Integration - BfSample.results connection without 
 
     const deck = await org.createTargetNode(BfDeck, {
       name: "Results Test Deck",
-      systemPrompt: "Test result connections",
+      content: "Test result connections",
       description: "Deck for testing result connection resolvers",
       slug: "results-test-deck",
     });
 
     // Create sample and graders for test setup
     const sample = await deck.createTargetNode(BfSample, {
+      name: "Results Test Sample",
       completionData: {
         id: "sample-1",
         model: "gpt-4",
@@ -243,13 +247,14 @@ Deno.test("GraphQL Connection Integration - BfSample.results connection with pag
 
     const deck = await org.createTargetNode(BfDeck, {
       name: "Pagination Error Test Deck",
-      systemPrompt: "Test pagination errors in results",
+      content: "Test pagination errors in results",
       description: "Testing pagination error handling",
       slug: "pagination-error-test-deck",
     });
 
     // Create sample for test setup
     const sample = await deck.createTargetNode(BfSample, {
+      name: "Pagination Error Test Sample",
       completionData: {
         id: "sample-1",
         model: "gpt-4",
@@ -309,7 +314,7 @@ Deno.test("GraphQL Connection Integration - empty connections should work correc
 
     const deck = await org.createTargetNode(BfDeck, {
       name: "Empty Deck",
-      systemPrompt: "Empty deck for testing",
+      content: "Empty deck for testing",
       description: "This deck has no samples",
       slug: "empty-deck",
     });
@@ -343,12 +348,13 @@ Deno.test("GraphQL Connection Integration - connection preserves node properties
 
     const deck = await org.createTargetNode(BfDeck, {
       name: "Property Preservation Deck",
-      systemPrompt: "Testing property preservation",
+      content: "Testing property preservation",
       description: "Verify all properties are maintained",
       slug: "property-preservation-deck",
     });
 
     const sample = await deck.createTargetNode(BfSample, {
+      name: "Property Preservation Sample",
       completionData: {
         id: "prop-sample",
         model: "gpt-4-turbo",

--- a/apps/bfDb/nodeTypes/rlhf/__tests__/RlhfMutations.integration.test.ts
+++ b/apps/bfDb/nodeTypes/rlhf/__tests__/RlhfMutations.integration.test.ts
@@ -73,7 +73,7 @@ Deno.test("createDeck mutation creates deck and auto-generates graders", async (
       mutation {
         createDeck(
           name: "Test Code Review Deck"
-          systemPrompt: "Evaluate code review responses for accuracy and helpfulness."
+          content: "Evaluate code review responses for accuracy and helpfulness."
           description: "A test deck for code review evaluation"
           slug: "test-org_test-code-review-deck"
         ) {
@@ -134,7 +134,7 @@ Deno.test("submitSample mutation creates sample linked to deck", async () => {
       mutation {
         createDeck(
           name: "Test Sample Deck"
-          systemPrompt: "Evaluate responses for quality."
+          content: "Evaluate responses for quality."
           description: "A test deck for sample submission"
           slug: "test-org_test-sample-deck"
         ) {

--- a/apps/bfDb/nodeTypes/rlhf/__tests__/RlhfPipelineIntegrationTest.test.ts
+++ b/apps/bfDb/nodeTypes/rlhf/__tests__/RlhfPipelineIntegrationTest.test.ts
@@ -34,7 +34,7 @@ Deno.test("RLHF Pipeline Integration - Complete end-to-end workflow", async () =
 
     const deck = await org.createTargetNode(BfDeck, {
       name: "Code Review Quality Deck",
-      systemPrompt:
+      content:
         "Evaluate code review responses for clarity, accuracy, and helpfulness. Rate on a scale of -3 to +3.",
       description:
         "A comprehensive deck for evaluating the quality of code review responses in software development teams.",
@@ -44,7 +44,7 @@ Deno.test("RLHF Pipeline Integration - Complete end-to-end workflow", async () =
     // Verify deck creation
     assertEquals(deck.props.name, "Code Review Quality Deck");
     assertEquals(
-      deck.props.systemPrompt,
+      deck.props.content,
       "Evaluate code review responses for clarity, accuracy, and helpfulness. Rate on a scale of -3 to +3.",
     );
     assertEquals(
@@ -111,6 +111,7 @@ Deno.test("RLHF Pipeline Integration - Complete end-to-end workflow", async () =
     };
 
     const sample = await deck.createTargetNode(BfSample, {
+      name: "Code Review Sample",
       completionData: completionData as unknown as JSONValue,
       collectionMethod: "manual",
     });
@@ -245,5 +246,22 @@ Deno.test("RLHF Pipeline Integration - Complete end-to-end workflow", async () =
       feedback.metadata.bfOid,
     ];
     assertEquals(new Set(allOids).size, 1); // All should be the same
+  });
+});
+
+Deno.test("Organization auto-creates demo RLHF content", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv({ orgSlug: "demo-org", email: "test@demo.com" });
+
+    const org = await BfOrganization.__DANGEROUS__createUnattached(cv, {
+      name: "Demo Organization",
+      domain: "demo.com",
+    });
+    await org.save();
+
+    // Check if a deck was automatically created
+    const decks = await org.queryTargetInstances(BfDeck);
+    assertEquals(decks.length, 1);
+    assertEquals(decks[0].props.name, "Customer Support Response Evaluator");
   });
 });

--- a/apps/bfDb/nodeTypes/rlhf/__tests__/RlhfWorkflow.test.ts
+++ b/apps/bfDb/nodeTypes/rlhf/__tests__/RlhfWorkflow.test.ts
@@ -22,7 +22,7 @@ Deno.test("RLHF Workflow - Create deck via sample submission, add AI evaluation 
     // Create deck (simulating telemetry endpoint)
     const deck = await org.createTargetNode(BfDeck, {
       name: "customer-service",
-      systemPrompt: "You are a helpful customer service agent.",
+      content: "You are a helpful customer service agent.",
       description: "Auto-created from telemetry",
       slug: "test-org_customer-service",
     });
@@ -38,6 +38,7 @@ Deno.test("RLHF Workflow - Create deck via sample submission, add AI evaluation 
         },
       }),
       collectionMethod: "telemetry",
+      name: "Customer Support Sample",
     });
 
     // Mock AI evaluation by directly creating a grader result
@@ -57,6 +58,7 @@ Deno.test("RLHF Workflow - Create deck via sample submission, add AI evaluation 
     // Verify workflow
     assertEquals(deck.props.name, "customer-service");
     assertEquals(sample.props.collectionMethod, "telemetry");
+    assertEquals(sample.props.name, "Customer Support Sample");
     assertEquals(feedback.props.score, 3);
     assertExists(feedback.props.explanation);
   });

--- a/apps/boltfoundry-com/handlers/telemetry.ts
+++ b/apps/boltfoundry-com/handlers/telemetry.ts
@@ -137,11 +137,10 @@ export async function handleTelemetryRequest(
       // Create new deck
       deck = await org.createTargetNode(BfDeck, {
         name: deckName,
-        systemPrompt: deckContent,
+        content: deckContent,
         description: `Auto-created from telemetry for ${deckName}`,
         slug,
       }) as BfDeck;
-      await deck.afterCreate();
       logger.info(`Created new deck: ${deckName} (slug: ${slug})`);
     }
 
@@ -155,6 +154,7 @@ export async function handleTelemetryRequest(
     };
 
     const sample = await deck.createTargetNode(BfSample, {
+      name: `Telemetry Sample ${Date.now()}`,
       completionData: JSON.stringify(completionData),
       collectionMethod: "telemetry",
     });

--- a/packages/bolt-foundry/bolt-foundry.ts
+++ b/packages/bolt-foundry/bolt-foundry.ts
@@ -3,6 +3,7 @@ import type { OpenAI } from "@openai/openai";
 
 export { BfClient } from "./BfClient.ts";
 export * from "./deck.ts";
+export { readLocalDeck } from "./deck.ts";
 
 let logger = console;
 const enableLogging = false;


### PR DESCRIPTION
ler for new BfDeck schema


Update test files to use new 'content' field instead of 'systemPrompt' and
include required 'name' field for BfSample creation.

Test updates:
- Replace systemPrompt references with content in all test files
- Add name field to BfSample creation calls
- Update GraphQL inheritance test expectations
- Add integration test for demo data creation
- Ensure all tests pass with new schema

Files updated:
- BfOrganization.test.ts - schema field updates
- GraphQLConnections.integration.test.ts - field name fixes
- RlhfMutations.integration.test.ts - schema updates
- RlhfPipelineIntegrationTest.test.ts - demo creation test
- RlhfWorkflow.test.ts - field name updates
- gqlSpec.inheritance.test.ts - schema expectation fixes

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
Add afterCreate hook to BfOrganization that automatically creates demo RLHF
deck content when new organizations are created for better onboarding.

Implementation:
- BfOrganization.afterCreate() calls addDemoDeck() method
- BfDeck.readPropsFromFile() loads deck content from filesystem
- Integration with bolt-foundry package for deck file reading
- Demo deck creation uses existing customer-support-demo.deck.md content

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
Update telemetry handler to use new 'content' field instead of 'systemPrompt'
and add required 'name' field for sample creation.

Changes:
- Use deck.content instead of deck.systemPrompt
- Add name field when creating BfSample instances
- Maintain existing telemetry functionality with new schema

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/1544).
* #1545
* __->__ #1544
* #1543

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/1544)
<!-- GitContextEnd -->