### PR TITLE
Add simple worker queue implementation memo

### DIFF
--- a/memos/bfnode-enum-support.md
+++ b/memos/bfnode-enum-support.md
@@ -1,0 +1,134 @@
+# BfNode Enum Support Implementation
+
+**Date**: 2025-07-29\
+**Status**: Ready to implement
+
+## Problem
+
+Currently using strings for fields that should be enums (like status fields). No
+compile-time or runtime validation.
+
+## Solution
+
+Add `.enum()` to the BfNode builder. Simple implementation that stores as
+strings but provides type safety.
+
+## Implementation
+
+### Step 1: Update type definitions
+
+```typescript
+// apps/bfDb/builders/bfDb/types.ts
+export type FieldSpec =
+  | { kind: "string" }
+  | { kind: "number" }
+  | { kind: "json" }
+  | { kind: "enum"; values: readonly string[] };
+```
+
+### Step 2: Add enum to field builder
+
+```typescript
+// apps/bfDb/builders/bfDb/makeFieldBuilder.ts
+export type FieldBuilder<F, R> = {
+  // ... existing methods
+
+  enum<N extends string, const V extends readonly string[]>(
+    name: N,
+    values: V,
+  ): FieldBuilder<F & { [K in N]: { kind: "enum"; values: V } }, R>;
+};
+
+// In makeFieldBuilder function:
+const enumField = <N extends string, const V extends readonly string[]>(
+  name: N,
+  values: V,
+) =>
+  next({
+    ...out,
+    fields: { ...out.fields, [name]: { kind: "enum", values } },
+  });
+
+return {
+  string,
+  number,
+  json,
+  enum: enumField, // Add this
+  one: addRel("out", "one"),
+  _spec: out,
+};
+```
+
+### Step 3: Update type inference
+
+```typescript
+// apps/bfDb/classes/BfNode.ts
+type FieldValue<S> = S extends { kind: "string" } ? string
+  : S extends { kind: "number" } ? number
+  : S extends { kind: "json" } ? JSONValue
+  : S extends { kind: "enum"; values: readonly (infer V)[] } ? V
+  : never;
+```
+
+### Step 4: Add runtime validation
+
+```typescript
+// apps/bfDb/classes/BfNode.ts
+// In BfNode class, add to beforeCreate():
+const spec = (this.constructor as typeof BfNode).bfNodeSpec;
+
+for (const [fieldName, fieldSpec] of Object.entries(spec.fields)) {
+  if (fieldSpec.kind === "enum" && this._props[fieldName] !== undefined) {
+    const value = this._props[fieldName];
+    if (!fieldSpec.values.includes(value as string)) {
+      throw new Error(
+        `Invalid enum value "${value}" for field "${fieldName}". ` +
+          `Valid values: ${fieldSpec.values.join(", ")}`,
+      );
+    }
+  }
+}
+```
+
+### Step 5: Usage example
+
+```typescript
+// Now you can do:
+export class BfJob extends BfNode<InferProps<typeof BfJob>> {
+  static override bfNodeSpec = this.defineBfNode((node) =>
+    node
+      .string("type")
+      .json("payload")
+      .enum(
+        "status",
+        ["available", "claimed", "running", "completed", "failed"] as const,
+      )
+      .number("attempts").default(0)
+      .string("error").optional()
+  );
+}
+
+// TypeScript knows job.props.status is "available" | "claimed" | etc.
+// Runtime validation ensures only valid values are saved
+```
+
+## What about GraphQL?
+
+Skip it for now. The GraphQL layer can treat enums as strings initially. Add
+proper GraphQL enum support later if needed.
+
+## Testing
+
+```typescript
+// Simple test
+const job = await BfJob.create({
+  type: "test",
+  payload: {},
+  status: "invalid", // TypeScript error AND runtime error
+  attempts: 0,
+}, viewer);
+```
+
+## That's it
+
+~50 lines of code for type-safe enums. Ship it.

