### PR TITLE
Add Apple container tool support for testing bleeding edge releases

### DIFF
--- a/apps/aibff/commands/render.ts
+++ b/apps/aibff/commands/render.ts
@@ -448,7 +448,7 @@ async function renderDeck(
             unknown
           >,
           ...(tool.function.parameters?.required
-            ? { required: tool.function.parameters.required as string[] }
+            ? { required: tool.function.parameters.required as Array<string> }
             : {}),
         },
       },

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -2,7 +2,7 @@
   "unstable": ["temporal", "webgpu", "net"],
   "nodeModulesDir": "auto",
   "imports": {
-    "@anthropic-ai/claude-code": "npm:@anthropic-ai/claude-code@^1.0.62",
+    "@anthropic-ai/claude-code": "npm:@anthropic-ai/claude-code@^1.0.64",
     "@bfmono/": "./",
     "@bolt-foundry/bolt-foundry": "./packages/bolt-foundry/bolt-foundry.ts",
     "@bolt-foundry/bolt-foundry/": "./packages/bolt-foundry/",

--- a/deno.lock
+++ b/deno.lock
@@ -66,8 +66,8 @@
     "jsr:@std/yaml@^1.0.5": "1.0.8",
     "jsr:@ts-morph/bootstrap@0.24": "0.24.0",
     "jsr:@ts-morph/common@0.24": "0.24.0",
-    "npm:@anthropic-ai/claude-code@*": "1.0.62",
-    "npm:@anthropic-ai/claude-code@^1.0.62": "1.0.62",
+    "npm:@anthropic-ai/claude-code@*": "1.0.64",
+    "npm:@anthropic-ai/claude-code@^1.0.64": "1.0.64",
     "npm:@babel/preset-react@^7.25.7": "7.27.1_@babel+core@7.28.0",
     "npm:@deno/vite-plugin@^1.0.4": "1.0.5_vite@6.3.5__picomatch@4.0.2_@types+node@22.15.15",
     "npm:@graphql-tools/schema@^10.0.6": "10.0.23_graphql@16.11.0",
@@ -385,8 +385,8 @@
         "@jridgewell/trace-mapping"
       ]
     },
-    "@anthropic-ai/claude-code@1.0.62": {
-      "integrity": "sha512-uWjIvjtOudC/knp7QMJhICdIcvEP8Nuz+0Rj3DeZc5eYyHgtiYTsb5mVTou2P7OTsCfwc3ajFdbFbtyq/LwYSw==",
+    "@anthropic-ai/claude-code@1.0.64": {
+      "integrity": "sha512-AI3Q/50+znj80gV1Aua4MOGLuOxS4G6m11CmYYyDCFuoVMzskG1aSI5fxAyGol3N5GI4Tuw0YPmANJdZ/MNvhQ==",
       "optionalDependencies": [
         "@img/sharp-darwin-arm64",
         "@img/sharp-darwin-x64",
@@ -3413,7 +3413,7 @@
       "jsr:@std/streams@^1.0.10",
       "jsr:@std/testing@^1.0.9",
       "jsr:@std/toml@^1.0.4",
-      "npm:@anthropic-ai/claude-code@^1.0.62",
+      "npm:@anthropic-ai/claude-code@^1.0.64",
       "npm:@graphql-tools/schema@^10.0.6",
       "npm:@isograph/babel-plugin@~0.3.1",
       "npm:@isograph/react@~0.3.1",

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,13 @@
         let
           lib = pkgs.lib;
           unstable = import nixpkgs-unstable { inherit system; config.allowUnfree = true; };
+          # Include custom container tool package
+          # To test a different version, set CONTAINER_VERSION environment variable:
+          # CONTAINER_VERSION=0.3.1 nix develop --refresh
+          containerVersion = builtins.getEnv "CONTAINER_VERSION";
+          containerTool = if containerVersion != "" 
+            then pkgs.callPackage ./infra/nix/container-tool-flexible.nix { version = containerVersion; }
+            else pkgs.callPackage ./infra/nix/container-tool.nix {};
         in
         [
           pkgs.unzip
@@ -48,6 +55,9 @@
           pkgs.nettools
           pkgs.ripgrep
           pkgs.fd
+        ] ++ lib.optionals pkgs.stdenv.isDarwin [
+          # Darwin-specific packages  
+          containerTool
         ] ++ lib.optionals (!pkgs.stdenv.isDarwin) [
           # Linux-only packages
           pkgs.chromium

--- a/infra/bft/tasks/dev.bft.ts
+++ b/infra/bft/tasks/dev.bft.ts
@@ -5,7 +5,7 @@ import { ui } from "@bfmono/packages/cli-ui/cli-ui.ts";
 import { parseArgs } from "@std/cli";
 import { getLogger } from "@bolt-foundry/logger";
 
-const _logger = getLogger(import.meta);
+const logger = getLogger(import.meta);
 
 async function dev(args: Array<string>): Promise<number> {
   // Check for global help flag
@@ -226,7 +226,7 @@ Examples:
           }
         }
       } catch (error) {
-        _logger.error("Error piping to log:", error);
+        logger.error("Error piping to log:", error);
       } finally {
         reader.releaseLock();
       }
@@ -316,7 +316,7 @@ Examples:
           }
         }
       } catch (error) {
-        _logger.error("Error piping to log:", error);
+        logger.error("Error piping to log:", error);
       } finally {
         reader.releaseLock();
       }

