### PR TITLE
Add internalbf-docs to Claude Code workspace permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,9 @@
   },
   "permissions": {
     "defaultMode": "bypassPermissions",
+    "additionalDirectories": [
+      "../@internalbf-docs"
+    ],
     "allow": [
       "Bash(ls:*)",
       "Bash(cat:*)",


### PR DESCRIPTION

Enable Claude Code to access the @internalbf-docs directory located in the parent
directory. This allows AI assistance across both the main monorepo and the
internal documentation repository.

Changes:
- Add ../@internalbf-docs to additionalDirectories in .claude/settings.json
- Maintain existing permission configuration

Test plan:
1. Open Claude Code in the monorepo
2. Attempt to read files from ../@internalbf-docs directory
3. Verify Claude Code can access and read documentation files
4. Ensure no other permissions are affected

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