--- a/memos/worker-queue-implementation.md
+++ b/memos/worker-queue-implementation.md
@@ -1,0 +1,140 @@
+# Worker Queue Implementation
+
+**Date**: 2025-07-29\
+**Status**: Ready to build
+
+## Problem
+
+We need a way to run tasks asynchronously in the background.
+
+## Solution
+
+Build a simple job queue backed by our existing database. Use Postgres row
+locking for atomic job claiming.
+
+## Implementation
+
+### Step 1: Add BfJob node type
+
+```typescript
+// apps/bfDb/nodeTypes/BfJob.ts
+import { BfNode, type InferProps } from "@bfmono/apps/bfDb/classes/BfNode.ts";
+
+export class BfJob extends BfNode<InferProps<typeof BfJob>> {
+  static override bfNodeSpec = this.defineBfNode((node) =>
+    node
+      .string("type")
+      .json("payload")
+      .enum("status", [
+        "available",
+        "claimed",
+        "running",
+        "completed",
+        "failed",
+      ])
+      .number("attempts").default(0)
+      .string("error").optional()
+      .string("workerId").optional()
+  );
+
+  static async claimNext(workerId: string) {
+    // Use Postgres row locking to atomically claim a job
+    const result = await this.storage.query(`
+      UPDATE bfDb 
+      SET props = jsonb_set(
+        jsonb_set(props, '{status}', '"claimed"'), 
+        '{workerId}', '"${workerId}"'
+      )
+      WHERE bf_gid = (
+        SELECT bf_gid FROM bfDb 
+        WHERE class_name = 'BfJob' 
+        AND props->>'status' = 'available'
+        ORDER BY created_at
+        LIMIT 1
+        FOR UPDATE SKIP LOCKED
+      )
+      RETURNING *
+    `);
+
+    return result[0] ? new BfJob(result[0]) : null;
+  }
+}
+```
+
+### Step 2: Queue jobs instead of sync calls
+
+```typescript
+// Before:
+await sendToPostHog(event);
+
+// After:
+await BfJob.create({
+  type: "track_usage",
+  payload: { event },
+  status: "available",
+}, viewer);
+```
+
+### Step 3: Simple worker loop
+
+```typescript
+// apps/collector/worker.ts
+import { BfJob } from "@bfmono/apps/bfDb/nodeTypes/BfJob.ts";
+import { sleep } from "@std/async/sleep";
+
+const workerId = crypto.randomUUID();
+
+while (true) {
+  const job = await BfJob.claimNext(workerId);
+
+  if (!job) {
+    await sleep(1000);
+    continue;
+  }
+
+  try {
+    job.props.status = "running";
+    await job.save();
+
+    // Process based on job type
+    switch (job.props.type) {
+      case "track_usage":
+        await sendToPostHog(job.props.payload.event);
+        break;
+      default:
+        throw new Error(`Unknown job type: ${job.props.type}`);
+    }
+
+    job.props.status = "completed";
+    await job.save();
+  } catch (error) {
+    job.props.attempts++;
+    job.props.status = job.props.attempts >= 3 ? "failed" : "available";
+    job.props.error = error.message;
+    job.props.workerId = null; // Release for retry
+    await job.save();
+  }
+}
+```
+
+### Step 4: Add worker command
+
+```typescript
+// infra/bft/tasks/worker.bft.ts
+export async function worker(): Promise<number> {
+  await import("../../apps/collector/worker.ts");
+  return 0;
+}
+```
+
+## Deployment
+
+1. Deploy code with jobs being created
+2. Run worker: `bft worker`
+3. Check it works:
+   `SELECT props->>'status', COUNT(*) FROM bfDb WHERE class_name = 'BfJob' GROUP BY 1`
+4. Remove sync calls
+
+## That's it
+
+Simple queue that works. Add features when you need them.


### PR DESCRIPTION

This memo outlines a pragmatic approach to implement async job processing using our existing BfNode infrastructure. The implementation includes:
- BfJob node type with status tracking (available → claimed → running → completed/failed)
- Atomic job claiming using Postgres row-level locking (FOR UPDATE SKIP LOCKED)
- Simple worker loop that polls and processes jobs
- Basic retry logic with configurable attempt limits
- Support for different job types via switch statement

The entire system can be built in a day and deployed incrementally, following the "ship fast and iterate" philosophy.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