--- a/infra/nix/QUICK-REFERENCE.md
+++ b/infra/nix/QUICK-REFERENCE.md
@@ -1,0 +1,55 @@
+# Container Tool Quick Reference
+
+## Test Container 0.3.0 (Current Default)
+
+```bash
+nix develop --refresh
+container --version
+bft codebot --force-rebuild
+```
+
+## Add a New Version
+
+```bash
+# 1. Get hash for new version
+./infra/scripts/update-container-version.sh 0.3.1
+
+# 2. Add to infra/nix/container-tool-flexible.nix:
+#    "0.3.1" = "sha256-XXXXX...";
+
+# 3. Test it
+CONTAINER_VERSION=0.3.1 nix develop --refresh
+```
+
+## Switch Between Versions
+
+```bash
+# Use specific version
+CONTAINER_VERSION=0.3.1 nix develop --refresh
+
+# Back to default
+unset CONTAINER_VERSION
+nix develop
+```
+
+## Files to Know
+
+- `container-tool.nix` - Default version config (in this directory)
+- `container-tool-flexible.nix` - Multi-version support (in this directory)
+- `../scripts/update-container-version.sh` - Hash generator
+
+## Common Commands
+
+```bash
+# Check current version
+container --version
+
+# Where is container installed?
+which container
+
+# Force rebuild codebot with new container
+bft codebot --force-rebuild
+
+# Clean nix cache if needed
+nix develop --refresh --impure
+```

