### PR TITLE
Add waitlist form to marketing site homepage

### DIFF
--- a/apps/boltfoundry-com/__generated__/__isograph/Mutation/JoinWaitlist/entrypoint.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Mutation/JoinWaitlist/entrypoint.ts
@@ -1,0 +1,28 @@
+import type {IsographEntrypoint, NormalizationAst, RefetchQueryNormalizationArtifactWrapper} from '@isograph/react';
+import {Mutation__JoinWaitlist__param} from './param_type.ts';
+import {Mutation__JoinWaitlist__output_type} from './output_type.ts';
+import readerResolver from './resolver_reader.ts';
+import queryText from './query_text.ts';
+import normalizationAst from './normalization_ast.ts';
+const nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[] = [];
+
+const artifact: IsographEntrypoint<
+  Mutation__JoinWaitlist__param,
+  Mutation__JoinWaitlist__output_type,
+  NormalizationAst
+> = {
+  kind: "Entrypoint",
+  networkRequestInfo: {
+    kind: "NetworkRequestInfo",
+    queryText,
+    normalizationAst,
+  },
+  concreteType: "Mutation",
+  readerWithRefetchQueries: {
+    kind: "ReaderWithRefetchQueries",
+    nestedRefetchQueries,
+    readerArtifact: readerResolver,
+  },
+};
+
+export default artifact;

--- a/apps/boltfoundry-com/__generated__/__isograph/Mutation/JoinWaitlist/normalization_ast.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Mutation/JoinWaitlist/normalization_ast.ts
@@ -1,0 +1,40 @@
+import type {NormalizationAst} from '@isograph/react';
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "joinWaitlist",
+      arguments: [
+        [
+          "name",
+          { kind: "Variable", name: "name" },
+        ],
+
+        [
+          "email",
+          { kind: "Variable", name: "email" },
+        ],
+
+        [
+          "company",
+          { kind: "Variable", name: "company" },
+        ],
+      ],
+      concreteType: "JoinWaitlistPayload",
+      selections: [
+        {
+          kind: "Scalar",
+          fieldName: "message",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "success",
+          arguments: null,
+        },
+      ],
+    },
+  ],
+};
+export default normalizationAst;

--- a/apps/boltfoundry-com/__generated__/__isograph/Mutation/JoinWaitlist/output_type.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Mutation/JoinWaitlist/output_type.ts
@@ -1,0 +1,3 @@
+import type React from 'react';
+import { JoinWaitlistMutation as resolver } from '../../../../mutations/JoinWaitlist.tsx';
+export type Mutation__JoinWaitlist__output_type = ReturnType<typeof resolver>;

--- a/apps/boltfoundry-com/__generated__/__isograph/Mutation/JoinWaitlist/param_type.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Mutation/JoinWaitlist/param_type.ts
@@ -1,0 +1,11 @@
+import type { Mutation__JoinWaitlist__parameters } from './parameters_type.ts';
+
+export type Mutation__JoinWaitlist__param = {
+  readonly data: {
+    readonly joinWaitlist: ({
+      readonly success: boolean,
+      readonly message: (string | null),
+    } | null),
+  },
+  readonly parameters: Mutation__JoinWaitlist__parameters,
+};

--- a/apps/boltfoundry-com/__generated__/__isograph/Mutation/JoinWaitlist/parameters_type.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Mutation/JoinWaitlist/parameters_type.ts
@@ -1,0 +1,5 @@
+export type Mutation__JoinWaitlist__parameters = {
+  readonly name: string,
+  readonly email: string,
+  readonly company: string,
+};

--- a/apps/boltfoundry-com/__generated__/__isograph/Mutation/JoinWaitlist/query_text.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Mutation/JoinWaitlist/query_text.ts
@@ -1,0 +1,6 @@
+export default 'mutation JoinWaitlist ($name: String!, $email: String!, $company: String!) {\
+  joinWaitlist____name___v_name____email___v_email____company___v_company: joinWaitlist(name: $name, email: $email, company: $company) {\
+    message,\
+    success,\
+  },\
+}';

