### PR TITLE
Add Terraform config generation step to deployment workflow

### DIFF
--- a/.github/workflows/deploy-boltfoundry-com.yml
+++ b/.github/workflows/deploy-boltfoundry-com.yml
@@ -40,6 +40,25 @@ jobs:
           chmod 600 ~/.ssh/id_rsa
           ssh-keyscan -H $(terraform output -raw server_ip 2>/dev/null || echo "placeholder-ip") >> ~/.ssh/known_hosts || true
 
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Generate Kamal config from Terraform state
+        run: |
+          cd infra/terraform/hetzner
+          terraform init -backend-config="endpoint=${{ secrets.S3_ENDPOINT }}"
+          terraform apply -refresh-only -auto-approve \
+            -var="hcloud_token=${{ secrets.HETZNER_API_TOKEN }}" \
+            -var="cloudflare_api_token=${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+            -var="cloudflare_zone_id=${{ secrets.CLOUDFLARE_ZONE_ID }}" \
+            -var="github_username=${{ github.repository_owner }}" \
+            -var="ssh_public_key=${{ secrets.SSH_PUBLIC_KEY }}" \
+            -var="hyperdx_api_key=${{ secrets.HYPERDX_API_KEY }}" \
+            -var="domain_name=next.boltfoundry.com"
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
       - name: Deploy with Kamal
         run: |
           nix develop .#github-actions --accept-flake-config --command bash -euc "

--- a/apps/boltfoundry-com/memos/plans/simple-rlhf-mvp.md
+++ b/apps/boltfoundry-com/memos/plans/simple-rlhf-mvp.md
@@ -98,7 +98,7 @@ workflow.
 
 ### Milestone 1: Backend Demo Data
 
-**Implement BfOrganization.afterCreate() lifecycle hook**:
+**Implemented BfOrganization.afterCreate() lifecycle hook**:
 
 - Create customer support demo deck with system prompt
 - Generate 4 realistic conversation samples (billing, technical, returns,


### PR DESCRIPTION

Fix Kamal deployment failure by regenerating config/deploy.yml from Terraform
state before running kamal deploy. The Kamal config file is generated by the
infrastructure workflow but not available during deployment.

Changes:
- Add Setup Terraform step using hashicorp/setup-terraform@v3
- Add Generate Kamal config step that runs terraform apply -refresh-only
- Include all required Terraform variables for config generation
- Regenerates config/deploy.yml from existing infrastructure state

Test plan:
1. Trigger deployment workflow manually
2. Verify Terraform successfully regenerates config/deploy.yml
3. Confirm Kamal deployment proceeds without "Configuration file not found" error
4. Test end-to-end deployment completes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/1548).
* #1549
* __->__ #1548
* #1547