### PR TITLE
Switch codebot container to Debian and fix hosts file persistence

### DIFF
--- a/infra/apps/codebot/Dockerfile
+++ b/infra/apps/codebot/Dockerfile
@@ -1,7 +1,13 @@
-FROM ubuntu:24.04
+FROM debian:bookworm-slim
+
+# Create a hosts file template that we'll use at runtime
+RUN mkdir -p /etc/container-init && \
+    echo "127.0.0.1        localhost localhost.localdomain" > /etc/container-init/hosts.template && \
+    echo "::1              localhost localhost.localdomain" >> /etc/container-init/hosts.template
+
 
 # Install dependencies for Nix installer and general development
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     ca-certificates \
     bash \
@@ -26,11 +32,35 @@ WORKDIR /workspace
 # Install our environment
 RUN nix profile install .#codebot-env --accept-flake-config
 
-# Initialize hosts file with basic entries
-RUN echo "127.0.0.1 localhost" > /etc/hosts && \
-    echo "::1 localhost ip6-localhost ip6-loopback" >> /etc/hosts
+# Create entrypoint script that ensures /etc/hosts exists (must be done as root)
+RUN printf '#!/bin/bash\n\
+# Check if /etc/hosts exists, create it if missing\n\
+if [ ! -f /etc/hosts ]; then\n\
+    echo "Warning: /etc/hosts missing, creating from template..."\n\
+    # Use sudo to create /etc/hosts since we run as codebot user\n\
+    if [ -f /etc/container-init/hosts.template ]; then\n\
+        sudo -n cp /etc/container-init/hosts.template /etc/hosts 2>/dev/null\n\
+    else\n\
+        # Fallback if template is also missing\n\
+        echo "127.0.0.1        localhost localhost.localdomain" | sudo -n tee /etc/hosts > /dev/null 2>&1\n\
+        echo "::1              localhost localhost.localdomain" | sudo -n tee -a /etc/hosts > /dev/null 2>&1\n\
+    fi\n\
+fi\n\
+\n\
+# Add hostname.codebot.local entry if not already present\n\
+if [ -n "$HOSTNAME" ] && ! grep -q "$HOSTNAME.codebot.local" /etc/hosts 2>/dev/null; then\n\
+    echo "127.0.0.1        $HOSTNAME.codebot.local $HOSTNAME" | sudo -n tee -a /etc/hosts > /dev/null 2>&1\n\
+fi\n\
+\n\
+# Execute bash with login shell\n\
+exec /bin/bash -l "$@"\n' > /usr/local/bin/docker-entrypoint.sh && \
+    chmod +x /usr/local/bin/docker-entrypoint.sh
 
-# Create non-root user (Ubuntu uses useradd)
+# Configure sudo for codebot user to allow /etc/hosts management without password
+RUN echo "codebot ALL=(ALL) NOPASSWD: /bin/cp * /etc/hosts, /usr/bin/tee /etc/hosts, /usr/bin/tee -a /etc/hosts" >> /etc/sudoers.d/codebot && \
+    chmod 0440 /etc/sudoers.d/codebot
+
+# Create non-root user (Debian uses useradd)
 RUN useradd -m -s /bin/bash codebot
 
 # Switch to codebot user and set up .bashrc
@@ -69,10 +99,13 @@ fi
 # Add Nix to PATH
 export PATH="/nix/var/nix/profiles/default/bin:\$PATH"
 
+# Set Puppeteer executable path for e2e tests
+export PUPPETEER_EXECUTABLE_PATH="/nix/var/nix/profiles/default/bin/chromium"
+
 # Source shared environment setup
 if [ -f "/workspace/infra/env-setup.sh" ]; then
   source /workspace/infra/env-setup.sh
 fi
 EOF
 
-ENTRYPOINT ["/bin/bash", "-l"]
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]


### PR DESCRIPTION
Replace Ubuntu 24.04 with Debian Bookworm for better stability and smaller image size.
Implement robust /etc/hosts management to ensure hostname resolution works correctly
in containerized environments, particularly for e2e tests requiring localhost access.

Changes:
- Switch base image from ubuntu:24.04 to debian:bookworm-slim
- Add entrypoint script to manage /etc/hosts at runtime
- Configure sudo permissions for hosts file management
- Create hosts template for container initialization
- Add PUPPETEER_EXECUTABLE_PATH for e2e test compatibility
- Update package installation to use --no-install-recommends flag

Test plan:
1. Build the container: `docker build -f infra/apps/codebot/Dockerfile -t codebot-test .`
2. Run container: `docker run -it --rm codebot-test`
3. Verify /etc/hosts contains localhost entries
4. Test hostname resolution: `ping -c 1 localhost`
5. Run e2e tests to verify Puppeteer works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/1693)
<!-- GitContextEnd -->