### PR TITLE
Add automatic workspace folder opening for codebot on macOS

### DIFF
--- a/infra/bft/tasks/codebot.bft.ts
+++ b/infra/bft/tasks/codebot.bft.ts
@@ -937,6 +937,22 @@ FIRST TIME SETUP:
     await Deno.remove(workspacePath, { recursive: true });
   } else {
     ui.output(`📁 Workspace preserved at: ${workspacePath}`);
+
+    // Open the workspace folder in Finder on macOS (only for new workspaces)
+    if (!reusingWorkspace) {
+      try {
+        const openCmd = new Deno.Command("open", {
+          args: [workspacePath],
+          stdout: "null",
+          stderr: "null",
+        });
+        await openCmd.output();
+        ui.output(`📂 Opened workspace folder in Finder`);
+      } catch (error) {
+        // Don't fail if open command fails, just log it
+        logger.debug(`Failed to open workspace folder: ${error}`);
+      }
+    }
   }
   return success ? 0 : 1;
 }


### PR DESCRIPTION
Improve developer workflow by automatically opening the newly created workspace folder
in Finder after the codebot container exits. This saves developers from manually
navigating to the workspace directory to access their files.

Changes:
- Add open command after Claude Code exits for new workspaces
- Only triggers for newly created workspaces (not when reusing with --workspace or --resume)
- Gracefully handles failures without breaking the command flow
- Displays confirmation message when folder is successfully opened

Test plan:
1. Run 'bft codebot' to create a new workspace
2. Exit the container (Ctrl+D or 'exit')
3. Verify the workspace folder automatically opens in Finder
4. Run 'bft codebot --workspace <existing>' and verify folder doesn't open again
5. Check that command still succeeds even if 'open' command fails

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/1710).
* __->__ #1710
* #1708

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/1710)
<!-- GitContextEnd -->