### PR TITLE
Fix Terraform config generation in deployment workflow

### DIFF
--- a/.github/workflows/deploy-boltfoundry-com.yml
+++ b/.github/workflows/deploy-boltfoundry-com.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           cd infra/terraform/hetzner
           terraform init -backend-config="endpoint=${{ secrets.S3_ENDPOINT }}"
-          terraform apply -refresh-only -auto-approve \
+          terraform apply -auto-approve \
             -var="hcloud_token=${{ secrets.HETZNER_API_TOKEN }}" \
             -var="cloudflare_api_token=${{ secrets.CLOUDFLARE_API_TOKEN }}" \
             -var="cloudflare_zone_id=${{ secrets.CLOUDFLARE_ZONE_ID }}" \

--- a/apps/boltfoundry-com/server.tsx
+++ b/apps/boltfoundry-com/server.tsx
@@ -1,6 +1,5 @@
 #!/usr/bin/env -S deno run --allow-env --allow-read --allow-write --allow-net --watch
 
-// Test deployment trigger - Docker fixes complete!
 import { parseArgs } from "@std/cli";
 import { getLogger } from "@bolt-foundry/logger";
 import { renderToReadableStream } from "react-dom/server";


### PR DESCRIPTION

Resolve issue where Kamal deploy.yml config file was not being created during deployment.
The previous refresh-only apply was only updating state without recreating the missing local_file resource.

Changes:
- Remove -refresh-only flag from terraform apply command in deployment workflow
- Allow terraform to recreate the missing config/deploy.yml file from state
- Remove test deployment trigger comment from server.tsx

Test plan:
1. Push changes to trigger deployment workflow
2. Verify terraform step creates config/deploy.yml file
3. Confirm Kamal deployment proceeds without Configuration file not found error
4. Test deployment health check at https://next.boltfoundry.com

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
