### PR TITLE
Fix post-update command and improve development environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Bolt Foundry - Customer Success Platform for AI
 
 **Make AI systems continuously improve through customer feedback, creating
-reliable, customer-centric AI that gets better every day.**
+reliable, customer-centric AI that gets better every day using RLHF workflows.**
 
 Most AI systems are built and deployed without meaningful connection to customer
 feedback. Companies launch AI features, get complaints, and struggle to

--- a/infra/bft/tasks/asset-upload.bft.ts
+++ b/infra/bft/tasks/asset-upload.bft.ts
@@ -62,7 +62,7 @@ Examples:
     }
     return 0;
   } catch (error) {
-    // Full error details available in error variable
+    ui.debug(`Full error details: ${error}`);
     ui.error(
       `Upload failed: ${
         error instanceof Error ? error.message : String(error)
@@ -262,7 +262,7 @@ async function checkAssetExists(
     });
 
     return response.ok;
-  } catch {
+  } catch (_error) {
     return false;
   }
 }

--- a/infra/env-setup.sh
+++ b/infra/env-setup.sh
@@ -17,4 +17,7 @@ export PATH="$BF_ROOT/infra/bin:$PATH"
 # Set DENO_DIR to keep cache out of repo
 export DENO_DIR="${HOME}/.cache/deno"
 
+# Set GitHub repository for gh CLI commands
+export GH_REPO="bolt-foundry/bolt-foundry"
+
 # Additional environment-specific setup can be added after sourcing this file


### PR DESCRIPTION
Enhance the bft post-update command to work correctly with Claude Code hooks
and improve the development environment setup for better integration.

Changes:
- Fix post-update command to read file paths from stdin when invoked by Claude hooks
- Add proper type extraction for different tool types (Edit, MultiEdit, Write)
- Skip type checking for non-TypeScript files (.md) to prevent parse errors
- Fix lint errors in asset-upload.bft.ts (ui.debug and _error in catch)
- Move GH_REPO environment variable from .env.local to infra/env-setup.sh
- Update README.md to mention RLHF workflows

Test plan:
1. Edit any .ts file and verify post-update runs format and type check
2. Edit any .md file and verify post-update only runs format
3. Run bft test to ensure all tests pass
4. Run bft lint to verify no lint errors
5. Verify GH_REPO is set by running: source infra/env-setup.sh && echo $GH_REPO

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/1636)
<!-- GitContextEnd -->