--- a/infra/nix/README.md
+++ b/infra/nix/README.md
@@ -1,0 +1,184 @@
+# Testing Bleeding Edge Apple Container Releases
+
+This guide explains how to test new Apple container tool releases before they're
+available in nixpkgs.
+
+## Quick Start
+
+To use container 0.3.0 (already configured):
+
+```bash
+# Refresh your nix environment to get container 0.3.0
+nix develop --refresh
+
+# Verify installation
+which container
+container --version
+
+# Test with bft codebot
+bft codebot --force-rebuild
+```
+
+## How It Works
+
+We've set up a nix package that downloads and installs pre-built container
+releases directly from GitHub. The system is designed to be flexible and easy to
+update.
+
+### File Structure
+
+```
+infra/nix/
+├── README.md                        # This documentation
+├── QUICK-REFERENCE.md               # Quick command reference
+├── container-tool.nix               # Default container 0.3.0 package
+├── container-tool-flexible.nix      # Flexible multi-version package
+└── ../scripts/
+    └── update-container-version.sh  # Helper to add new versions
+```
+
+## Adding New Container Versions
+
+When a new container release is available (e.g., 0.3.1):
+
+### Step 1: Get the Version Hash
+
+```bash
+# Run the update script with the new version number
+./infra/scripts/update-container-version.sh 0.3.1
+```
+
+This will output something like:
+
+```
+Version: 0.3.1
+SHA256: sha256-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+Add this to infra/nix/container-tool-flexible.nix:
+    "0.3.1" = "sha256-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+```
+
+### Step 2: Update the Flexible Package
+
+Edit `container-tool-flexible.nix` (in this directory) and add the new version
+to the `versionHashes` map:
+
+```nix
+versionHashes = {
+  "0.3.0" = "sha256-D3oAhATmZhGA6mehw6UEAY5Xwu8jjvTNqNcPKBUWxuY=";
+  "0.3.1" = "sha256-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";  # Add this line
+};
+```
+
+### Step 3: Test the New Version
+
+```bash
+# Test with the new version using environment variable
+CONTAINER_VERSION=0.3.1 nix develop --refresh
+
+# Verify it's using the new version
+container --version
+```
+
+## Testing Different Versions
+
+You can switch between container versions without modifying any files:
+
+```bash
+# Use default version (0.3.0)
+nix develop
+
+# Use a specific version (must be in versionHashes)
+CONTAINER_VERSION=0.3.1 nix develop --refresh
+
+# Go back to default
+unset CONTAINER_VERSION
+nix develop
+```
+
+## Making a Version the Default
+
+To make a new version the default for everyone:
+
+1. Update `container-tool.nix` (in this directory) with the new version:
+   ```nix
+   version = "0.3.1";  # Changed from 0.3.0
+   ```
+
+2. Make sure the hash is correct in that file
+
+3. Commit the change
+
+## Troubleshooting
+
+### "Unknown container version" Error
+
+If you see this error, it means the version hash hasn't been added to
+`container-tool-flexible.nix`. Follow the "Adding New Container Versions" steps
+above.
+
+### Container Command Not Found
+
+Make sure you're in the nix develop shell:
+
+```bash
+nix develop --refresh
+which container  # Should show a nix store path
+```
+
+### Old Version Still Being Used
+
+The nix environment might be cached. Force a refresh:
+
+```bash
+nix develop --refresh --impure
+```
+
+### Hash Mismatch Error
+
+If you get a hash mismatch error, the download might have failed or the file
+might be corrupted. Re-run the update script to get the correct hash.
+
+## Implementation Details
+
+The system works by:
+
+1. Downloading the official `.pkg` installer from GitHub releases
+2. Extracting the binary using `xar` and `cpio`
+3. Installing it into the nix store
+4. Making it available in your development environment
+
+The flexible system allows testing multiple versions through the
+`CONTAINER_VERSION` environment variable, while the default package ensures
+everyone gets a stable version.
+
+## Best Practices
+
+1. **Test First**: Always test new versions with `CONTAINER_VERSION` before
+   making them default
+2. **Document Changes**: When updating the default version, mention it in your
+   commit message
+3. **Keep Old Versions**: Don't remove old version hashes - they're useful for
+   debugging
+4. **Verify Functionality**: After installing a new version, test core
+   functionality with `bft codebot`
+
+## Example Workflow
+
+Here's a complete example of testing container 0.3.1 when it's released:
+
+```bash
+# 1. Add the new version
+./infra/scripts/update-container-version.sh 0.3.1
+
+# 2. Edit infra/nix/container-tool-flexible.nix and add the hash
+
+# 3. Test the new version
+CONTAINER_VERSION=0.3.1 nix develop --refresh
+
+# 4. Verify it works
+container --version
+bft codebot --force-rebuild
+
+# 5. If everything works, optionally make it default by updating container-tool.nix
+```

