### PR TITLE
Centralize environment setup and fix DENO_DIR configuration

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,3 @@
 dotenv_if_exists .env.local
 use flake
-export DENO_DIR=$PWD/.deno
 export PATH="$PWD/bin:$PWD/areas/bolt-foundry-monorepo/infra/bin:$PATH"

--- a/deno.lock
+++ b/deno.lock
@@ -74,6 +74,7 @@
     "npm:@hexagon/base64@^1.1.27": "1.1.28",
     "npm:@isograph/babel-plugin@0.3.1": "0.3.1",
     "npm:@isograph/babel-plugin@~0.3.1": "0.3.1",
+    "npm:@isograph/compiler@*": "0.3.1",
     "npm:@isograph/compiler@0.3.1": "0.3.1",
     "npm:@isograph/react@0.3.1": "0.3.1_react@19.1.0",
     "npm:@isograph/react@~0.3.1": "0.3.1_react@19.1.0",

--- a/flake.nix
+++ b/flake.nix
@@ -74,16 +74,8 @@
           base:${toString (map (p: p.name or "<pkg>") baseDeps)}  \
           extras:${toString (map (p: p.name or "<pkg>") extras)}"
 
-          # --- your custom logic ---
-          export PATH="$PWD/infra/bin:$PATH"   # prepend ./infra/bin
-          if ! command -v deno >/dev/null; then
-            echo "Installing deno user tools…"
-            # runs once per machine-wide cache; cheap if already installed
-            deno install --allow-read --allow-write --allow-env -q -f https://deno.land/x/denon/denon.ts
-          fi
-
-          # Set DENO_DIR to keep cache out of repo
-          export DENO_DIR="${builtins.getEnv "HOME"}/.cache/deno"
+          # Source shared environment setup
+          source ./infra/env-setup.sh
 
           # Load .env.local if it exists
           if [ -f ".env.local" ]; then

--- a/infra/apps/codebot/Dockerfile
+++ b/infra/apps/codebot/Dockerfile
@@ -33,9 +33,9 @@ if [ "\$CODEBOT_INITIALIZED" != "1" ]; then
   export CODEBOT_INITIALIZED=1
   
   # .claude directory is mounted directly from host
-  # Copy .claude.json from workspace if it exists
-  if [ -f "/workspace/.claude.json" ]; then
-    cp /workspace/.claude.json /home/codebot/.claude.json
+  # Copy .claude.json from workspace/tmp if it exists
+  if [ -f "/workspace/tmp/.claude.json" ]; then
+    cp /workspace/tmp/.claude.json /home/codebot/.claude.json
   fi
   
   # Configure Sapling identity for codebot
@@ -57,6 +57,11 @@ fi
 
 # Add Nix to PATH
 export PATH="/nix/var/nix/profiles/default/bin:\$PATH"
+
+# Source shared environment setup
+if [ -f "/workspace/infra/env-setup.sh" ]; then
+  source /workspace/infra/env-setup.sh
+fi
 EOF
 
 ENTRYPOINT ["/bin/bash", "-l"]

--- a/infra/bft/tasks/codebot.bft.ts
+++ b/infra/bft/tasks/codebot.bft.ts
@@ -346,11 +346,11 @@ FIRST TIME SETUP:
           args: [
             "--reflink=auto",
             claudeJsonPath,
-            `${workspacePath}/.claude.json`,
+            `${workspacePath}/tmp/.claude.json`,
           ],
         });
         await copyClaudeJson.output();
-        ui.output("📋 CoW copied .claude.json to workspace");
+        ui.output("📋 CoW copied .claude.json to workspace/tmp");
       } catch {
         // File doesn't exist, skip
       }

--- a/infra/env-setup.sh
+++ b/infra/env-setup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Shared environment setup for development shells and containers
+# Source this file to set up the Bolt Foundry environment
+
+# Determine the root directory
+# In container: /workspace
+# In dev shell: current directory
+if [ -d "/workspace" ] && [ -d "/workspace/infra/bin" ]; then
+  export BF_ROOT="/workspace"
+else
+  export BF_ROOT="$PWD"
+fi
+
+# Add infra/bin to PATH
+export PATH="$BF_ROOT/infra/bin:$PATH"
+
+# Set DENO_DIR to keep cache out of repo
+export DENO_DIR="${HOME}/.cache/deno"
+
+# Additional environment-specific setup can be added after sourcing this file


### PR DESCRIPTION
Extract common environment configuration to a shared setup script to ensure consistent
behavior across development shells and containers. This fixes the issue where .deno
directories were being created in the project root instead of the user's cache directory.

Changes:
- Create infra/env-setup.sh with centralized environment configuration
- Update flake.nix to source env-setup.sh instead of duplicating setup logic
- Remove hardcoded DENO_DIR from .envrc that was overriding proper configuration
- Update codebot Dockerfile to source shared environment setup
- Move codebot's .claude.json copy to workspace/tmp directory
- Add @isograph/compiler to deno.lock dependencies

Test plan:
1. Exit and re-enter nix shell: exit then nix develop
2. Run: echo $DENO_DIR and verify it shows ~/.cache/deno
3. Run any deno command and verify no .deno folder appears in project root
4. Test codebot container: bft codebot:start and verify environment is set correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/1616)
<!-- GitContextEnd -->