### PR TITLE
Fix Kamal deployment to run within Nix environment

### DIFF
--- a/.github/workflows/deploy-boltfoundry-com.yml
+++ b/.github/workflows/deploy-boltfoundry-com.yml
@@ -41,7 +41,11 @@ jobs:
           ssh-keyscan -H $(terraform output -raw server_ip 2>/dev/null || echo "placeholder-ip") >> ~/.ssh/known_hosts || true
 
       - name: Deploy with Kamal
-        run: kamal deploy
+        run: |
+          nix develop .#github-actions --accept-flake-config --command bash -euc "
+            export KAMAL_REGISTRY_PASSWORD=\"$KAMAL_REGISTRY_PASSWORD\"
+            kamal deploy
+          "
         env:
           KAMAL_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         working-directory: ./


### PR DESCRIPTION

Resolve deployment failure where Kamal command was not found by wrapping
the kamal deploy step in the Nix development environment.

Changes:
- Wrap kamal deploy command in nix develop .#github-actions shell
- Export KAMAL_REGISTRY_PASSWORD within Nix environment context
- Ensure Kamal binary is available from unstable nixpkgs packages

Test plan:
1. Trigger deployment workflow manually via GitHub Actions
2. Verify Docker build and push steps complete successfully
3. Confirm Kamal deployment step no longer fails with "command not found"
4. Check that deployment completes end-to-end without errors

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