--- a/infra/nix/container-tool-flexible.nix
+++ b/infra/nix/container-tool-flexible.nix
@@ -1,0 +1,46 @@
+# Flexible container tool package that can be overridden with different versions
+# Usage in flake.nix:
+#   containerTool = pkgs.callPackage ./infra/nix/container-tool-flexible.nix {
+#     version = "0.3.0";  # or any other version
+#   };
+
+{ pkgs, lib, stdenv, fetchurl, version ? "0.3.0" }:
+
+let
+  # Map of known versions to their hashes
+  versionHashes = {
+    "0.3.0" = "sha256-D3oAhATmZhGA6mehw6UEAY5Xwu8jjvTNqNcPKBUWxuY=";
+    # Add more versions here as they're released
+  };
+
+  sha256 = versionHashes.${version} or (throw "Unknown container version: ${version}. Please add the hash to versionHashes.");
+in
+stdenv.mkDerivation rec {
+  pname = "apple-container";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/apple/container/releases/download/${version}/container-${version}-installer-signed.pkg";
+    inherit sha256;
+  };
+
+  nativeBuildInputs = [ pkgs.xar pkgs.cpio ];
+
+  unpackPhase = ''
+    xar -xf $src
+    cd com.apple.pkg.container
+    cat Payload | gunzip -dc | cpio -i
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+    cp -R usr/* $out/
+  '';
+
+  meta = with lib; {
+    description = "Apple's container runtime (version ${version})";
+    homepage = "https://github.com/apple/container";
+    license = licenses.asl20;
+    platforms = [ "aarch64-darwin" "x86_64-darwin" ];
+  };
+}

--- a/infra/nix/container-tool.nix
+++ b/infra/nix/container-tool.nix
@@ -1,0 +1,31 @@
+{ pkgs, lib, stdenv, fetchurl, undmg }:
+
+stdenv.mkDerivation rec {
+  pname = "apple-container";
+  version = "0.3.0";
+
+  src = fetchurl {
+    url = "https://github.com/apple/container/releases/download/${version}/container-${version}-installer-signed.pkg";
+    sha256 = "sha256-D3oAhATmZhGA6mehw6UEAY5Xwu8jjvTNqNcPKBUWxuY=";
+  };
+
+  nativeBuildInputs = [ pkgs.xar pkgs.cpio ];
+
+  unpackPhase = ''
+    xar -xf $src
+    cat Payload | gunzip -dc | cpio -i
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+    cp -R bin $out/
+    cp -R libexec $out/
+  '';
+
+  meta = with lib; {
+    description = "Apple's container runtime";
+    homepage = "https://github.com/apple/container";
+    license = licenses.asl20;
+    platforms = [ "aarch64-darwin" "x86_64-darwin" ];
+  };
+}

--- a/infra/scripts/build-container-tool.sh
+++ b/infra/scripts/build-container-tool.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Script to build Apple container tool from source
+
+set -euo pipefail
+
+VERSION=${1:-0.3.0}
+BUILD_DIR="/tmp/container-build"
+
+echo "Building Apple container tool version $VERSION..."
+
+# Clone the repository
+if [ -d "$BUILD_DIR" ]; then
+    rm -rf "$BUILD_DIR"
+fi
+
+git clone --depth 1 --branch "$VERSION" https://github.com/apple/container.git "$BUILD_DIR"
+cd "$BUILD_DIR"
+
+# Build using Swift
+swift build -c release
+
+# Copy binary to local bin
+mkdir -p ~/bin
+cp .build/release/container ~/bin/container-$VERSION
+
+echo "Container tool built and installed to ~/bin/container-$VERSION"
+echo "Add ~/bin to your PATH or alias container=~/bin/container-$VERSION"

--- a/infra/scripts/update-container-version.sh
+++ b/infra/scripts/update-container-version.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Script to help update container tool version in nix
+
+set -euo pipefail
+
+VERSION=${1:-}
+
+if [ -z "$VERSION" ]; then
+    echo "Usage: $0 <version>"
+    echo "Example: $0 0.3.1"
+    exit 1
+fi
+
+echo "Fetching container version $VERSION..."
+
+# Download the pkg file to get its hash
+URL="https://github.com/apple/container/releases/download/$VERSION/container-$VERSION-installer-signed.pkg"
+TEMP_FILE="/tmp/container-$VERSION.pkg"
+
+echo "Downloading from $URL..."
+if ! curl -L -o "$TEMP_FILE" "$URL"; then
+    echo "Failed to download container $VERSION. Make sure the version exists."
+    exit 1
+fi
+
+# Get the sha256 hash
+HASH=$(nix-hash --type sha256 --flat "$TEMP_FILE")
+NIX_HASH=$(nix hash to-sri --type sha256 "$HASH")
+
+echo ""
+echo "Version: $VERSION"
+echo "SHA256: $NIX_HASH"
+echo ""
+echo "Add this to infra/nix/container-tool-flexible.nix:"
+echo "    \"$VERSION\" = \"$NIX_HASH\";"
+
+# Cleanup
+rm -f "$TEMP_FILE"


### PR DESCRIPTION

Enable testing of Apple container tool releases before they land in nixpkgs by
creating a flexible nix package system. This allows the team to test new container
versions (like 0.3.0) immediately after release without waiting for nixpkgs updates.

Changes:
- Add container-tool.nix package that extracts binaries from official pkg releases
- Create flexible container-tool-flexible.nix with version override support
- Update flake.nix to include container tool in Darwin environments
- Support CONTAINER_VERSION env var for testing different versions
- Add update-container-version.sh script to fetch hashes for new releases
- Create comprehensive documentation in infra/nix/README.md
- Add quick reference guide in infra/nix/QUICK-REFERENCE.md
- Fix Array<T> syntax in render.ts for TypeScript consistency
- Update Claude Code to v1.0.64 in deno.jsonc
- Fix unused logger variable in dev.bft.ts

Test plan:
1. Run 'nix develop --refresh' to install container 0.3.0
2. Verify with 'container --version'
3. Test container functionality with 'bft codebot --force-rebuild'
4. Test version override: 'CONTAINER_VERSION=0.3.0 nix develop --refresh'
5. Run 'bft check && bft lint && bft format' to verify code quality

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
