### PR TITLE
Add builder arch configuration for Kamal 2.x compatibility

### DIFF
--- a/.github/workflows/deploy-boltfoundry-com.yml
+++ b/.github/workflows/deploy-boltfoundry-com.yml
@@ -60,7 +60,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Install Kamal
-        run: gem install kamal --version 2.7.0 --no-document
+        run: sudo gem install kamal --version 2.7.0 --no-document
 
       - name: Deploy with Kamal
         run: |

--- a/infra/terraform/hetzner/deploy.yml.tpl
+++ b/infra/terraform/hetzner/deploy.yml.tpl
@@ -6,6 +6,10 @@ servers:
   web:
     - ${floating_ip}
 
+# Builder configuration for Kamal 2.x
+builder:
+  arch: amd64
+
 # Kamal 2.x proxy configuration with SSL and healthcheck
 proxy:
   ssl: true


### PR DESCRIPTION

Fix Kamal::ConfigurationError by adding required builder arch setting in deploy.yml template.
Kamal 2.x requires explicit builder architecture specification.

Changes:
- Add builder.arch: amd64 configuration to deploy.yml.tpl template
- Resolves 'Builder arch not set' error in Kamal 2.x deployment

Test plan:
1. Trigger deployment workflow manually
2. Verify Kamal configuration validation passes with builder arch set
3. Confirm deployment proceeds past configuration validation step
4. Test complete deployment with all Kamal 2.x configuration requirements

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
