### PR TITLE
Fix Kamal 2.x secrets configuration in deployment workflow

### DIFF
--- a/.github/workflows/deploy-boltfoundry-com.yml
+++ b/.github/workflows/deploy-boltfoundry-com.yml
@@ -64,7 +64,12 @@ jobs:
 
       - name: Deploy with Kamal
         run: |
-          export KAMAL_REGISTRY_PASSWORD="${KAMAL_REGISTRY_PASSWORD}"
+          # Create .kamal directory and secrets file for Kamal 2.x
+          mkdir -p .kamal
+          echo "GITHUB_TOKEN=${KAMAL_REGISTRY_PASSWORD}" > .kamal/secrets
+          chmod 600 .kamal/secrets
+
+          # Deploy with Kamal 2.x
           kamal deploy
         env:
           KAMAL_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION

Replace environment variable approach with proper secrets file format required by Kamal 2.x.
This resolves the 'Secret GITHUB_TOKEN not found' error that was preventing deployments.

Changes:
- Create .kamal/secrets file with GITHUB_TOKEN for registry authentication
- Add proper directory structure setup (.kamal directory)
- Set secure file permissions (600) for secrets file
- Update deployment step to use Kamal 2.x secrets format

Test plan:
1. Trigger deployment workflow manually
2. Verify Kamal secrets configuration validates successfully
3. Confirm deployment proceeds past registry authentication step
4. Test complete end-to-end deployment with new secrets format

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
