### PR TITLE
Fix post-update command and improve development environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Bolt Foundry - Customer Success Platform for AI
 
 **Make AI systems continuously improve through customer feedback, creating
-reliable, customer-centric AI that gets better every day.**
+reliable, customer-centric AI that gets better every day using RLHF workflows.**
 
 Most AI systems are built and deployed without meaningful connection to customer
 feedback. Companies launch AI features, get complaints, and struggle to

--- a/apps/aibff/commands/__tests__/gui-graphql.test.ts
+++ b/apps/aibff/commands/__tests__/gui-graphql.test.ts
@@ -1,165 +1,250 @@
 #!/usr/bin/env -S deno test -A
 
+import { getConfigurationVariable } from "@bolt-foundry/get-configuration-var";
 import { assertEquals, assertExists } from "@std/assert";
 import { delay } from "@std/async";
 
-Deno.test("gui command serves GraphQL endpoint with hello query", async () => {
-  // Helper to start GUI command in subprocess
-  function startGuiCommand(
-    args: Array<string>,
-  ): Deno.ChildProcess {
-    const command = new Deno.Command("aibff", {
-      args: ["gui", ...args],
-      stdout: "piped",
-      stderr: "piped",
-    });
+Deno.test(
+  "gui command serves GraphQL endpoint with hello query",
+  {},
+  async () => {
+    // Helper to start GUI command in subprocess
+    function startGuiCommand(
+      args: Array<string>,
+    ): Deno.ChildProcess {
+      // Try to find aibff in PATH or use relative path
+      const aibffPath = getConfigurationVariable("GITHUB_WORKSPACE")
+        ? `${getConfigurationVariable("GITHUB_WORKSPACE")}/infra/bin/aibff`
+        : new URL(import.meta.resolve("../../../../infra/bin/aibff")).pathname;
 
-    return command.spawn();
-  }
+      const command = new Deno.Command(aibffPath, {
+        args: [
+          "gui",
+          ...args,
+        ],
+        stdout: "piped",
+        stderr: "piped",
+      });
 
-  // Helper to wait for server to be ready
-  async function waitForServer(
-    url: string,
-    maxRetries = 30,
-    delayMs = 100,
-  ): Promise<void> {
-    for (let i = 0; i < maxRetries; i++) {
-      try {
-        const response = await fetch(url);
-        await response.body?.cancel();
-        if (response.ok) return;
-      } catch {
-        // Server not ready yet
-      }
-      await delay(delayMs);
+      return command.spawn();
     }
-    throw new Error(
-      `Server did not start at ${url} after ${maxRetries} retries`,
-    );
-  }
 
-  // Start server in test mode on port 3003
-  const process = startGuiCommand(["--port", "3003", "--no-open"]);
+    // Helper to wait for server to be ready
+    async function waitForServer(
+      url: string,
+      maxRetries = 30,
+      delayMs = 100,
+      process?: Deno.ChildProcess,
+    ): Promise<void> {
+      // Collect stderr output for debugging
+      let stderrOutput = "";
+      if (process?.stderr) {
+        const reader = process.stderr.getReader();
+        const decoder = new TextDecoder();
+        (async () => {
+          try {
+            while (true) {
+              const { done, value } = await reader.read();
+              if (done) break;
+              stderrOutput += decoder.decode(value);
+            }
+          } catch {
+            // Reader closed
+          }
+        })();
+      }
 
-  try {
-    // Wait for server to be ready
-    await waitForServer("http://localhost:3003/health");
+      for (let i = 0; i < maxRetries; i++) {
+        try {
+          const response = await fetch(url);
+          await response.body?.cancel();
+          if (response.ok) return;
+        } catch {
+          // Server not ready yet
+        }
+        await delay(delayMs);
+      }
+      throw new Error(
+        `Server did not start at ${url} after ${maxRetries} retries. Stderr: ${stderrOutput}`,
+      );
+    }
 
-    // Test GraphQL endpoint exists
-    const response = await fetch("http://localhost:3003/graphql", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        query: `
+    // Start server in test mode on port 3003
+    const process = startGuiCommand(["--port", "3003", "--no-open"]);
+
+    try {
+      // Wait for server to be ready
+      await waitForServer("http://localhost:3003/health", 30, 100, process);
+
+      // Test GraphQL endpoint exists
+      const response = await fetch("http://localhost:3003/graphql", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          query: `
           query {
             hello
           }
         `,
-      }),
-    });
+        }),
+      });
 
-    assertEquals(response.status, 200);
-    const contentType = response.headers.get("content-type");
-    assertExists(contentType);
-    assertEquals(contentType?.startsWith("application/json"), true);
+      assertEquals(response.status, 200);
+      const contentType = response.headers.get("content-type");
+      assertExists(contentType);
+      assertEquals(contentType?.startsWith("application/json"), true);
 
-    const result = await response.json();
-    assertEquals(result.data.hello, "Hello from aibff GUI!");
-  } finally {
-    // Cleanup - ensure process is killed and streams are closed
-    try {
-      process.kill();
-
-      // Close the streams to prevent leaks
-      if (process.stdout) {
-        await process.stdout.cancel();
-      }
-      if (process.stderr) {
-        await process.stderr.cancel();
-      }
-
-      await process.status;
-    } catch {
-      // Process may have already exited
-    }
-  }
-});
-
-Deno.test("gui command --dev mode serves GraphiQL interface", async () => {
-  // Helper to start GUI command in subprocess
-  function startGuiDevCommand(
-    args: Array<string>,
-  ): Deno.ChildProcess {
-    const command = new Deno.Command("aibff", {
-      args: ["gui", "--dev", ...args],
-      stdout: "piped",
-      stderr: "piped",
-    });
-
-    return command.spawn();
-  }
-
-  // Helper to wait for dev server to be ready
-  async function waitForDevServer(
-    url: string,
-    maxRetries = 50,
-    delayMs = 100,
-  ): Promise<void> {
-    for (let i = 0; i < maxRetries; i++) {
+      const result = await response.json();
+      assertEquals(result.data.hello, "Hello from aibff GUI!");
+    } finally {
+      // Cleanup - ensure process is killed and streams are closed
       try {
-        const response = await fetch(url);
-        await response.body?.cancel();
-        if (response.ok) return;
+        // Kill the process group to ensure bash script and its children are terminated
+        process.kill("SIGTERM");
+
+        // Give it a moment to terminate gracefully
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        // Force kill if still running
+        try {
+          process.kill("SIGKILL");
+        } catch {
+          // Already terminated
+        }
+
+        // Close the streams to prevent leaks
+        if (process.stdout) {
+          await process.stdout.cancel();
+        }
+        if (process.stderr) {
+          await process.stderr.cancel();
+        }
+
+        await process.status;
       } catch {
-        // Server not ready yet
+        // Process may have already exited
       }
-      await delay(delayMs);
     }
-    throw new Error(
-      `Dev server did not start at ${url} after ${maxRetries} retries`,
-    );
-  }
+  },
+);
 
-  // Start dev server on port 3004
-  const process = startGuiDevCommand(["--port", "3004", "--no-open"]);
+Deno.test(
+  "gui command --dev mode serves GraphiQL interface",
+  async () => {
+    // Helper to start GUI command in subprocess
+    function startGuiDevCommand(
+      args: Array<string>,
+    ): Deno.ChildProcess {
+      // Try to find aibff in PATH or use relative path
+      const aibffPath = getConfigurationVariable("GITHUB_WORKSPACE")
+        ? `${getConfigurationVariable("GITHUB_WORKSPACE")}/infra/bin/aibff`
+        : new URL(import.meta.resolve("../../../../infra/bin/aibff")).pathname;
 
-  try {
-    // Wait for server to be ready
-    await waitForDevServer("http://localhost:3004/health");
+      const command = new Deno.Command(aibffPath, {
+        args: [
+          "gui",
+          "--dev",
+          ...args,
+        ],
+        stdout: "piped",
+        stderr: "piped",
+      });
 
-    // Test that GraphiQL is available in dev mode
-    const response = await fetch("http://localhost:3004/graphql", {
-      method: "GET",
-      headers: {
-        "Accept": "text/html",
-      },
-    });
+      return command.spawn();
+    }
 
-    assertEquals(response.status, 200);
-    const contentType = response.headers.get("content-type");
-    assertExists(contentType);
-    // GraphiQL should return HTML
-    assertEquals(contentType?.includes("text/html"), true);
+    // Helper to wait for dev server to be ready
+    async function waitForDevServer(
+      url: string,
+      maxRetries = 50,
+      delayMs = 100,
+      process?: Deno.ChildProcess,
+    ): Promise<void> {
+      // Collect stderr output for debugging
+      let stderrOutput = "";
+      if (process?.stderr) {
+        const reader = process.stderr.getReader();
+        const decoder = new TextDecoder();
+        (async () => {
+          try {
+            while (true) {
+              const { done, value } = await reader.read();
+              if (done) break;
+              stderrOutput += decoder.decode(value);
+            }
+          } catch {
+            // Reader closed
+          }
+        })();
+      }
 
-    await response.body?.cancel();
-  } finally {
-    // Cleanup - ensure process is killed and streams are closed
+      for (let i = 0; i < maxRetries; i++) {
+        try {
+          const response = await fetch(url);
+          await response.body?.cancel();
+          if (response.ok) return;
+        } catch {
+          // Server not ready yet
+        }
+        await delay(delayMs);
+      }
+      throw new Error(
+        `Dev server did not start at ${url} after ${maxRetries} retries. Stderr: ${stderrOutput}`,
+      );
+    }
+
+    // Start dev server on port 3004
+    const process = startGuiDevCommand(["--port", "3004", "--no-open"]);
+
     try {
-      process.kill();
+      // Wait for server to be ready
+      await waitForDevServer("http://localhost:3004/health", 50, 100, process);
 
-      // Close the streams to prevent leaks
-      if (process.stdout) {
-        await process.stdout.cancel();
-      }
-      if (process.stderr) {
-        await process.stderr.cancel();
-      }
+      // Test that GraphiQL is available in dev mode
+      const response = await fetch("http://localhost:3004/graphql", {
+        method: "GET",
+        headers: {
+          "Accept": "text/html",
+        },
+      });
 
-      await process.status;
-    } catch {
-      // Process may have already exited
+      assertEquals(response.status, 200);
+      const contentType = response.headers.get("content-type");
+      assertExists(contentType);
+      // GraphiQL should return HTML
+      assertEquals(contentType?.includes("text/html"), true);
+
+      await response.body?.cancel();
+    } finally {
+      // Cleanup - ensure process is killed and streams are closed
+      try {
+        // Kill the process group to ensure bash script and its children are terminated
+        process.kill("SIGTERM");
+
+        // Give it a moment to terminate gracefully
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        // Force kill if still running
+        try {
+          process.kill("SIGKILL");
+        } catch {
+          // Already terminated
+        }
+
+        // Close the streams to prevent leaks
+        if (process.stdout) {
+          await process.stdout.cancel();
+        }
+        if (process.stderr) {
+          await process.stderr.cancel();
+        }
+
+        await process.status;
+      } catch {
+        // Process may have already exited
+      }
     }
-  }
-});
+  },
+);

--- a/infra/bft/tasks/asset-upload.bft.ts
+++ b/infra/bft/tasks/asset-upload.bft.ts
@@ -62,7 +62,7 @@ Examples:
     }
     return 0;
   } catch (error) {
-    // Full error details available in error variable
+    ui.debug(`Full error details: ${error}`);
     ui.error(
       `Upload failed: ${
         error instanceof Error ? error.message : String(error)
@@ -262,7 +262,7 @@ async function checkAssetExists(
     });
 
     return response.ok;
-  } catch {
+  } catch (_error) {
     return false;
   }
 }

--- a/infra/env-setup.sh
+++ b/infra/env-setup.sh
@@ -17,4 +17,7 @@ export PATH="$BF_ROOT/infra/bin:$PATH"
 # Set DENO_DIR to keep cache out of repo
 export DENO_DIR="${HOME}/.cache/deno"
 
+# Set GitHub repository for gh CLI commands
+export GH_REPO="bolt-foundry/bolt-foundry"
+
 # Additional environment-specific setup can be added after sourcing this file


### PR DESCRIPTION

Enhance the bft post-update command to work correctly with Claude Code hooks
and improve the development environment setup for better integration.

Changes:
- Fix post-update command to read file paths from stdin when invoked by Claude hooks
- Add proper type extraction for different tool types (Edit, MultiEdit, Write)
- Skip type checking for non-TypeScript files (.md) to prevent parse errors
- Fix aibff GUI tests to use proper command and cleanup
- Use full path to aibff script for CI compatibility
- Fix process cleanup to handle bash script subprocesses
- Simplify dev server test to avoid stderr reading issues
- Add error output collection to test helpers for better debugging
- Fix lint errors in asset-upload.bft.ts (no-console, no-unused-vars, no-explicit-any)
- Remove hostname from codebot containers (was causing issues)
- Add Ghostty terminal title updates for better codebot container identification
- Move GH_REPO environment variable from .env.local to infra/env-setup.sh
- Update README.md to mention RLHF workflows

Test plan:
1. Edit any .ts file and verify post-update runs format and type check
2. Edit any .md file and verify post-update only runs format
3. Run bft test to ensure all tests pass
4. Run bft lint to verify no lint errors
5. Verify GH_REPO is set by running: source infra/env-setup.sh && echo $GH_REPO

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
