### PR TITLE
Open codebot workspace in Finder immediately on creation

### DIFF
--- a/infra/bft/tasks/codebot.bft.ts
+++ b/infra/bft/tasks/codebot.bft.ts
@@ -488,6 +488,22 @@ FIRST TIME SETUP:
     // Ignore errors if not running in a terminal that supports title updates
   }
 
+  // Open the workspace folder in Finder on macOS immediately after creating/selecting workspace
+  if (!reusingWorkspace) {
+    try {
+      const openCmd = new Deno.Command("open", {
+        args: [workspacePath],
+        stdout: "null",
+        stderr: "null",
+      });
+      await openCmd.output();
+      ui.output(`📂 Opened workspace folder in Finder`);
+    } catch (error) {
+      // Don't fail if open command fails, just log it
+      logger.debug(`Failed to open workspace folder: ${error}`);
+    }
+  }
+
   // Create abort controller for cancelling operations
   const abortController = new AbortController();
 
@@ -937,22 +953,6 @@ FIRST TIME SETUP:
     await Deno.remove(workspacePath, { recursive: true });
   } else {
     ui.output(`📁 Workspace preserved at: ${workspacePath}`);
-
-    // Open the workspace folder in Finder on macOS (only for new workspaces)
-    if (!reusingWorkspace) {
-      try {
-        const openCmd = new Deno.Command("open", {
-          args: [workspacePath],
-          stdout: "null",
-          stderr: "null",
-        });
-        await openCmd.output();
-        ui.output(`📂 Opened workspace folder in Finder`);
-      } catch (error) {
-        // Don't fail if open command fails, just log it
-        logger.debug(`Failed to open workspace folder: ${error}`);
-      }
-    }
   }
   return success ? 0 : 1;
 }


### PR DESCRIPTION
Move the macOS Finder open command to run immediately after workspace creation instead
of after Claude Code exits. This improves the developer experience by having the
workspace folder visible alongside the terminal from the start.

Changes:
- Move workspace folder opening logic to run right after workspace ID is determined
- Remove duplicate code that opened folder at the end of execution
- Maintain the same error handling and logging behavior

Test plan:
1. Run `bft codebot` to create a new workspace
2. Verify Finder window opens immediately showing the workspace folder
3. Confirm the workspace folder is not opened again when exiting Claude Code
4. Test with `bft codebot --workspace existing-name` to verify folder doesn't open for existing workspaces

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/1714)
<!-- GitContextEnd -->