### PR TITLE
Add auto-scaling memory and CPU configuration to codebot containers

### DIFF
--- a/infra/bft/tasks/codebot.bft.ts
+++ b/infra/bft/tasks/codebot.bft.ts
@@ -16,6 +16,8 @@ interface CodebotArgs {
   cleanup?: boolean;
   "cleanup-containers"?: boolean;
   workspace?: string;
+  memory?: string;
+  cpus?: string;
 }
 
 async function generateRandomName(): Promise<string> {
@@ -57,9 +59,59 @@ async function codebot(args: Array<string>): Promise<number> {
       "cleanup",
       "cleanup-containers",
     ],
-    string: ["exec", "workspace"],
+    string: ["exec", "workspace", "memory", "cpus"],
     alias: { h: "help" },
   }) as CodebotArgs;
+
+  // Auto-calculate maximum resources if not specified
+  let autoMemory = "1g";
+  let autoCpus = "4";
+
+  if (!parsed.memory || !parsed.cpus) {
+    try {
+      // Get total system memory in bytes
+      const memCmd = new Deno.Command("sysctl", {
+        args: ["-n", "hw.memsize"],
+        stdout: "piped",
+      });
+      const memResult = await memCmd.output();
+
+      if (memResult.success) {
+        const totalMemBytes = parseInt(
+          new TextDecoder().decode(memResult.stdout).trim(),
+        );
+        // Use 80% of total memory, leaving 20% for host system
+        const containerMemGb = Math.floor(
+          (totalMemBytes / 1024 / 1024 / 1024) * 0.8,
+        );
+        autoMemory = `${containerMemGb}g`;
+      }
+
+      // Get total CPU cores
+      const cpuCmd = new Deno.Command("sysctl", {
+        args: ["-n", "hw.ncpu"],
+        stdout: "piped",
+      });
+      const cpuResult = await cpuCmd.output();
+
+      if (cpuResult.success) {
+        const totalCpus = parseInt(
+          new TextDecoder().decode(cpuResult.stdout).trim(),
+        );
+        // Use all available CPUs (container framework handles scheduling)
+        autoCpus = totalCpus.toString();
+      }
+
+      logger.info(
+        `Auto-detected system resources: ${autoMemory} RAM, ${autoCpus} CPUs`,
+      );
+    } catch (error) {
+      logger.warn(
+        "Failed to auto-detect system resources, using defaults",
+        error,
+      );
+    }
+  }
 
   if (parsed.help) {
     ui.output(`
@@ -76,6 +128,8 @@ OPTIONS:
   --workspace NAME     Reuse existing workspace or create new one with specific name
   --cleanup            Remove workspace after completion (default: keep)
   --force-rebuild      Force rebuild container image before starting
+  --memory SIZE        Container memory limit (e.g., 4g, 8g, 16g) (default: auto-detect 80% of system RAM)
+  --cpus COUNT         Number of CPUs (e.g., 2, 4, 8) (default: auto-detect all available CPUs)
   --help               Show this help message
 
 EXAMPLES:
@@ -84,6 +138,7 @@ EXAMPLES:
   bft codebot --cleanup                 # Start and cleanup workspace when done
   bft codebot --shell                   # Open container shell for debugging
   bft codebot --exec "ls -la"           # Run command and exit
+  bft codebot --memory 8g --cpus 8      # Run with 8GB RAM and 8 CPUs
 
 FIRST TIME SETUP:
   On first run, you'll need to authenticate inside the container:
@@ -571,6 +626,10 @@ FIRST TIME SETUP:
       "-it",
       "--name",
       workspaceId,
+      "--memory",
+      parsed.memory || autoMemory,
+      "--cpus",
+      parsed.cpus || autoCpus,
       "--volume",
       `${claudeDir}:/home/codebot/.claude`,
       "--volume",
@@ -605,6 +664,10 @@ FIRST TIME SETUP:
       "--rm",
       "--name",
       workspaceId,
+      "--memory",
+      parsed.memory || autoMemory,
+      "--cpus",
+      parsed.cpus || autoCpus,
       "--volume",
       `${claudeDir}:/home/codebot/.claude`,
       "--volume",
@@ -640,6 +703,11 @@ FIRST TIME SETUP:
   ui.output(
     `📡 Workspace will be available at: http://${workspaceId}.codebot.local:8000`,
   );
+  ui.output(
+    `💾 Memory: ${parsed.memory || autoMemory} | CPUs: ${
+      parsed.cpus || autoCpus
+    }`,
+  );
 
   // Check if this is first run (no credentials)
   try {
@@ -656,6 +724,10 @@ FIRST TIME SETUP:
     "-it",
     "--name",
     workspaceId,
+    "--memory",
+    parsed.memory || "1g",
+    "--cpus",
+    parsed.cpus || "4",
     "--volume",
     `${claudeDir}:/home/codebot/.claude`,
     "--volume",


### PR DESCRIPTION
Enable codebot containers to automatically use maximum available system resources to prevent OOM errors. By default, containers now use 80% of system RAM and all available CPU cores for optimal performance.

Changes:
- Add --memory and --cpus flags to codebot command
- Implement auto-detection of system resources using sysctl
- Default to 80% of total RAM to leave headroom for host system
- Use all available CPUs (container framework handles scheduling efficiently)
- Update all container run commands to use configured resources
- Display allocated resources when starting containers

Test plan:
1. Run 'bft codebot --help' to see new options
2. Run 'bft codebot' and verify auto-detected resources are displayed
3. Run 'bft codebot --memory 16g --cpus 8' to test manual override
4. Monitor container performance with increased resources

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/1625)
<!-- GitContextEnd -->