### PR TITLE
Fix Kamal installation permissions in deployment workflow

### DIFF
--- a/.github/workflows/deploy-boltfoundry-com.yml
+++ b/.github/workflows/deploy-boltfoundry-com.yml
@@ -60,7 +60,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Install Kamal
-        run: gem install kamal --version 2.7.0 --no-document
+        run: sudo gem install kamal --version 2.7.0 --no-document
 
       - name: Deploy with Kamal
         run: |


### PR DESCRIPTION

Add sudo to gem install command to resolve permission error when installing Kamal 2.7.0.

Changes:
- Add sudo to gem install kamal command in deployment workflow
- Resolves FilePermissionError for /var/lib/gems/3.2.0 directory

Test plan:
1. Trigger deployment workflow manually
2. Verify Kamal 2.7.0 installs successfully with sudo permissions
3. Confirm deployment proceeds to Kamal deploy step
4. Test complete end-to-end deployment with new Kamal 2.x configuration

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
