### PR TITLE
Fix missing blog CSS styles for e2e tests

### DIFF
--- a/apps/aibff/commands/render.ts
+++ b/apps/aibff/commands/render.ts
@@ -448,7 +448,7 @@ async function renderDeck(
             unknown
           >,
           ...(tool.function.parameters?.required
-            ? { required: tool.function.parameters.required as string[] }
+            ? { required: tool.function.parameters.required as Array<string> }
             : {}),
         },
       },

--- a/apps/bfDb/graphql/__generated__/schema.graphql
+++ b/apps/bfDb/graphql/__generated__/schema.graphql
@@ -1,10 +1,10 @@
 ### @generated 
 type BfDeck implements BfNode {
+  content: String
   description: String
   id: ID!
   name: String
   slug: String!
-  systemPrompt: String
 }
 
 type BfEdge implements BfNode {
@@ -103,7 +103,7 @@ type JoinWaitlistPayload {
 }
 
 type Mutation {
-  createDeck(description: String, name: String!, slug: String!, systemPrompt: String!): BfDeck
+  createDeck(content: String!, description: String, name: String!, slug: String!): BfDeck
   joinWaitlist(company: String, email: String!, name: String!): JoinWaitlistPayload
   loginWithGoogle(idToken: String!): CurrentViewer
   submitSample(collectionMethod: String, completionData: String!, deckId: String!, name: String): BfSample

--- a/apps/boltfoundry-com/__generated__/__isograph/BlogPost/BlogPostView/param_type.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/BlogPost/BlogPostView/param_type.ts
@@ -1,0 +1,13 @@
+
+export type BlogPost__BlogPostView__param = {
+  readonly data: {
+    readonly id: string,
+    readonly content: string,
+    readonly author: (string | null),
+    readonly publishedAt: (string | null),
+    readonly tags: string,
+    readonly title: string,
+    readonly heroImage: (string | null),
+  },
+  readonly parameters: Record<PropertyKey, never>,
+};

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/Blog/output_type.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/Blog/output_type.ts
@@ -1,0 +1,4 @@
+import type { ExtractSecondParam, CombineWithIntrinsicAttributes } from '@isograph/react';
+import type React from 'react';
+import { Blog as resolver } from '../../../../components/Blog.tsx';
+export type Query__Blog__output_type = (React.FC<CombineWithIntrinsicAttributes<ExtractSecondParam<typeof resolver>>>);

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/Blog/param_type.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/Blog/param_type.ts
@@ -1,0 +1,10 @@
+import { type QueryBlogPostsConnection__BlogPostList__output_type } from '../../QueryBlogPostsConnection/BlogPostList/output_type.ts';
+
+export type Query__Blog__param = {
+  readonly data: {
+    readonly blogPosts: ({
+      readonly BlogPostList: QueryBlogPostsConnection__BlogPostList__output_type,
+    } | null),
+  },
+  readonly parameters: Record<PropertyKey, never>,
+};

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/Blog/resolver_reader.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/Blog/resolver_reader.ts
@@ -1,0 +1,42 @@
+import type {ComponentReaderArtifact, ExtractSecondParam, ReaderAst } from '@isograph/react';
+import { Query__Blog__param } from './param_type.ts';
+import { Blog as resolver } from '../../../../components/Blog.tsx';
+import QueryBlogPostsConnection__BlogPostList__resolver_reader from '../../QueryBlogPostsConnection/BlogPostList/resolver_reader.ts';
+
+const readerAst: ReaderAst<Query__Blog__param> = [
+  {
+    kind: "Linked",
+    fieldName: "blogPosts",
+    alias: null,
+    arguments: [
+      [
+        "first",
+        { kind: "Literal", value: 10 },
+      ],
+    ],
+    condition: null,
+    isUpdatable: false,
+    selections: [
+      {
+        kind: "Resolver",
+        alias: "BlogPostList",
+        arguments: null,
+        readerArtifact: QueryBlogPostsConnection__BlogPostList__resolver_reader,
+        usedRefetchQueries: [],
+      },
+    ],
+  },
+];
+
+const artifact: ComponentReaderArtifact<
+  Query__Blog__param,
+  ExtractSecondParam<typeof resolver>
+> = {
+  kind: "ComponentReaderArtifact",
+  fieldName: "Query.Blog",
+  resolver,
+  readerAst,
+  hasUpdatable: false,
+};
+
+export default artifact;

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointBlog/entrypoint.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointBlog/entrypoint.ts
@@ -1,0 +1,28 @@
+import type {IsographEntrypoint, NormalizationAst, RefetchQueryNormalizationArtifactWrapper} from '@isograph/react';
+import {Query__EntrypointBlog__param} from './param_type.ts';
+import {Query__EntrypointBlog__output_type} from './output_type.ts';
+import readerResolver from './resolver_reader.ts';
+import queryText from './query_text.ts';
+import normalizationAst from './normalization_ast.ts';
+const nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[] = [];
+
+const artifact: IsographEntrypoint<
+  Query__EntrypointBlog__param,
+  Query__EntrypointBlog__output_type,
+  NormalizationAst
+> = {
+  kind: "Entrypoint",
+  networkRequestInfo: {
+    kind: "NetworkRequestInfo",
+    queryText,
+    normalizationAst,
+  },
+  concreteType: "Query",
+  readerWithRefetchQueries: {
+    kind: "ReaderWithRefetchQueries",
+    nestedRefetchQueries,
+    readerArtifact: readerResolver,
+  },
+};
+
+export default artifact;

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointBlog/normalization_ast.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointBlog/normalization_ast.ts
@@ -1,0 +1,109 @@
+import type {NormalizationAst} from '@isograph/react';
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Scalar",
+      fieldName: "id",
+      arguments: null,
+    },
+    {
+      kind: "Linked",
+      fieldName: "blogPosts",
+      arguments: [
+        [
+          "first",
+          { kind: "Literal", value: 10 },
+        ],
+      ],
+      concreteType: "QueryBlogPostsConnection",
+      selections: [
+        {
+          kind: "Linked",
+          fieldName: "edges",
+          arguments: null,
+          concreteType: "QueryBlogPostsConnectionEdge",
+          selections: [
+            {
+              kind: "Scalar",
+              fieldName: "cursor",
+              arguments: null,
+            },
+            {
+              kind: "Linked",
+              fieldName: "node",
+              arguments: null,
+              concreteType: "BlogPost",
+              selections: [
+                {
+                  kind: "Scalar",
+                  fieldName: "id",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "author",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "excerpt",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "heroImage",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "publishedAt",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "tags",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "title",
+                  arguments: null,
+                },
+              ],
+            },
+          ],
+        },
+        {
+          kind: "Linked",
+          fieldName: "pageInfo",
+          arguments: null,
+          concreteType: "PageInfo",
+          selections: [
+            {
+              kind: "Scalar",
+              fieldName: "endCursor",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "hasNextPage",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "hasPreviousPage",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "startCursor",
+              arguments: null,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+export default normalizationAst;

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointBlog/output_type.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointBlog/output_type.ts
@@ -1,0 +1,3 @@
+import type React from 'react';
+import { EntrypointBlog as resolver } from '../../../../entrypoints/EntrypointBlog.ts';
+export type Query__EntrypointBlog__output_type = ReturnType<typeof resolver>;

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointBlog/param_type.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointBlog/param_type.ts
@@ -1,0 +1,8 @@
+import { type Query__Blog__output_type } from '../../Query/Blog/output_type.ts';
+
+export type Query__EntrypointBlog__param = {
+  readonly data: {
+    readonly Blog: Query__Blog__output_type,
+  },
+  readonly parameters: Record<PropertyKey, never>,
+};

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointBlog/query_text.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointBlog/query_text.ts
@@ -1,0 +1,23 @@
+export default 'query EntrypointBlog  {\
+  id,\
+  blogPosts____first___l_10: blogPosts(first: 10) {\
+    edges {\
+      cursor,\
+      node {\
+        id,\
+        author,\
+        excerpt,\
+        heroImage,\
+        publishedAt,\
+        tags,\
+        title,\
+      },\
+    },\
+    pageInfo {\
+      endCursor,\
+      hasNextPage,\
+      hasPreviousPage,\
+      startCursor,\
+    },\
+  },\
+}';

--- a/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointBlog/resolver_reader.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/Query/EntrypointBlog/resolver_reader.ts
@@ -1,0 +1,28 @@
+import type { EagerReaderArtifact, ReaderAst } from '@isograph/react';
+import { Query__EntrypointBlog__param } from './param_type.ts';
+import { Query__EntrypointBlog__output_type } from './output_type.ts';
+import { EntrypointBlog as resolver } from '../../../../entrypoints/EntrypointBlog.ts';
+import Query__Blog__resolver_reader from '../../Query/Blog/resolver_reader.ts';
+
+const readerAst: ReaderAst<Query__EntrypointBlog__param> = [
+  {
+    kind: "Resolver",
+    alias: "Blog",
+    arguments: null,
+    readerArtifact: Query__Blog__resolver_reader,
+    usedRefetchQueries: [],
+  },
+];
+
+const artifact: EagerReaderArtifact<
+  Query__EntrypointBlog__param,
+  Query__EntrypointBlog__output_type
+> = {
+  kind: "EagerReaderArtifact",
+  fieldName: "Query.EntrypointBlog",
+  resolver,
+  readerAst,
+  hasUpdatable: false,
+};
+
+export default artifact;

--- a/apps/boltfoundry-com/__generated__/__isograph/QueryBlogPostsConnection/BlogPostList/output_type.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/QueryBlogPostsConnection/BlogPostList/output_type.ts
@@ -1,0 +1,4 @@
+import type { ExtractSecondParam, CombineWithIntrinsicAttributes } from '@isograph/react';
+import type React from 'react';
+import { BlogPostList as resolver } from '../../../../components/BlogPostList.tsx';
+export type QueryBlogPostsConnection__BlogPostList__output_type = (React.FC<CombineWithIntrinsicAttributes<ExtractSecondParam<typeof resolver>>>);

--- a/apps/boltfoundry-com/__generated__/__isograph/QueryBlogPostsConnection/BlogPostList/param_type.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/QueryBlogPostsConnection/BlogPostList/param_type.ts
@@ -1,0 +1,24 @@
+
+export type QueryBlogPostsConnection__BlogPostList__param = {
+  readonly data: {
+    readonly edges: (ReadonlyArray<({
+      readonly cursor: string,
+      readonly node: ({
+        readonly id: string,
+        readonly author: (string | null),
+        readonly publishedAt: (string | null),
+        readonly excerpt: string,
+        readonly tags: string,
+        readonly title: string,
+        readonly heroImage: (string | null),
+      } | null),
+    } | null)> | null),
+    readonly pageInfo: {
+      readonly hasNextPage: boolean,
+      readonly hasPreviousPage: boolean,
+      readonly startCursor: (string | null),
+      readonly endCursor: (string | null),
+    },
+  },
+  readonly parameters: Record<PropertyKey, never>,
+};

--- a/apps/boltfoundry-com/__generated__/__isograph/QueryBlogPostsConnection/BlogPostList/resolver_reader.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/QueryBlogPostsConnection/BlogPostList/resolver_reader.ts
@@ -1,0 +1,133 @@
+import type {ComponentReaderArtifact, ExtractSecondParam, ReaderAst } from '@isograph/react';
+import { QueryBlogPostsConnection__BlogPostList__param } from './param_type.ts';
+import { BlogPostList as resolver } from '../../../../components/BlogPostList.tsx';
+
+const readerAst: ReaderAst<QueryBlogPostsConnection__BlogPostList__param> = [
+  {
+    kind: "Linked",
+    fieldName: "edges",
+    alias: null,
+    arguments: null,
+    condition: null,
+    isUpdatable: false,
+    selections: [
+      {
+        kind: "Scalar",
+        fieldName: "cursor",
+        alias: null,
+        arguments: null,
+        isUpdatable: false,
+      },
+      {
+        kind: "Linked",
+        fieldName: "node",
+        alias: null,
+        arguments: null,
+        condition: null,
+        isUpdatable: false,
+        selections: [
+          {
+            kind: "Scalar",
+            fieldName: "id",
+            alias: null,
+            arguments: null,
+            isUpdatable: false,
+          },
+          {
+            kind: "Scalar",
+            fieldName: "author",
+            alias: null,
+            arguments: null,
+            isUpdatable: false,
+          },
+          {
+            kind: "Scalar",
+            fieldName: "publishedAt",
+            alias: null,
+            arguments: null,
+            isUpdatable: false,
+          },
+          {
+            kind: "Scalar",
+            fieldName: "excerpt",
+            alias: null,
+            arguments: null,
+            isUpdatable: false,
+          },
+          {
+            kind: "Scalar",
+            fieldName: "tags",
+            alias: null,
+            arguments: null,
+            isUpdatable: false,
+          },
+          {
+            kind: "Scalar",
+            fieldName: "title",
+            alias: null,
+            arguments: null,
+            isUpdatable: false,
+          },
+          {
+            kind: "Scalar",
+            fieldName: "heroImage",
+            alias: null,
+            arguments: null,
+            isUpdatable: false,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    kind: "Linked",
+    fieldName: "pageInfo",
+    alias: null,
+    arguments: null,
+    condition: null,
+    isUpdatable: false,
+    selections: [
+      {
+        kind: "Scalar",
+        fieldName: "hasNextPage",
+        alias: null,
+        arguments: null,
+        isUpdatable: false,
+      },
+      {
+        kind: "Scalar",
+        fieldName: "hasPreviousPage",
+        alias: null,
+        arguments: null,
+        isUpdatable: false,
+      },
+      {
+        kind: "Scalar",
+        fieldName: "startCursor",
+        alias: null,
+        arguments: null,
+        isUpdatable: false,
+      },
+      {
+        kind: "Scalar",
+        fieldName: "endCursor",
+        alias: null,
+        arguments: null,
+        isUpdatable: false,
+      },
+    ],
+  },
+];
+
+const artifact: ComponentReaderArtifact<
+  QueryBlogPostsConnection__BlogPostList__param,
+  ExtractSecondParam<typeof resolver>
+> = {
+  kind: "ComponentReaderArtifact",
+  fieldName: "QueryBlogPostsConnection.BlogPostList",
+  resolver,
+  readerAst,
+  hasUpdatable: false,
+};
+
+export default artifact;

--- a/apps/boltfoundry-com/__generated__/__isograph/iso.ts
+++ b/apps/boltfoundry-com/__generated__/__isograph/iso.ts
@@ -1,7 +1,10 @@
 import type { IsographEntrypoint } from '@isograph/react';
+import { type BlogPost__BlogPostView__param } from './BlogPost/BlogPostView/param_type.ts';
 import { type CurrentViewer__LoginPage__param } from './CurrentViewer/LoginPage/param_type.ts';
 import { type CurrentViewer__RlhfHome__param } from './CurrentViewer/RlhfHome/param_type.ts';
 import { type Mutation__JoinWaitlist__param } from './Mutation/JoinWaitlist/param_type.ts';
+import { type Query__Blog__param } from './Query/Blog/param_type.ts';
+import { type Query__EntrypointBlog__param } from './Query/EntrypointBlog/param_type.ts';
 import { type Query__EntrypointEval__param } from './Query/EntrypointEval/param_type.ts';
 import { type Query__EntrypointHome__param } from './Query/EntrypointHome/param_type.ts';
 import { type Query__EntrypointLogin__param } from './Query/EntrypointLogin/param_type.ts';
@@ -9,7 +12,9 @@ import { type Query__EntrypointRlhf__param } from './Query/EntrypointRlhf/param_
 import { type Query__Eval__param } from './Query/Eval/param_type.ts';
 import { type Query__Home__param } from './Query/Home/param_type.ts';
 import { type Query__RlhfInterface__param } from './Query/RlhfInterface/param_type.ts';
+import { type QueryBlogPostsConnection__BlogPostList__param } from './QueryBlogPostsConnection/BlogPostList/param_type.ts';
 import entrypoint_Mutation__JoinWaitlist from '../__isograph/Mutation/JoinWaitlist/entrypoint.ts';
+import entrypoint_Query__EntrypointBlog from '../__isograph/Query/EntrypointBlog/entrypoint.ts';
 import entrypoint_Query__EntrypointEval from '../__isograph/Query/EntrypointEval/entrypoint.ts';
 import entrypoint_Query__EntrypointHome from '../__isograph/Query/EntrypointHome/entrypoint.ts';
 import entrypoint_Query__EntrypointLogin from '../__isograph/Query/EntrypointLogin/entrypoint.ts';
@@ -64,6 +69,10 @@ type MatchesWhitespaceAndString<
 > = Whitespace<T> extends `${TString}${string}` ? T : never;
 
 export function iso<T>(
+  param: T & MatchesWhitespaceAndString<'field BlogPost.BlogPostView', T>
+): IdentityWithParamComponent<BlogPost__BlogPostView__param>;
+
+export function iso<T>(
   param: T & MatchesWhitespaceAndString<'field CurrentViewer.LoginPage', T>
 ): IdentityWithParamComponent<CurrentViewer__LoginPage__param>;
 
@@ -74,6 +83,14 @@ export function iso<T>(
 export function iso<T>(
   param: T & MatchesWhitespaceAndString<'field Mutation.JoinWaitlist', T>
 ): IdentityWithParam<Mutation__JoinWaitlist__param>;
+
+export function iso<T>(
+  param: T & MatchesWhitespaceAndString<'field Query.Blog', T>
+): IdentityWithParamComponent<Query__Blog__param>;
+
+export function iso<T>(
+  param: T & MatchesWhitespaceAndString<'field Query.EntrypointBlog', T>
+): IdentityWithParam<Query__EntrypointBlog__param>;
 
 export function iso<T>(
   param: T & MatchesWhitespaceAndString<'field Query.EntrypointEval', T>
@@ -104,8 +121,16 @@ export function iso<T>(
 ): IdentityWithParamComponent<Query__RlhfInterface__param>;
 
 export function iso<T>(
+  param: T & MatchesWhitespaceAndString<'field QueryBlogPostsConnection.BlogPostList', T>
+): IdentityWithParamComponent<QueryBlogPostsConnection__BlogPostList__param>;
+
+export function iso<T>(
   param: T & MatchesWhitespaceAndString<'entrypoint Mutation.JoinWaitlist', T>
 ): typeof entrypoint_Mutation__JoinWaitlist;
+
+export function iso<T>(
+  param: T & MatchesWhitespaceAndString<'entrypoint Query.EntrypointBlog', T>
+): typeof entrypoint_Query__EntrypointBlog;
 
 export function iso<T>(
   param: T & MatchesWhitespaceAndString<'entrypoint Query.EntrypointEval', T>
@@ -131,6 +156,8 @@ export function iso(isographLiteralText: string):
   switch (isographLiteralText) {
     case 'entrypoint Mutation.JoinWaitlist':
       return entrypoint_Mutation__JoinWaitlist;
+    case 'entrypoint Query.EntrypointBlog':
+      return entrypoint_Query__EntrypointBlog;
     case 'entrypoint Query.EntrypointEval':
       return entrypoint_Query__EntrypointEval;
     case 'entrypoint Query.EntrypointHome':

--- a/apps/boltfoundry-com/__generated__/builtRoutes.ts
+++ b/apps/boltfoundry-com/__generated__/builtRoutes.ts
@@ -9,17 +9,20 @@ export type RouteEntrypoint = {
 };
 
 iso(`entrypoint Mutation.JoinWaitlist`)
+iso(`entrypoint Query.EntrypointBlog`)
 iso(`entrypoint Query.EntrypointEval`)
 iso(`entrypoint Query.EntrypointHome`)
 iso(`entrypoint Query.EntrypointLogin`)
 iso(`entrypoint Query.EntrypointRlhf`)
 
+import entrypointBlog from "@iso-bfc/Query/EntrypointBlog/entrypoint.ts"
 import entrypointEval from "@iso-bfc/Query/EntrypointEval/entrypoint.ts"
 import entrypointHome from "@iso-bfc/Query/EntrypointHome/entrypoint.ts"
 import entrypointLogin from "@iso-bfc/Query/EntrypointLogin/entrypoint.ts"
 import entrypointRlhf from "@iso-bfc/Query/EntrypointRlhf/entrypoint.ts"
 import joinWaitlist from "@iso-bfc/Mutation/JoinWaitlist/entrypoint.ts"
 
+export {entrypointBlog};
 export {entrypointEval};
 export {entrypointHome};
 export {entrypointLogin};

--- a/apps/boltfoundry-com/__tests__/e2e/blog.test.e2e.ts
+++ b/apps/boltfoundry-com/__tests__/e2e/blog.test.e2e.ts
@@ -1,0 +1,242 @@
+import { assert } from "@std/assert";
+import {
+  navigateTo,
+  teardownE2ETest,
+} from "@bfmono/infra/testing/e2e/setup.ts";
+import { getLogger } from "@bfmono/packages/logger/logger.ts";
+import { setupBoltFoundryComTest } from "../helpers.ts";
+
+const logger = getLogger(import.meta);
+
+Deno.test("Blog page loads successfully", async () => {
+  const context = await setupBoltFoundryComTest();
+
+  try {
+    // Start video recording
+    const stopRecording = await context.startAnnotatedVideoRecording(
+      "blog-page-demo",
+    );
+
+    // Navigate to the blog page
+    await navigateTo(context, "/blog");
+
+    // Wait for content to load
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+
+    // Basic assertions to verify the page loaded
+    const title = await context.page.title();
+    logger.info("Page title:", title);
+
+    // Verify we're on the blog page (title should include 'Blog' or be 'Bolt Foundry')
+    assert(
+      title.includes("Blog") || title === "Bolt Foundry",
+      `Expected title to include 'Blog' or be 'Bolt Foundry', got: ${title}`,
+    );
+
+    // Verify the page content is present
+    const pageContent = await context.page.evaluate(() =>
+      document.body.textContent
+    );
+    assert(pageContent, "Page should have content");
+
+    // Check if the blog header is present
+    const hasBlogHeader = pageContent.includes("Blog Posts");
+    assert(hasBlogHeader, "Blog page should have 'Blog Posts' header");
+
+    // Check if blog navigation is active
+    const blogNavActive = await context.page.evaluate(() => {
+      const blogButton = Array.from(document.querySelectorAll("button, a"))
+        .find((el) => el.textContent?.trim() === "Blog");
+      return blogButton?.classList.contains("bf-ds-button--primary") || false;
+    });
+    logger.info("Blog navigation active:", blogNavActive);
+
+    // Check if blog posts are loaded
+    const blogPosts = await context.page.evaluate(() => {
+      const articles = document.querySelectorAll("article.blog-post-preview");
+      return articles.length;
+    });
+    logger.info("Number of blog posts found:", blogPosts);
+    assert(blogPosts > 0, "Should have at least one blog post");
+
+    // Check if blog post elements have correct structure
+    const firstPostDetails = await context.page.evaluate(() => {
+      const firstPost = document.querySelector("article.blog-post-preview");
+      if (!firstPost) return null;
+
+      const title = firstPost.querySelector("h2")?.textContent;
+      const metadata = firstPost.querySelector(".metadata")?.textContent;
+      const excerpt = firstPost.querySelector("p")?.textContent;
+      const readMoreLink = firstPost.querySelector("a[href^='/blog/']");
+
+      return {
+        hasTitle: !!title,
+        hasMetadata: !!metadata,
+        hasExcerpt: !!excerpt,
+        hasReadMoreLink: !!readMoreLink,
+        title,
+      };
+    });
+
+    logger.info("First post details:", firstPostDetails);
+    assert(firstPostDetails, "Should have first post details");
+    assert(firstPostDetails.hasTitle, "Blog post should have title");
+    assert(firstPostDetails.hasMetadata, "Blog post should have metadata");
+    assert(
+      firstPostDetails.hasReadMoreLink,
+      "Blog post should have read more link",
+    );
+
+    // Check if blog CSS is loaded
+    const blogStylesLoaded = await context.page.evaluate(() => {
+      const blogMain = document.querySelector(".blog-main");
+      if (!blogMain) return false;
+
+      const styles = globalThis.getComputedStyle(blogMain);
+      // Check if blog styles are applied (not default values)
+      return styles.padding !== "0px" || styles.margin !== "0px";
+    });
+    logger.info("Blog styles loaded:", blogStylesLoaded);
+
+    // Take a screenshot for comparison
+    await context.takeScreenshot("blog-page-loaded");
+
+    // Stop video recording
+    const videoResult = await stopRecording.stop();
+    if (videoResult) {
+      logger.info("Video recorded:", videoResult.videoPath);
+    }
+
+    logger.info("Blog page loaded successfully");
+  } finally {
+    await teardownE2ETest(context);
+  }
+});
+
+Deno.test("Blog navigation from homepage works", async () => {
+  const context = await setupBoltFoundryComTest();
+
+  try {
+    // Start video recording
+    const stopRecording = await context.startAnnotatedVideoRecording(
+      "blog-navigation-demo",
+    );
+
+    // Start at homepage
+    await navigateTo(context, "/");
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    // Click on Blog navigation button
+    await context.page.evaluate(() => {
+      const blogButton = Array.from(document.querySelectorAll("button, a"))
+        .find((el) => el.textContent?.trim() === "Blog");
+      if (blogButton instanceof HTMLElement) {
+        blogButton.click();
+      }
+    });
+
+    // Wait for navigation
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    // Verify we're on the blog page
+    const url = context.page.url();
+    assert(url.endsWith("/blog"), `Should navigate to /blog, got ${url}`);
+
+    // Verify blog content loaded
+    const hasBlogContent = await context.page.evaluate(() => {
+      const blogHeader = document.body.textContent?.includes("Blog Posts");
+      const articles = document.querySelectorAll("article.blog-post-preview");
+      return blogHeader && articles.length > 0;
+    });
+    assert(hasBlogContent, "Blog page should load after navigation");
+
+    // Take a screenshot of the blog page after navigation
+    await context.takeScreenshot("blog-navigation-success");
+
+    // Stop video recording
+    const videoResult = await stopRecording.stop();
+    if (videoResult) {
+      logger.info("Video recorded:", videoResult.videoPath);
+    }
+
+    logger.info("Blog navigation successful");
+  } finally {
+    await teardownE2ETest(context);
+  }
+});
+
+Deno.test("Blog post links navigate to individual post pages", async () => {
+  const context = await setupBoltFoundryComTest();
+
+  try {
+    // Start video recording for the link test
+    const stopRecording = await context.startAnnotatedVideoRecording(
+      "blog-links-demo",
+    );
+
+    // Navigate to the blog page
+    await navigateTo(context, "/blog");
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+
+    // Take screenshot of blog list
+    await context.takeScreenshot("blog-links-initial");
+
+    // Check all blog post links
+    const postLinks = await context.page.evaluate(() => {
+      const links = Array.from(
+        document.querySelectorAll("article a[href^='/blog/']"),
+      );
+      return links.map((link) => ({
+        href: link.getAttribute("href"),
+        text: link.textContent,
+      }));
+    });
+
+    logger.info("Found blog post links:", postLinks);
+    assert(postLinks.length > 0, "Should have blog post links");
+
+    // Verify each link has proper format
+    for (const link of postLinks) {
+      assert(link.href?.startsWith("/blog/"), "Links should start with /blog/");
+      assert(
+        link.href && link.href.length > 6,
+        "Links should have slug after /blog/",
+      );
+    }
+
+    // Check that clicking a blog post link shows coming soon message
+    if (postLinks.length > 0) {
+      await context.page.click(`a[href="${postLinks[0].href}"]`);
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+
+      // Take screenshot of individual blog post page
+      await context.takeScreenshot("blog-individual-post");
+
+      // Wait for the page to load after navigation
+      await context.page.waitForSelector(".blog-layout", { timeout: 5000 });
+
+      // Verify we're on a blog post page
+      const currentUrl = context.page.url();
+      assert(
+        currentUrl.includes("/blog/") && !currentUrl.endsWith("/blog/"),
+        `Should navigate to individual blog post URL. Current URL: ${currentUrl}`,
+      );
+
+      // Just verify the blog layout exists (content will be implemented later)
+      const hasBlogLayout = await context.page.evaluate(() => {
+        return document.querySelector(".blog-layout") !== null;
+      });
+      assert(hasBlogLayout, "Should have blog layout on individual post page");
+    }
+
+    // Stop video recording
+    const videoResult = await stopRecording.stop();
+    if (videoResult) {
+      logger.info("Video recorded:", videoResult.videoPath);
+    }
+
+    logger.info("Blog post links properly formatted");
+  } finally {
+    await teardownE2ETest(context);
+  }
+});

--- a/apps/boltfoundry-com/components/Blog.tsx
+++ b/apps/boltfoundry-com/components/Blog.tsx
@@ -1,0 +1,75 @@
+import { iso } from "@iso-bfc";
+import { getLogger } from "@bfmono/packages/logger/logger.ts";
+import { BfDsButton } from "@bfmono/apps/bfDs/components/BfDsButton.tsx";
+import { Nav } from "./Nav.tsx";
+
+const _logger = getLogger(import.meta);
+
+// Main Blog component that switches between list and single post
+export const Blog = iso(`
+  field Query.Blog @component {
+    blogPosts(first: 10) {
+      BlogPostList
+    }
+  }
+`)(function Blog({ data, parameters = {} }) {
+  const hasSlug = Boolean(parameters?.slug);
+
+  // If data is not available, show loading
+  if (!data) {
+    return (
+      <div className="landing-page">
+        <Nav page="blog" />
+        <section className="docs-section">
+          <div className="landing-content">
+            <div className="blog-layout">
+              <div>Loading...</div>
+            </div>
+          </div>
+        </section>
+      </div>
+    );
+  }
+
+  return (
+    <div className="landing-page">
+      {/* Header */}
+      <Nav page="blog" />
+      {/* Blog Content */}
+      <section className="docs-section">
+        <div className="landing-content">
+          <div className="blog-layout">
+            {hasSlug
+              ? <div>Individual blog posts coming soon...</div>
+              : (data.blogPosts
+                ? <data.blogPosts.BlogPostList />
+                : <div>Loading blog posts...</div>)}
+          </div>
+        </div>
+        <div className="landing-footer">
+          <div className="landing-content flexRow gapMedium alignItemsCenter">
+            <div className="flex1">
+              &copy; 2025 Bolt Foundry. All rights reserved.
+            </div>
+            <BfDsButton
+              size="small"
+              variant="ghost"
+              icon="brand-discord"
+              iconOnly
+              href="https://discord.gg/tU5ksTBfEj"
+              target="_blank"
+            />
+            <BfDsButton
+              size="small"
+              variant="ghost"
+              icon="brand-github"
+              iconOnly
+              href="https://github.com/bolt-foundry/bolt-foundry"
+              target="_blank"
+            />
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+});

--- a/apps/boltfoundry-com/components/BlogPostList.tsx
+++ b/apps/boltfoundry-com/components/BlogPostList.tsx
@@ -1,0 +1,125 @@
+import { iso } from "@iso-bfc";
+import { BfDsButton } from "@bfmono/apps/bfDs/components/BfDsButton.tsx";
+import { BfDsPill } from "@bfmono/apps/bfDs/components/BfDsPill.tsx";
+import { blogMetadata } from "../lib/blogHelper.ts";
+
+// Blog list component for QueryBlogPostsConnection
+export const BlogPostList = iso(`
+  field QueryBlogPostsConnection.BlogPostList @component {
+    edges {
+      cursor
+      node {
+        id
+        author
+        publishedAt
+        excerpt
+        tags
+        title
+        heroImage
+      }
+    }
+    pageInfo {
+      hasNextPage
+      hasPreviousPage
+      startCursor
+      endCursor
+    }
+  }
+`)(function BlogPostList({ data }) {
+  if (!data || !data.edges) {
+    return <div>No blog posts found.</div>;
+  }
+
+  const connection = data;
+  const edges = connection.edges!; // Non-null assertion since we checked above
+
+  return (
+    <main className="blog-main">
+      <div className="blog-list">
+        <h1>Blog Posts</h1>
+        <div className="blog-posts">
+          {edges.map((edge) => {
+            if (!edge || !edge.node) return null;
+            const {
+              id,
+              author,
+              publishedAt,
+              excerpt,
+              tags,
+              title,
+              heroImage,
+            } = edge.node;
+
+            const metadata = blogMetadata(author, publishedAt);
+            const previewImage = heroImage;
+            const tagsArray = tags ? JSON.parse(tags) : [];
+            const renderTags = tagsArray.map((tag: string) => (
+              <BfDsPill
+                variant="primary"
+                text={tag}
+                key={tag}
+              />
+            ));
+
+            return (
+              <article
+                key={edge.cursor}
+                className="blog-post-preview paper"
+                style={{
+                  marginBottom: "2rem",
+                }}
+              >
+                <div className="rowReverse-column gapLarge">
+                  {previewImage && (
+                    <img
+                      className="blog-list-hero-image"
+                      src={previewImage}
+                      alt={title}
+                    />
+                  )}
+                  <div className="flex1">
+                    <h2 style={{ marginTop: 0 }}>
+                      <a
+                        href={`/blog/${id}`}
+                        style={{ color: "inherit", textDecoration: "none" }}
+                      >
+                        {title}
+                      </a>
+                    </h2>
+                    {(metadata || renderTags.length > 0) && (
+                      <div className="metadata flexRow gapMedium flexWrap">
+                        {metadata ?? ""}
+                        {renderTags}
+                      </div>
+                    )}
+                    {excerpt && (
+                      <p style={{ marginTop: "1rem" }}>
+                        {excerpt}
+                      </p>
+                    )}
+                    <a
+                      href={`/blog/${id}`}
+                      style={{ color: "var(--link)", textDecoration: "none" }}
+                    >
+                      Read more →
+                    </a>
+                  </div>
+                </div>
+              </article>
+            );
+          })}
+        </div>
+        {connection.pageInfo.hasNextPage && (
+          <div style={{ marginTop: "2rem" }}>
+            <BfDsButton
+              variant="primary"
+              disabled
+            >
+              Load more posts
+            </BfDsButton>
+          </div>
+        )}
+      </div>
+    </main>
+  );
+});

--- a/apps/boltfoundry-com/components/BlogPostView.tsx
+++ b/apps/boltfoundry-com/components/BlogPostView.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useRef } from "react";
+import { iso } from "@iso-bfc";
+import { marked, Renderer } from "marked";
+import { blogMetadata } from "../lib/blogHelper.ts";
+import { BfDsPill } from "@bfmono/apps/bfDs/components/BfDsPill.tsx";
+
+// Single blog post view component
+export const BlogPostView = iso(`
+  field BlogPost.BlogPostView @component {
+    id
+    content
+    author
+    publishedAt
+    tags
+    title
+    heroImage
+  }
+`)(function BlogPostView({ data }) {
+  const docRef = useRef<HTMLDivElement>(null);
+
+  if (!data) {
+    return <div>Blog post not found</div>;
+  }
+
+  const blogPost = data;
+
+  // Convert markdown to HTML
+  const renderer = new Renderer();
+  renderer.table = function (
+    token: {
+      header: Array<{ text: string }>;
+      rows: Array<Array<{ text: string }>>;
+    },
+  ) {
+    const headerHtml = token.header.map((cell) => `<th>${cell.text}</th>`).join(
+      "",
+    );
+    const rowsHtml = token.rows.map((row) =>
+      `<tr>${row.map((cell) => `<td>${cell.text}</td>`).join("")}</tr>`
+    ).join("");
+    return `<div class="table-wrapper"><table><thead><tr>${headerHtml}</tr></thead><tbody>${rowsHtml}</tbody></table></div>`;
+  };
+
+  // Add IDs to headings for anchor links
+  const metadata = blogMetadata(
+    blogPost.author,
+    blogPost.publishedAt,
+  );
+  const tagsArray = blogPost.tags ? JSON.parse(blogPost.tags) : [];
+
+  // Use the hero image from GraphQL for hero display
+  const heroImage = blogPost.heroImage;
+  let firstImageSkipped = false;
+
+  let firstH1Skipped = false;
+  // Skip first image from content since we'll display it as hero
+  renderer.image = function (
+    token: { href: string; title: string | null; text: string },
+  ) {
+    // Skip the first image in content since we'll display it as hero
+    if (token.href === heroImage && !firstImageSkipped) {
+      firstImageSkipped = true;
+      return "";
+    }
+
+    // For subsequent images, render normally
+    const titleAttr = token.title ? ` title="${token.title}"` : "";
+    return `<img class="blog-post-image" src="${token.href}" alt="${token.text}"${titleAttr} />`;
+  };
+
+  renderer.heading = function (
+    token: { tokens: Array<{ text?: string; raw?: string }>; depth: number },
+  ) {
+    const text = token.tokens.map((t) => t.text || t.raw || "").join("");
+    // Skip the first h1 heading since we'll display the title separately
+    if (token.depth === 1 && !firstH1Skipped) {
+      firstH1Skipped = true;
+      return "";
+    }
+    const id = text
+      .toLowerCase()
+      .replace(/[^\w\s-]/g, "") // Remove special characters except spaces and hyphens
+      .replace(/\s+/g, "-") // Replace spaces with hyphens
+      .replace(/-+/g, "-") // Replace multiple hyphens with single hyphen
+      .trim();
+
+    return `<h${token.depth} id="${id}">${text}</h${token.depth}>`;
+  };
+
+  // Make external links open in new tab
+  renderer.link = function ({ href, title, tokens }: {
+    href: string;
+    title?: string | null;
+    tokens: Array<{ text?: string; raw?: string }>;
+  }) {
+    const text = tokens.map((t) => t.text || t.raw || "").join("");
+    const isExternal = href.startsWith("http://") ||
+      href.startsWith("https://");
+    const titleAttr = title ? ` title="${title}"` : "";
+    const target = isExternal
+      ? ' target="_blank" rel="noopener noreferrer"'
+      : "";
+
+    return `<a href="${href}"${titleAttr}${target}>${text}</a>`;
+  };
+
+  const htmlContent = marked(blogPost.content, { renderer }) as string;
+
+  // Handle anchor link clicks
+  useEffect(() => {
+    const handleAnchorClick = (event: Event) => {
+      const target = event.target as HTMLAnchorElement;
+      if (target.tagName === "A" && target.href.includes("#")) {
+        const hash = target.getAttribute("href");
+        if (hash?.startsWith("#")) {
+          event.preventDefault();
+          const element = document.getElementById(hash.substring(1));
+          if (element) {
+            element.scrollIntoView({ behavior: "smooth" });
+          }
+        }
+      }
+    };
+
+    if (docRef.current) {
+      docRef.current.addEventListener("click", handleAnchorClick);
+      return () => {
+        docRef.current?.removeEventListener("click", handleAnchorClick);
+      };
+    }
+  }, [htmlContent]);
+
+  return (
+    <main className="blog-main paper">
+      <article ref={docRef} className="prose prose-lg">
+        {heroImage && (
+          <img
+            className="blog-post-hero-image"
+            src={heroImage}
+            alt={blogPost.title}
+          />
+        )}
+        <h1 style={{ marginTop: 0 }}>{blogPost.title}</h1>
+        {(metadata || tagsArray.length > 0) && (
+          <div
+            className="metadata flexRow gapMedium flexWrap"
+            style={{ marginBottom: "2rem" }}
+          >
+            {metadata ?? ""}
+            {tagsArray.map((tag: string) => (
+              <BfDsPill
+                key={tag}
+                variant="primary"
+                text={tag}
+              />
+            ))}
+          </div>
+        )}
+        <div dangerouslySetInnerHTML={{ __html: htmlContent }} />
+      </article>
+    </main>
+  );
+});

--- a/apps/boltfoundry-com/components/Nav.tsx
+++ b/apps/boltfoundry-com/components/Nav.tsx
@@ -45,8 +45,7 @@ export function Nav({ page, onSidebarToggle, sidebarOpen }: Props) {
             icon="home"
           />
         )}
-        {
-          /* <BfDsButton
+        <BfDsButton
           variant={page === "blog" ? "primary" : "outline"}
           overlay={page !== "blog"}
           href="/blog"
@@ -54,7 +53,8 @@ export function Nav({ page, onSidebarToggle, sidebarOpen }: Props) {
         >
           Blog
         </BfDsButton>
-        <BfDsButton
+        {
+          /* <BfDsButton
           variant={page === "docs" ? "primary" : "outline"}
           overlay={page !== "docs"}
           href="/docs"

--- a/apps/boltfoundry-com/components/blog.css
+++ b/apps/boltfoundry-com/components/blog.css
@@ -1,0 +1,64 @@
+/* Blog styles for boltfoundry-com */
+
+.blog-layout {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+.blog-main {
+  padding: 1rem;
+}
+
+.blog-list h1 {
+  margin-bottom: 2rem;
+}
+
+.blog-posts {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.blog-post-preview {
+  background: var(--color-surface);
+  border-radius: 8px;
+  padding: 2rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: box-shadow 0.2s ease;
+}
+
+.blog-post-preview:hover {
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+.blog-post-preview h2 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+.blog-post-preview .metadata {
+  color: var(--color-text-secondary);
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+}
+
+.blog-post-preview p {
+  margin: 1rem 0;
+  color: var(--color-text);
+}
+
+.blog-list-hero-image {
+  width: 300px;
+  height: 200px;
+  object-fit: cover;
+  border-radius: 4px;
+}
+
+@media (max-width: 768px) {
+  .blog-list-hero-image {
+    width: 100%;
+    height: auto;
+    max-height: 200px;
+  }
+}

--- a/apps/boltfoundry-com/entrypoints/EntrypointBlog.ts
+++ b/apps/boltfoundry-com/entrypoints/EntrypointBlog.ts
@@ -1,0 +1,14 @@
+import { iso } from "@iso-bfc";
+import { getLogger } from "@bfmono/packages/logger/logger.ts";
+
+const _logger = getLogger(import.meta);
+
+export const EntrypointBlog = iso(`
+  field Query.EntrypointBlog {
+    Blog
+  }
+`)(function EntrypointBlog({ data }) {
+  const Body = data.Blog;
+  const title = "Blog";
+  return { Body, title };
+});

--- a/apps/boltfoundry-com/lib/blogHelper.ts
+++ b/apps/boltfoundry-com/lib/blogHelper.ts
@@ -1,0 +1,13 @@
+export function blogMetadata(
+  author: string | null,
+  publishedAt: string | null,
+): string {
+  const authorText = author ? `By ${author}` : "Someone";
+  const date = publishedAt && new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  }).format(new Date(publishedAt));
+  const publishedAtText = date ? `on ${date}` : "Published at an unknown date";
+  return `${authorText} ${publishedAtText}`;
+}

--- a/apps/boltfoundry-com/routes.ts
+++ b/apps/boltfoundry-com/routes.ts
@@ -2,6 +2,7 @@ import { Plinko } from "./components/plinko/Plinko.tsx";
 import { UIDemo } from "./components/UIDemo.tsx";
 import type { BfIsographEntrypoint } from "./lib/BfIsographEntrypoint.ts";
 import {
+  entrypointBlog,
   entrypointEval,
   entrypointHome,
   entrypointLogin,
@@ -31,4 +32,7 @@ export const isographAppRoutes = new Map<string, IsographRoute>([
   ["/login", entrypointLogin],
   ["/rlhf", entrypointRlhf],
   ["/eval", entrypointEval],
+  ["/blog", entrypointBlog],
+  ["/blog/", entrypointBlog],
+  ["/blog/:slug", entrypointBlog],
 ]);

--- a/apps/boltfoundry-com/styles/index.ts
+++ b/apps/boltfoundry-com/styles/index.ts
@@ -7,5 +7,6 @@ import "@bfmono/static/landingStyle.css";
 import "../components/WaitlistSection.css";
 import "@bfmono/static/evalStyle.css";
 import "../components/plinko/plinko.css";
+import "@bfmono/static/blogStyle.css";
 
 // Add any future CSS imports here

--- a/apps/boltfoundry-com/styles/index.ts
+++ b/apps/boltfoundry-com/styles/index.ts
@@ -8,5 +8,6 @@ import "../components/WaitlistSection.css";
 import "@bfmono/static/evalStyle.css";
 import "../components/plinko/plinko.css";
 import "@bfmono/static/blogStyle.css";
+import "../components/blog.css";
 
 // Add any future CSS imports here

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -2,7 +2,7 @@
   "unstable": ["temporal", "webgpu", "net"],
   "nodeModulesDir": "auto",
   "imports": {
-    "@anthropic-ai/claude-code": "npm:@anthropic-ai/claude-code@^1.0.62",
+    "@anthropic-ai/claude-code": "npm:@anthropic-ai/claude-code@^1.0.64",
     "@bfmono/": "./",
     "@bolt-foundry/bolt-foundry": "./packages/bolt-foundry/bolt-foundry.ts",
     "@bolt-foundry/bolt-foundry/": "./packages/bolt-foundry/",

--- a/deno.lock
+++ b/deno.lock
@@ -66,8 +66,8 @@
     "jsr:@std/yaml@^1.0.5": "1.0.8",
     "jsr:@ts-morph/bootstrap@0.24": "0.24.0",
     "jsr:@ts-morph/common@0.24": "0.24.0",
-    "npm:@anthropic-ai/claude-code@*": "1.0.62",
-    "npm:@anthropic-ai/claude-code@^1.0.62": "1.0.62",
+    "npm:@anthropic-ai/claude-code@*": "1.0.64",
+    "npm:@anthropic-ai/claude-code@^1.0.64": "1.0.64",
     "npm:@babel/preset-react@^7.25.7": "7.27.1_@babel+core@7.28.0",
     "npm:@deno/vite-plugin@^1.0.4": "1.0.5_vite@6.3.5__picomatch@4.0.2_@types+node@22.15.15",
     "npm:@graphql-tools/schema@^10.0.6": "10.0.23_graphql@16.11.0",
@@ -385,8 +385,8 @@
         "@jridgewell/trace-mapping"
       ]
     },
-    "@anthropic-ai/claude-code@1.0.62": {
-      "integrity": "sha512-uWjIvjtOudC/knp7QMJhICdIcvEP8Nuz+0Rj3DeZc5eYyHgtiYTsb5mVTou2P7OTsCfwc3ajFdbFbtyq/LwYSw==",
+    "@anthropic-ai/claude-code@1.0.64": {
+      "integrity": "sha512-AI3Q/50+znj80gV1Aua4MOGLuOxS4G6m11CmYYyDCFuoVMzskG1aSI5fxAyGol3N5GI4Tuw0YPmANJdZ/MNvhQ==",
       "optionalDependencies": [
         "@img/sharp-darwin-arm64",
         "@img/sharp-darwin-x64",
@@ -3413,7 +3413,7 @@
       "jsr:@std/streams@^1.0.10",
       "jsr:@std/testing@^1.0.9",
       "jsr:@std/toml@^1.0.4",
-      "npm:@anthropic-ai/claude-code@^1.0.62",
+      "npm:@anthropic-ai/claude-code@^1.0.64",
       "npm:@graphql-tools/schema@^10.0.6",
       "npm:@isograph/babel-plugin@~0.3.1",
       "npm:@isograph/react@~0.3.1",

--- a/infra/bft/tasks/dev.bft.ts
+++ b/infra/bft/tasks/dev.bft.ts
@@ -5,7 +5,7 @@ import { ui } from "@bfmono/packages/cli-ui/cli-ui.ts";
 import { parseArgs } from "@std/cli";
 import { getLogger } from "@bolt-foundry/logger";
 
-const _logger = getLogger(import.meta);
+const logger = getLogger(import.meta);
 
 async function dev(args: Array<string>): Promise<number> {
   // Check for global help flag
@@ -226,7 +226,7 @@ Examples:
           }
         }
       } catch (error) {
-        _logger.error("Error piping to log:", error);
+        logger.error("Error piping to log:", error);
       } finally {
         reader.releaseLock();
       }
@@ -316,7 +316,7 @@ Examples:
           }
         }
       } catch (error) {
-        _logger.error("Error piping to log:", error);
+        logger.error("Error piping to log:", error);
       } finally {
         reader.releaseLock();
       }


### PR DESCRIPTION
- Add blog.css with required styles for blog-post-preview elements
- Import blog.css in styles/index.ts
- Fixes failing e2e tests that check for blog post styling

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/1694).
* __->__ #1694
* #1687

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/1694)
<!-- GitContextEnd -->