--- a/apps/boltfoundry-com/__generated__/__isograph/Mutation/JoinWaitlist/resolver_reader.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Mutation/JoinWaitlist/resolver_reader.ts
@@ -1,0 +1,59 @@
+import type { EagerReaderArtifact, ReaderAst } from '@isograph/react';
+import { Mutation__JoinWaitlist__param } from './param_type.ts';
+import { Mutation__JoinWaitlist__output_type } from './output_type.ts';
+import { JoinWaitlistMutation as resolver } from '../../../../mutations/JoinWaitlist.tsx';
+
+const readerAst: ReaderAst<Mutation__JoinWaitlist__param> = [
+  {
+    kind: "Linked",
+    fieldName: "joinWaitlist",
+    alias: null,
+    arguments: [
+      [
+        "name",
+        { kind: "Variable", name: "name" },
+      ],
+
+      [
+        "email",
+        { kind: "Variable", name: "email" },
+      ],
+
+      [
+        "company",
+        { kind: "Variable", name: "company" },
+      ],
+    ],
+    condition: null,
+    isUpdatable: false,
+    selections: [
+      {
+        kind: "Scalar",
+        fieldName: "success",
+        alias: null,
+        arguments: null,
+        isUpdatable: false,
+      },
+      {
+        kind: "Scalar",
+        fieldName: "message",
+        alias: null,
+        arguments: null,
+        isUpdatable: false,
+      },
+    ],
+  },
+];
+
+const artifact: EagerReaderArtifact<
+  Mutation__JoinWaitlist__param,
+  Mutation__JoinWaitlist__output_type
+> = {
+  kind: "EagerReaderArtifact",
+  fieldName: "Mutation.JoinWaitlist",
+  resolver,
+  readerAst,
+  hasUpdatable: false,
+};
+
+export default artifact;

--- a/apps/boltfoundry-com/__generated__/__isograph/iso.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/iso.ts
@@ -1,11 +1,13 @@
 import type { IsographEntrypoint } from '@isograph/react';
 import { type CurrentViewer__LoginPage__param } from './CurrentViewer/LoginPage/param_type.ts';
 import { type CurrentViewer__RlhfHome__param } from './CurrentViewer/RlhfHome/param_type.ts';
+import { type Mutation__JoinWaitlist__param } from './Mutation/JoinWaitlist/param_type.ts';
 import { type Query__EntrypointHome__param } from './Query/EntrypointHome/param_type.ts';
 import { type Query__EntrypointLogin__param } from './Query/EntrypointLogin/param_type.ts';
 import { type Query__EntrypointRlhf__param } from './Query/EntrypointRlhf/param_type.ts';
 import { type Query__Home__param } from './Query/Home/param_type.ts';
 import { type Query__RlhfInterface__param } from './Query/RlhfInterface/param_type.ts';
+import entrypoint_Mutation__JoinWaitlist from '../__isograph/Mutation/JoinWaitlist/entrypoint.ts';
 import entrypoint_Query__EntrypointHome from '../__isograph/Query/EntrypointHome/entrypoint.ts';
 import entrypoint_Query__EntrypointLogin from '../__isograph/Query/EntrypointLogin/entrypoint.ts';
 import entrypoint_Query__EntrypointRlhf from '../__isograph/Query/EntrypointRlhf/entrypoint.ts';
@@ -67,6 +69,10 @@ export function iso<T>(
 ): IdentityWithParamComponent<CurrentViewer__RlhfHome__param>;
 
 export function iso<T>(
+  param: T & MatchesWhitespaceAndString<'field Mutation.JoinWaitlist', T>
+): IdentityWithParam<Mutation__JoinWaitlist__param>;
+
+export function iso<T>(
   param: T & MatchesWhitespaceAndString<'field Query.EntrypointHome', T>
 ): IdentityWithParam<Query__EntrypointHome__param>;
 
