### PR TITLE
Fix GUI tests to use full path to aibff script in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Bolt Foundry - Customer Success Platform for AI
 
 **Make AI systems continuously improve through customer feedback, creating
-reliable, customer-centric AI that gets better every day.**
+reliable, customer-centric AI that gets better every day using RLHF workflows.**
 
 Most AI systems are built and deployed without meaningful connection to customer
 feedback. Companies launch AI features, get complaints, and struggle to

--- a/apps/aibff/commands/__tests__/gui-graphql.test.ts
+++ b/apps/aibff/commands/__tests__/gui-graphql.test.ts
@@ -11,7 +11,12 @@ Deno.test(
     function startGuiCommand(
       args: Array<string>,
     ): Deno.ChildProcess {
-      const command = new Deno.Command("aibff", {
+      // Try to find aibff in PATH or use relative path
+      const aibffPath = Deno.env.get("GITHUB_WORKSPACE")
+        ? `${Deno.env.get("GITHUB_WORKSPACE")}/infra/bin/aibff`
+        : new URL(import.meta.resolve("../../../../infra/bin/aibff")).pathname;
+
+      const command = new Deno.Command(aibffPath, {
         args: [
           "gui",
           ...args,
@@ -120,7 +125,12 @@ Deno.test(
     function startGuiDevCommand(
       args: Array<string>,
     ): Deno.ChildProcess {
-      const command = new Deno.Command("aibff", {
+      // Try to find aibff in PATH or use relative path
+      const aibffPath = Deno.env.get("GITHUB_WORKSPACE")
+        ? `${Deno.env.get("GITHUB_WORKSPACE")}/infra/bin/aibff`
+        : new URL(import.meta.resolve("../../../../infra/bin/aibff")).pathname;
+
+      const command = new Deno.Command(aibffPath, {
         args: [
           "gui",
           "--dev",

--- a/apps/aibff/commands/__tests__/gui-graphql.test.ts
+++ b/apps/aibff/commands/__tests__/gui-graphql.test.ts
@@ -3,140 +3,125 @@
 import { assertEquals, assertExists } from "@std/assert";
 import { delay } from "@std/async";
 
-Deno.test("gui command serves GraphQL endpoint with hello query", {
-  ignore: true,
-}, async () => {
-  // Helper to start GUI command in subprocess
-  function startGuiCommand(
-    args: Array<string>,
-  ): Deno.ChildProcess {
-    const mainPath = new URL(import.meta.resolve("../../main.ts")).pathname;
-    const command = new Deno.Command("deno", {
-      args: [
-        "run",
-        "--allow-env",
-        "--allow-read",
-        "--allow-write",
-        "--allow-net",
-        "--allow-run",
-        mainPath,
-        "gui",
-        ...args,
-      ],
-      stdout: "piped",
-      stderr: "piped",
-    });
+Deno.test(
+  "gui command serves GraphQL endpoint with hello query",
+  {},
+  async () => {
+    // Helper to start GUI command in subprocess
+    function startGuiCommand(
+      args: Array<string>,
+    ): Deno.ChildProcess {
+      const command = new Deno.Command("aibff", {
+        args: [
+          "gui",
+          ...args,
+        ],
+        stdout: "piped",
+        stderr: "piped",
+      });
 
-    return command.spawn();
-  }
+      return command.spawn();
+    }
 
-  // Helper to wait for server to be ready
-  async function waitForServer(
-    url: string,
-    maxRetries = 30,
-    delayMs = 100,
-    process?: Deno.ChildProcess,
-  ): Promise<void> {
-    // Collect stderr output for debugging
-    let stderrOutput = "";
-    if (process?.stderr) {
-      const reader = process.stderr.getReader();
-      const decoder = new TextDecoder();
-      (async () => {
-        try {
-          while (true) {
-            const { done, value } = await reader.read();
-            if (done) break;
-            stderrOutput += decoder.decode(value);
+    // Helper to wait for server to be ready
+    async function waitForServer(
+      url: string,
+      maxRetries = 30,
+      delayMs = 100,
+      process?: Deno.ChildProcess,
+    ): Promise<void> {
+      // Collect stderr output for debugging
+      let stderrOutput = "";
+      if (process?.stderr) {
+        const reader = process.stderr.getReader();
+        const decoder = new TextDecoder();
+        (async () => {
+          try {
+            while (true) {
+              const { done, value } = await reader.read();
+              if (done) break;
+              stderrOutput += decoder.decode(value);
+            }
+          } catch {
+            // Reader closed
           }
-        } catch (_e) {
-          // Reader closed
-        }
-      })();
-    }
-
-    for (let i = 0; i < maxRetries; i++) {
-      try {
-        const response = await fetch(url);
-        await response.body?.cancel();
-        if (response.ok) return;
-      } catch {
-        // Server not ready yet
+        })();
       }
-      await delay(delayMs);
+
+      for (let i = 0; i < maxRetries; i++) {
+        try {
+          const response = await fetch(url);
+          await response.body?.cancel();
+          if (response.ok) return;
+        } catch {
+          // Server not ready yet
+        }
+        await delay(delayMs);
+      }
+      throw new Error(
+        `Server did not start at ${url} after ${maxRetries} retries. Stderr: ${stderrOutput}`,
+      );
     }
-    throw new Error(
-      `Server did not start at ${url} after ${maxRetries} retries. Stderr: ${stderrOutput}`,
-    );
-  }
 
-  // Start server in test mode on port 3003
-  const process = startGuiCommand(["--port", "3003", "--no-open"]);
+    // Start server in test mode on port 3003
+    const process = startGuiCommand(["--port", "3003", "--no-open"]);
 
-  try {
-    // Wait for server to be ready
-    await waitForServer("http://localhost:3003/health", 30, 100, process);
+    try {
+      // Wait for server to be ready
+      await waitForServer("http://localhost:3003/health", 30, 100, process);
 
-    // Test GraphQL endpoint exists
-    const response = await fetch("http://localhost:3003/graphql", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        query: `
+      // Test GraphQL endpoint exists
+      const response = await fetch("http://localhost:3003/graphql", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          query: `
           query {
             hello
           }
         `,
-      }),
-    });
+        }),
+      });
 
-    assertEquals(response.status, 200);
-    const contentType = response.headers.get("content-type");
-    assertExists(contentType);
-    assertEquals(contentType?.startsWith("application/json"), true);
+      assertEquals(response.status, 200);
+      const contentType = response.headers.get("content-type");
+      assertExists(contentType);
+      assertEquals(contentType?.startsWith("application/json"), true);
 
-    const result = await response.json();
-    assertEquals(result.data.hello, "Hello from aibff GUI!");
-  } finally {
-    // Cleanup - ensure process is killed and streams are closed
-    try {
-      process.kill();
+      const result = await response.json();
+      assertEquals(result.data.hello, "Hello from aibff GUI!");
+    } finally {
+      // Cleanup - ensure process is killed and streams are closed
+      try {
+        process.kill();
 
-      // Close the streams to prevent leaks
-      if (process.stdout) {
-        await process.stdout.cancel();
+        // Close the streams to prevent leaks
+        if (process.stdout) {
+          await process.stdout.cancel();
+        }
+        if (process.stderr) {
+          await process.stderr.cancel();
+        }
+
+        await process.status;
+      } catch {
+        // Process may have already exited
       }
-      if (process.stderr) {
-        await process.stderr.cancel();
-      }
-
-      await process.status;
-    } catch {
-      // Process may have already exited
     }
-  }
-});
+  },
+);
 
 Deno.test(
   "gui command --dev mode serves GraphiQL interface",
-  { ignore: true },
   async () => {
     // Helper to start GUI command in subprocess
     function startGuiDevCommand(
       args: Array<string>,
     ): Deno.ChildProcess {
-      const mainPath = new URL(import.meta.resolve("../../main.ts")).pathname;
-      const command = new Deno.Command("deno", {
+      const command = new Deno.Command("aibff", {
         args: [
-          "run",
-          "--allow-env",
-          "--allow-read",
-          "--allow-write",
-          "--allow-net",
-          "--allow-run",
-          mainPath,
           "gui",
           "--dev",
           ...args,
@@ -167,7 +152,7 @@ Deno.test(
               if (done) break;
               stderrOutput += decoder.decode(value);
             }
-          } catch (_e) {
+          } catch {
             // Reader closed
           }
         })();

--- a/apps/aibff/commands/__tests__/gui.test.ts
+++ b/apps/aibff/commands/__tests__/gui.test.ts
@@ -17,7 +17,12 @@ Deno.test("gui command starts server and responds to health check", async () => 
   function startGuiCommand(
     args: Array<string>,
   ): Deno.ChildProcess {
-    const command = new Deno.Command("aibff", {
+    // Try to find aibff in PATH or use relative path
+    const aibffPath = Deno.env.get("GITHUB_WORKSPACE")
+      ? `${Deno.env.get("GITHUB_WORKSPACE")}/infra/bin/aibff`
+      : new URL(import.meta.resolve("../../../../infra/bin/aibff")).pathname;
+
+    const command = new Deno.Command(aibffPath, {
       args: [
         "gui",
         ...args,
@@ -132,16 +137,13 @@ Deno.test("gui command --dev starts vite dev server and proxies requests", async
   function startGuiDevCommand(
     args: Array<string>,
   ): Deno.ChildProcess {
-    const mainPath = new URL(import.meta.resolve("../../main.ts")).pathname;
-    const command = new Deno.Command("deno", {
+    // Try to find aibff in PATH or use relative path
+    const aibffPath = Deno.env.get("GITHUB_WORKSPACE")
+      ? `${Deno.env.get("GITHUB_WORKSPACE")}/infra/bin/aibff`
+      : new URL(import.meta.resolve("../../../../infra/bin/aibff")).pathname;
+
+    const command = new Deno.Command(aibffPath, {
       args: [
-        "run",
-        "--allow-env",
-        "--allow-read",
-        "--allow-write",
-        "--allow-net",
-        "--allow-run",
-        mainPath,
         "gui",
         "--dev",
         ...args,

--- a/apps/aibff/commands/__tests__/gui.test.ts
+++ b/apps/aibff/commands/__tests__/gui.test.ts
@@ -12,23 +12,13 @@ Deno.test("gui command exists with correct properties", async () => {
   assertEquals(guiCommand.description, "Launch the aibff GUI web interface");
 });
 
-Deno.test("gui command starts server and responds to health check", {
-  ignore: true,
-}, async () => {
+Deno.test("gui command starts server and responds to health check", async () => {
   // Helper to start GUI command in subprocess
   function startGuiCommand(
     args: Array<string>,
   ): Deno.ChildProcess {
-    const mainPath = new URL(import.meta.resolve("../../main.ts")).pathname;
-    const command = new Deno.Command("deno", {
+    const command = new Deno.Command("aibff", {
       args: [
-        "run",
-        "--allow-env",
-        "--allow-read",
-        "--allow-write",
-        "--allow-net",
-        "--allow-run",
-        mainPath,
         "gui",
         ...args,
       ],
@@ -58,7 +48,7 @@ Deno.test("gui command starts server and responds to health check", {
             if (done) break;
             stderrOutput += decoder.decode(value);
           }
-        } catch (_e) {
+        } catch {
           // Reader closed
         }
       })();
@@ -137,9 +127,7 @@ Deno.test("gui command --build runs vite build", async () => {
   assert(distExists, "dist directory should exist after build");
 });
 
-Deno.test("gui command --dev starts vite dev server and proxies requests", {
-  ignore: true,
-}, async () => {
+Deno.test("gui command --dev starts vite dev server and proxies requests", async () => {
   // Helper to start GUI command in subprocess
   function startGuiDevCommand(
     args: Array<string>,
@@ -184,7 +172,7 @@ Deno.test("gui command --dev starts vite dev server and proxies requests", {
             if (done) break;
             stderrOutput += decoder.decode(value);
           }
-        } catch (_e) {
+        } catch {
           // Reader closed
         }
       })();

--- a/infra/bft/tasks/asset-upload.bft.ts
+++ b/infra/bft/tasks/asset-upload.bft.ts
@@ -62,7 +62,7 @@ Examples:
     }
     return 0;
   } catch (error) {
-    // Full error details available in error variable
+    ui.debug(`Full error details: ${error}`);
     ui.error(
       `Upload failed: ${
         error instanceof Error ? error.message : String(error)
@@ -262,7 +262,7 @@ async function checkAssetExists(
     });
 
     return response.ok;
-  } catch {
+  } catch (_error) {
     return false;
   }
 }

--- a/infra/env-setup.sh
+++ b/infra/env-setup.sh
@@ -17,4 +17,7 @@ export PATH="$BF_ROOT/infra/bin:$PATH"
 # Set DENO_DIR to keep cache out of repo
 export DENO_DIR="${HOME}/.cache/deno"
 
+# Set GitHub repository for gh CLI commands
+export GH_REPO="bolt-foundry/bolt-foundry"
+
 # Additional environment-specific setup can be added after sourcing this file


### PR DESCRIPTION

- Use GITHUB_WORKSPACE env var to locate aibff script in CI
- Fall back to relative path resolution for local development
- Ensures tests can find aibff command regardless of PATH setup

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/1640).
* __->__ #1640
* #1637
* #1634