### PR TITLE
Fix import path and test configuration issues

### DIFF
--- a/packages/env/__tests__/env-system.integration.test.ts
+++ b/packages/env/__tests__/env-system.integration.test.ts
@@ -147,6 +147,8 @@ console.log(JSON.stringify({
       "run",
       "--allow-read",
       "--allow-env",
+      "--import-map",
+      join(Deno.cwd(), "deno.jsonc"),
       "test-env-wrapper.ts",
     ]);
     assertEquals(result.code, 0, `Script failed: ${result.stderr}`);

--- a/packages/get-configuration-var/get-configuration-var.ts
+++ b/packages/get-configuration-var/get-configuration-var.ts
@@ -17,7 +17,7 @@
 import {
   PRIVATE_CONFIG_KEYS,
   PUBLIC_CONFIG_KEYS,
-} from "../../apps/boltFoundry/__generated__/configKeys.ts";
+} from "@bfmono/apps/boltFoundry/__generated__/configKeys.ts";
 
 /* ─── environment helpers ─────────────────────────────────────────────────── */
 const isDeno = typeof Deno !== "undefined" && !!Deno?.version?.deno;


### PR DESCRIPTION

Resolve failing tests found during code quality checks. The main issue was an incorrect import path that included an absolute filesystem path.

Changes:
- Fix import path in get-configuration-var.ts to use proper @bfmono alias
- Add import-map flag to env system integration test for module resolution

Test plan:
1. Run bft test to verify all tests pass
2. Run bft check to ensure no type errors

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/1631).
* #1633
* #1632
* __->__ #1631