@@ -87,6 +93,10 @@ export function iso<T>(
 ): IdentityWithParamComponent<Query__RlhfInterface__param>;
 
 export function iso<T>(
+  param: T & MatchesWhitespaceAndString<'entrypoint Mutation.JoinWaitlist', T>
+): typeof entrypoint_Mutation__JoinWaitlist;
+
+export function iso<T>(
   param: T & MatchesWhitespaceAndString<'entrypoint Query.EntrypointHome', T>
 ): typeof entrypoint_Query__EntrypointHome;
 
@@ -104,6 +114,8 @@ export function iso(isographLiteralText: string):
   | IsographEntrypoint<any, any, any>
 {
   switch (isographLiteralText) {
+    case 'entrypoint Mutation.JoinWaitlist':
+      return entrypoint_Mutation__JoinWaitlist;
     case 'entrypoint Query.EntrypointHome':
       return entrypoint_Query__EntrypointHome;
     case 'entrypoint Query.EntrypointLogin':

--- a/apps/boltfoundry-com/__generated__/builtRoutes.ts
+++ b/apps/boltfoundry-com/__generated__/builtRoutes.ts
@@ -8,6 +8,7 @@ export type RouteEntrypoint = {
   headers?: Record<string, string>;
 };
 
+iso(`entrypoint Mutation.JoinWaitlist`)
 iso(`entrypoint Query.EntrypointHome`)
 iso(`entrypoint Query.EntrypointLogin`)
 iso(`entrypoint Query.EntrypointRlhf`)
@@ -15,7 +16,9 @@ iso(`entrypoint Query.EntrypointRlhf`)
 import entrypointHome from "@iso-bfc/Query/EntrypointHome/entrypoint.ts"
 import entrypointLogin from "@iso-bfc/Query/EntrypointLogin/entrypoint.ts"
 import entrypointRlhf from "@iso-bfc/Query/EntrypointRlhf/entrypoint.ts"
+import joinWaitlist from "@iso-bfc/Mutation/JoinWaitlist/entrypoint.ts"
 
 export {entrypointHome};
 export {entrypointLogin};
 export {entrypointRlhf};
+export {joinWaitlist};

--- a/apps/boltfoundry-com/components/Home.tsx
+++ b/apps/boltfoundry-com/components/Home.tsx
@@ -3,6 +3,7 @@ import { BfDsButton } from "@bfmono/apps/bfDs/index.ts";
 import { BfDsCopyButton } from "@bfmono/apps/bfDs/index.ts";
 import { useRouter } from "../contexts/RouterContext.tsx";
 import { Nav } from "./Nav.tsx";
+import { WaitlistSection } from "./WaitlistSection.tsx";
 
 export const Home = iso(`
   field Query.Home @component {
@@ -66,6 +67,9 @@ export const Home = iso(`
           </div>
         </div>
       </main>
+
+      {/* Waitlist Section */}
+      <WaitlistSection />
 
       {/* Footer */}
       <div className="landing-footer">

--- a/apps/boltfoundry-com/components/WaitlistSection.css
+++ b/apps/boltfoundry-com/components/WaitlistSection.css
@@ -1,0 +1,62 @@
+/* Waitlist Section Specific Styles */
+
+.waitlist-form-header {
+  margin-bottom: 2rem;
+  text-align: center;
+}
+
+.waitlist-form-header h2 {
+  font-size: 2.5rem;
+  font-family: var(--marketingFontFamily);
+  font-weight: 400;
+  line-height: 1.2;
+  margin-bottom: 1rem;
+  color: var(--bfds-text);
+}
+
+.waitlist-form-header p {
+  font-size: 1.1rem;
+  line-height: 1.5;
+  color: var(--bfds-text-06);
+  max-width: 500px;
+  margin: 0 auto;
+}
+
+.waitlist-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.waitlist-form-loading {
+  justify-content: center;
+  padding: 1rem;
+  color: var(--bfds-text-06);
+  font-size: 0.9rem;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .waitlist-form-header h2 {
+    font-size: 2rem;
+  }
+
+  .waitlist-form-header p {
+    font-size: 1rem;
+  }
+
+  .substack-form {
+    max-width: 100%;
+    padding: 0 1rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .waitlist-form-header h2 {
+    font-size: 1.8rem;
+  }
+
+  .waitlist-form {
+    gap: 1rem;
+  }
+}

--- a/apps/boltfoundry-com/components/WaitlistSection.tsx
+++ b/apps/boltfoundry-com/components/WaitlistSection.tsx
@@ -1,0 +1,153 @@
+import * as React from "react";
+import { BfDsForm } from "@bfmono/apps/bfDs/components/BfDsForm.tsx";
+import { BfDsInput } from "@bfmono/apps/bfDs/components/BfDsInput.tsx";
+import { BfDsFormSubmitButton } from "@bfmono/apps/bfDs/components/BfDsFormSubmitButton.tsx";
+import { BfDsSpinner } from "@bfmono/apps/bfDs/components/BfDsSpinner.tsx";
+import JoinWaitlistMutation from "../__generated__/__isograph/Mutation/JoinWaitlist/entrypoint.ts";
+import { useMutation } from "../hooks/isographPrototypes/useMutation.tsx";
+
+const { useState, useCallback, useEffect } = React;
+
+/**
+ * Form data interface for the waitlist signup
+ */
+export interface WaitlistFormData {
+  name: string;
+  email: string;
+  company: string;
+}
+
+/**
+ * Props for the WaitlistSection component
+ */
+export interface WaitlistSectionProps {
+  /** Optional additional CSS classes */
+  className?: string;
+  /** Test ID for testing purposes */
+  testId?: string;
+}
+
+/**
+ * State for handling form submission and responses
+ */
+interface SubmissionState {
+  isLoading: boolean;
+}
+
+/**
+ * Waitlist section component with form for collecting user information
+ * Includes proper form validation, loading states, and success/error handling
+ */
+export function WaitlistSection({ className, testId }: WaitlistSectionProps) {
+  const [submissionState, setSubmissionState] = useState<SubmissionState>({
+    isLoading: false,
+  });
+
+  const joinWaitlistMutation = useMutation(JoinWaitlistMutation);
+
+  const initialFormData: WaitlistFormData = {
+    name: "",
+    email: "",
+    company: "",
+  };
+
+  const handleFormSubmit = useCallback((formData: WaitlistFormData) => {
+    // Set loading state
+    setSubmissionState({ isLoading: true });
+
+    // Commit the mutation with form data
+    // The response will be handled through joinWaitlistMutation.responseElement
+    joinWaitlistMutation.commit({
+      name: formData.name,
+      email: formData.email,
+      company: formData.company,
+    });
+  }, [joinWaitlistMutation]);
+
+  // Reset loading state when response is available
+  useEffect(() => {
+    if (joinWaitlistMutation.responseElement) {
+      setSubmissionState({ isLoading: false });
+    }
+  }, [joinWaitlistMutation.responseElement]);
+
+  const sectionClasses = [
+    "substack-section",
+    className,
+  ].filter(Boolean).join(" ");
+
+  return (
+    <section className={sectionClasses} data-testid={testId}>
+      <div className="landing-content">
+        <div className="substack-form">
+          <div className="waitlist-form-container">
+            <div className="waitlist-form-header">
+              <h2>Join the Waitlist</h2>
+              <p>
+                Be the first to know when new features and improvements are
+                ready. Get early access to enhanced AI tooling and structured
+                prompt workflows.
+              </p>
+            </div>
+
+            {/* Loading Spinner */}
+            {submissionState.isLoading && (
+              <div className="waitlist-form-loading flexRow alignItemsCenter gapSmall">
+                <BfDsSpinner size={24} />
+                <span>Joining waitlist...</span>
+              </div>
+            )}
+
+            {/* Form */}
+            <BfDsForm
+              initialData={initialFormData}
+              onSubmit={handleFormSubmit}
+              className="waitlist-form"
+            >
+              <BfDsInput
+                name="name"
+                label="Full Name"
+                placeholder="Enter your full name"
+                required
+                type="text"
+                autoComplete="name"
+                disabled={submissionState.isLoading}
+              />
+
+              <BfDsInput
+                name="email"
+                label="Email Address"
+                placeholder="Enter your email address"
+                required
+                type="email"
+                autoComplete="email"
+                disabled={submissionState.isLoading}
+              />
+
+              <BfDsInput
+                name="company"
+                label="Company"
+                placeholder="Enter your company name"
+                required
+                type="text"
+                autoComplete="organization"
+                disabled={submissionState.isLoading}
+              />
+
+              <BfDsFormSubmitButton
+                text="Join Waitlist"
+                variant="primary"
+                size="medium"
+                disabled={submissionState.isLoading}
+                spinner={submissionState.isLoading}
+              />
+            </BfDsForm>
+
+            {/* Mutation Response */}
+            {joinWaitlistMutation.responseElement}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/boltfoundry-com/hooks/isographPrototypes/useMutation.tsx
+++ b/apps/boltfoundry-com/hooks/isographPrototypes/useMutation.tsx
@@ -1,0 +1,29 @@
+import {
+  FragmentReader,
+  type IsographEntrypoint,
+  type NormalizationAst,
+  useImperativeReference,
+} from "@isograph/react";
+
+export function useMutation<
+  // deno-lint-ignore no-explicit-any
+  T extends IsographEntrypoint<any, any, NormalizationAst>,
+>(
+  mutation: T,
+) {
+  const {
+    fragmentReference: mutationRef,
+    loadFragmentReference: commit,
+  } = useImperativeReference(mutation);
+  const returnable = {
+    responseElement: null as React.ReactNode,
+    commit,
+  };
+  if (mutationRef) {
+    returnable.responseElement = (
+      <FragmentReader fragmentReference={mutationRef} additionalProps={{}} />
+    );
+  }
+
+  return returnable;
+}

--- a/apps/boltfoundry-com/mutations/JoinWaitlist.tsx
+++ b/apps/boltfoundry-com/mutations/JoinWaitlist.tsx
@@ -1,0 +1,15 @@
+import { iso } from "@bfmono/apps/boltfoundry-com/__generated__/__isograph/iso.ts";
+import { getLogger } from "@bfmono/packages/logger/logger.ts";
+const logger = getLogger(import.meta);
+
+export const JoinWaitlistMutation = iso(`
+  field Mutation.JoinWaitlist($name: String!, $email: String!, $company: String!) {
+    joinWaitlist(name: $name, email: $email, company: $company){
+      success
+      message
+    }
+  }
+`)(function JoinWaitlist({ data }) {
+  logger.debug("joinWaitlistMutation", data);
+  return data;
+});

--- a/apps/boltfoundry-com/styles/index.ts
+++ b/apps/boltfoundry-com/styles/index.ts
@@ -4,5 +4,6 @@
 import "../src/index.css";
 import "@bfmono/static/bfDsStyle.css";
 import "@bfmono/static/landingStyle.css";
+import "../components/WaitlistSection.css";
 
 // Add any future CSS imports here


### PR DESCRIPTION

Implement complete waitlist signup functionality for the boltfoundry-com marketing site.
This enables potential users to join the waitlist directly from the homepage, improving
lead capture and user engagement.

Changes:
- Add JoinWaitlist mutation infrastructure with Isograph integration
- Create WaitlistSection component with BfDs form components
- Add useMutation hook for GraphQL mutation handling
- Integrate waitlist section into Home.tsx between hero and footer
- Add CSS styling with responsive design patterns
- Generate mutation artifacts and update built routes

Test plan:
1. Run dev server: `bft dev boltfoundry-com`
2. Navigate to homepage and verify waitlist form renders
3. Fill out form with test data and submit
4. Verify form shows loading state during submission
5. Run E2E tests: `bft e2e` to verify integration

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
