### PR TITLE
Migrate codebot Docker image from Alpine to Ubuntu for glibc compatibility

### DIFF
--- a/infra/apps/codebot/Dockerfile
+++ b/infra/apps/codebot/Dockerfile
@@ -1,7 +1,14 @@
-FROM alpine:latest
+FROM ubuntu:24.04
 
-# Install curl and ca-certificates for the Nix installer
-RUN apk add --no-cache curl ca-certificates bash
+# Install dependencies for Nix installer and general development
+RUN apt-get update && apt-get install -y \
+    curl \
+    ca-certificates \
+    bash \
+    git \
+    sudo \
+    xz-utils \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install Nix using Determinate Nix installer
 RUN curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install linux \
@@ -19,8 +26,8 @@ WORKDIR /workspace
 # Install our environment
 RUN nix profile install .#codebot-env --accept-flake-config
 
-# Create non-root user (Alpine uses adduser)
-RUN adduser -D -s /bin/bash codebot
+# Create non-root user (Ubuntu uses useradd)
+RUN useradd -m -s /bin/bash codebot
 
 # Switch to codebot user and set up .bashrc
 USER codebot

--- a/infra/apps/codebot/Dockerfile.ubuntu-migration.md
+++ b/infra/apps/codebot/Dockerfile.ubuntu-migration.md
@@ -1,0 +1,41 @@
+# Codebot Dockerfile Migration: Alpine to Ubuntu
+
+## Changes Made
+
+1. **Base Image**: Changed from `alpine:latest` to `ubuntu:24.04`
+   - Ubuntu 24.04 LTS provides long-term support and stability
+   - Uses glibc instead of musl libc, ensuring compatibility with Deno-compiled
+     binaries
+
+2. **Package Installation**:
+   - Changed from `apk add` to `apt-get install`
+   - Added additional packages: `git`, `sudo`, `xz-utils` for better development
+     support
+   - Added cleanup of apt cache to reduce image size
+
+3. **User Creation**:
+   - Changed from `adduser -D` (Alpine) to `useradd -m` (Ubuntu)
+   - Both create a home directory and set bash as the shell
+
+## Benefits
+
+1. **Binary Compatibility**: Deno-compiled binaries will work without glibc/musl
+   issues
+2. **Better Tool Support**: More packages and tools available in Ubuntu
+   repositories
+3. **E2E Testing**: Chromium and other testing tools will work out of the box
+4. **Debugging**: Better debugging tools and libraries available
+
+## Testing Plan
+
+1. Build new Docker image
+2. Test basic functionality (file operations, git, etc.)
+3. Run e2e tests to verify they work correctly
+4. Check image size difference
+
+## Notes
+
+- Ubuntu 24.04 image is larger than Alpine (~75MB vs ~5MB base)
+- The trade-off is worth it for development/testing compatibility
+- Can optimize image size later if needed (multi-stage builds, minimal Ubuntu
+  variant)


### PR DESCRIPTION

Switch from Alpine Linux to Ubuntu 24.04 to resolve binary compatibility issues with
Deno-compiled executables. Alpine uses musl libc while our compiled binaries require
glibc, preventing e2e tests from running in the containerized environment.

Changes:
- Update base image from alpine:latest to ubuntu:24.04
- Replace Alpine package manager (apk) with Ubuntu's apt-get
- Add development packages: git, sudo, xz-utils for better tooling support
- Update user creation from Alpine's adduser to Ubuntu's useradd
- Add apt cache cleanup to minimize image size increase

Test plan:
1. Build new Docker image: docker build -f infra/apps/codebot/Dockerfile -t codebot-test .
2. Run container and verify basic functionality: docker run -it codebot-test
3. Test e2e execution: bft e2e apps/boltfoundry-com/__tests__/e2e/homepage.test.e2e.ts
4. Verify Deno-compiled binaries execute without glibc errors

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
