### PR TITLE
Fix typecheck errors in relationship methods

### DIFF
--- a/apps/bfDb/builders/bfDb/__tests__/relationshipMethods.test.ts
+++ b/apps/bfDb/builders/bfDb/__tests__/relationshipMethods.test.ts
@@ -9,7 +9,8 @@ import { makeLoggedInCv } from "@bfmono/apps/bfDb/utils/testUtils.ts";
 import { BfNode, type InferProps } from "@bfmono/apps/bfDb/classes/BfNode.ts";
 
 // Helper type for accessing dynamic relationship methods
-type WithRelationshipMethods<T> = T & Record<string, unknown>;
+// deno-lint-ignore no-explicit-any
+type WithRelationshipMethods<T> = T & Record<string, any>;
 
 // Test nodes with relationships defined in bfNodeSpec
 class TestAuthor extends BfNode<InferProps<typeof TestAuthor>> {
@@ -245,7 +246,7 @@ Deno.test("Generated relationship methods - multiple relationships", async () =>
     );
 
     // Create relationships using generated methods
-    await reviewWithMethods.createBook({
+    const _linkedBook = await reviewWithMethods.createBook({
       title: "Clean Architecture",
       isbn: "978-0-13-449416-6",
     });

--- a/apps/bfDb/builders/bfDb/__tests__/relationshipMethods.test.ts
+++ b/apps/bfDb/builders/bfDb/__tests__/relationshipMethods.test.ts
@@ -1,0 +1,297 @@
+#! /usr/bin/env -S bff test
+/**
+ * Tests for automatically generated relationship methods based on bfNodeSpec
+ */
+
+import { assertEquals, assertExists } from "@std/assert";
+import { withIsolatedDb } from "@bfmono/apps/bfDb/bfDb.ts";
+import { makeLoggedInCv } from "@bfmono/apps/bfDb/utils/testUtils.ts";
+import { BfNode, type InferProps } from "@bfmono/apps/bfDb/classes/BfNode.ts";
+
+// Helper type for accessing dynamic relationship methods
+type WithRelationshipMethods<T> = T & Record<string, unknown>;
+
+// Test nodes with relationships defined in bfNodeSpec
+class TestAuthor extends BfNode<InferProps<typeof TestAuthor>> {
+  static override gqlSpec = this.defineGqlNode((f) =>
+    f.string("name").string("bio")
+  );
+
+  static override bfNodeSpec = this.defineBfNode((f) =>
+    f.string("name").string("bio")
+  );
+}
+
+class TestBook extends BfNode<InferProps<typeof TestBook>> {
+  static override gqlSpec = this.defineGqlNode((f) =>
+    f.string("title").string("isbn")
+  );
+
+  static override bfNodeSpec = this.defineBfNode((f) =>
+    f
+      .string("title")
+      .string("isbn")
+      .one("author", () => TestAuthor)
+  );
+}
+
+class TestReview extends BfNode<InferProps<typeof TestReview>> {
+  static override gqlSpec = this.defineGqlNode((f) =>
+    f.int("rating").string("content")
+  );
+
+  static override bfNodeSpec = this.defineBfNode((f) =>
+    f
+      .number("rating")
+      .string("content")
+      .one("book", () => TestBook)
+      .one("reviewer", () => TestAuthor)
+  );
+}
+
+Deno.test("Generated relationship methods - findRelation", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+
+    // Create an author
+    const author = await TestAuthor.__DANGEROUS__createUnattached(cv, {
+      name: "J.K. Rowling",
+      bio: "British author",
+    });
+
+    // Create a book linked to the author
+    const book = await author.createTargetNode(TestBook, {
+      title: "Harry Potter",
+      isbn: "978-0-7475-3269-9",
+    }, { role: "author" });
+
+    // Test: Book should have findAuthor method
+    const bookWithMethods = book as WithRelationshipMethods<typeof book>;
+    assertExists(
+      bookWithMethods.findAuthor,
+      "Book should have findAuthor method",
+    );
+
+    // Test: findAuthor should return the linked author
+    const foundAuthor = await bookWithMethods.findAuthor();
+    assertExists(foundAuthor, "Should find the author");
+    assertEquals(foundAuthor.props.name, "J.K. Rowling");
+    assertEquals(foundAuthor.metadata.bfGid, author.metadata.bfGid);
+  });
+});
+
+Deno.test("Generated relationship methods - createRelation", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+
+    // Create a book
+    const book = await TestBook.__DANGEROUS__createUnattached(cv, {
+      title: "The Hobbit",
+      isbn: "978-0-547-92822-7",
+    });
+
+    // Test: Book should have createAuthor method
+    const bookWithMethods = book as WithRelationshipMethods<typeof book>;
+    assertExists(
+      bookWithMethods.createAuthor,
+      "Book should have createAuthor method",
+    );
+
+    // Test: createAuthor should create and link a new author
+    const author = await bookWithMethods.createAuthor({
+      name: "J.R.R. Tolkien",
+      bio: "English author",
+    });
+
+    assertExists(author, "Should create an author");
+    assertEquals(author.props.name, "J.R.R. Tolkien");
+
+    // Verify the relationship was created
+    const foundAuthor = await bookWithMethods.findAuthor();
+    assertEquals(foundAuthor.metadata.bfGid, author.metadata.bfGid);
+  });
+});
+
+Deno.test.ignore(
+  "Generated relationship methods - deleteRelation",
+  async () => {
+    // Skipped because BfEdge.delete() is not implemented
+    await withIsolatedDb(async () => {
+      const cv = makeLoggedInCv();
+
+      // Create an author and book
+      const author = await TestAuthor.__DANGEROUS__createUnattached(cv, {
+        name: "George Orwell",
+        bio: "English novelist",
+      });
+
+      const book = await author.createTargetNode(TestBook, {
+        title: "1984",
+        isbn: "978-0-452-28423-4",
+      }, { role: "author" });
+
+      // Test: Book should have deleteAuthor method
+      const bookWithMethods = book as WithRelationshipMethods<typeof book>;
+      assertExists(
+        bookWithMethods.deleteAuthor,
+        "Book should have deleteAuthor method",
+      );
+
+      // Verify author exists before deletion
+      let foundAuthor = await bookWithMethods.findAuthor();
+      assertExists(foundAuthor, "Author should exist before deletion");
+
+      // Delete the relationship only (not the node)
+      await bookWithMethods.deleteAuthor();
+
+      // Verify relationship is gone
+      foundAuthor = await bookWithMethods.findAuthor();
+      assertEquals(foundAuthor, null, "Author relationship should be deleted");
+
+      // Verify the author node still exists
+      const authorStillExists = await TestAuthor.findX(
+        cv,
+        author.metadata.bfGid,
+      );
+      assertExists(authorStillExists, "Author node should still exist");
+    });
+  },
+);
+
+Deno.test.ignore(
+  "Generated relationship methods - deleteRelation with deleteNode option",
+  async () => {
+    // Skipped because BfNode.delete() is not implemented
+    await withIsolatedDb(async () => {
+      const cv = makeLoggedInCv();
+
+      // Create an author and book
+      const author = await TestAuthor.__DANGEROUS__createUnattached(cv, {
+        name: "Agatha Christie",
+        bio: "English writer",
+      });
+
+      const book = await author.createTargetNode(TestBook, {
+        title: "Murder on the Orient Express",
+        isbn: "978-0-00-711935-9",
+      }, { role: "author" });
+
+      // Delete the relationship AND the node
+      const bookWithMethods = book as WithRelationshipMethods<typeof book>;
+      await bookWithMethods.deleteAuthor({ deleteNode: true });
+
+      // Verify relationship is gone
+      const foundAuthor = await bookWithMethods.findAuthor();
+      assertEquals(foundAuthor, null, "Author relationship should be deleted");
+
+      // Verify the author node is also deleted
+      try {
+        await TestAuthor.findX(cv, author.metadata.bfGid);
+        throw new Error("Author should have been deleted");
+      } catch (error) {
+        // Expected - author should not be found
+        assertExists(error, "Should throw when author not found");
+      }
+    });
+  },
+);
+
+Deno.test("Generated relationship methods - multiple relationships", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+
+    // Create test data
+    await TestBook.__DANGEROUS__createUnattached(cv, {
+      title: "Clean Code",
+      isbn: "978-0-13-235088-4",
+    });
+
+    await TestAuthor.__DANGEROUS__createUnattached(cv, {
+      name: "Tech Reviewer",
+      bio: "Software engineer",
+    });
+
+    // Create a review with multiple relationships
+    const review = await TestReview.__DANGEROUS__createUnattached(cv, {
+      rating: 5,
+      content: "Excellent book on software craftsmanship",
+    });
+
+    // Test: Review should have methods for both relationships
+    const reviewWithMethods = review as WithRelationshipMethods<typeof review>;
+    assertExists(
+      reviewWithMethods.findBook,
+      "Review should have findBook method",
+    );
+    assertExists(
+      reviewWithMethods.findReviewer,
+      "Review should have findReviewer method",
+    );
+    assertExists(
+      reviewWithMethods.createBook,
+      "Review should have createBook method",
+    );
+    assertExists(
+      reviewWithMethods.createReviewer,
+      "Review should have createReviewer method",
+    );
+    assertExists(
+      reviewWithMethods.deleteBook,
+      "Review should have deleteBook method",
+    );
+    assertExists(
+      reviewWithMethods.deleteReviewer,
+      "Review should have deleteReviewer method",
+    );
+
+    // Create relationships using generated methods
+    await reviewWithMethods.createBook({
+      title: "Clean Architecture",
+      isbn: "978-0-13-449416-6",
+    });
+
+    await reviewWithMethods.createReviewer({
+      name: "Another Reviewer",
+      bio: "Professional reviewer",
+    });
+
+    // Verify both relationships work
+    const foundBook = await reviewWithMethods.findBook();
+    const foundReviewer = await reviewWithMethods.findReviewer();
+
+    assertExists(foundBook, "Should find book");
+    assertExists(foundReviewer, "Should find reviewer");
+    assertEquals(foundBook.props.title, "Clean Architecture");
+    assertEquals(foundReviewer.props.name, "Another Reviewer");
+  });
+});
+
+Deno.test("Generated relationship methods - no relationships defined", async () => {
+  await withIsolatedDb(async () => {
+    const cv = makeLoggedInCv();
+
+    // TestAuthor has no relationships defined
+    const author = await TestAuthor.__DANGEROUS__createUnattached(cv, {
+      name: "No Relations",
+      bio: "Lonely author",
+    });
+
+    // Should not have any relationship methods
+    const authorWithMethods = author as WithRelationshipMethods<typeof author>;
+    assertEquals(
+      authorWithMethods.findBook,
+      undefined,
+      "Should not have findBook",
+    );
+    assertEquals(
+      authorWithMethods.createBook,
+      undefined,
+      "Should not have createBook",
+    );
+    assertEquals(
+      authorWithMethods.deleteBook,
+      undefined,
+      "Should not have deleteBook",
+    );
+  });
+});

--- a/apps/bfDb/builders/bfDb/relationshipMethods.ts
+++ b/apps/bfDb/builders/bfDb/relationshipMethods.ts
@@ -1,0 +1,195 @@
+/**
+ * Type definitions and utilities for generating typed relationship methods
+ * based on bfNodeSpec relations.
+ *
+ * This system will generate methods like:
+ * - findBfGrader() / findBfSample()
+ * - createBfGrader() / createBfSample()
+ * - deleteBfGrader() / deleteBfSample()
+ */
+
+import type { AnyBfNodeCtor, RelationSpec } from "./types.ts";
+
+/**
+ * Type that extracts relation names from a node's bfNodeSpec
+ */
+export type RelationNames<T extends AnyBfNodeCtor> = T extends {
+  bfNodeSpec: { relations: infer R };
+} ? keyof R
+  : never;
+
+/**
+ * Type that gets the target type for a specific relation
+ */
+export type RelationTarget<
+  T extends AnyBfNodeCtor,
+  R extends RelationNames<T>,
+> = T extends { bfNodeSpec: { relations: infer Relations } }
+  ? Relations extends Record<string, RelationSpec>
+    ? Relations[R] extends
+      { target: () => infer Target | Promise<infer Target> }
+      ? Target extends AnyBfNodeCtor ? Target : never
+    : never
+  : never
+  : never;
+
+/**
+ * Interface for generated relationship methods on a BfNode instance
+ *
+ * For each relation defined in bfNodeSpec, this generates:
+ * - find{RelationName}(): Find the related node
+ * - create{RelationName}(): Create and link a new related node
+ * - delete{RelationName}(): Remove the relationship (and optionally the node)
+ */
+export type RelationshipMethods<T extends AnyBfNodeCtor> =
+  & {
+    [K in RelationNames<T> as `find${Capitalize<string & K>}`]: () => Promise<
+      InstanceType<RelationTarget<T, K>> | null
+    >;
+  }
+  & {
+    [K in RelationNames<T> as `create${Capitalize<string & K>}`]: (
+      props: RelationTarget<T, K> extends { bfNodeSpec: { fields: infer F } }
+        ? { [P in keyof F]: import("./types.ts").FieldValue<F[P]> }
+        : never,
+    ) => Promise<InstanceType<RelationTarget<T, K>>>;
+  }
+  & {
+    [K in RelationNames<T> as `delete${Capitalize<string & K>}`]: (
+      options?: { deleteNode?: boolean },
+    ) => Promise<void>;
+  };
+
+/**
+ * Capitalizes the first letter of a string
+ */
+function capitalize(str: string): string {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+/**
+ * Generates relationship methods for a BfNode class based on its bfNodeSpec relations
+ *
+ * @param nodeClass The BfNode class to generate methods for
+ * @param instance The instance to attach methods to
+ */
+export function generateRelationshipMethods<T extends AnyBfNodeCtor>(
+  nodeClass: T,
+  instance: InstanceType<T>,
+): void {
+  const spec = (nodeClass as AnyBfNodeCtor & {
+    bfNodeSpec?: { relations?: Record<string, RelationSpec> };
+  }).bfNodeSpec;
+  if (!spec?.relations) return;
+
+  for (const [relationName, relationSpec] of Object.entries(spec.relations)) {
+    const relation = relationSpec as RelationSpec;
+    const methodBaseName = capitalize(relationName);
+
+    // Generate find method
+    (instance as Record<string, unknown>)[`find${methodBaseName}`] =
+      async function () {
+        // For "one" relationships, query for the single related node
+        if (relation.cardinality === "one") {
+          // Need to determine if this is an outgoing or incoming relationship
+          // For now, we'll try querySourceInstances first (assuming the related node points to this one)
+          const TargetClass = await relation.target();
+          let results = await this.querySourceInstances(
+            TargetClass,
+            {},
+            {},
+          );
+
+          // If no results, try the other direction
+          if (results.length === 0) {
+            results = await this.queryTargetInstances(
+              TargetClass,
+              {},
+              {},
+            );
+          }
+
+          return results[0] || null;
+        }
+        // For "many" relationships (when implemented), return all
+        throw new Error("Many relationships not yet implemented");
+      };
+
+    // Generate create method
+    (instance as Record<string, unknown>)[`create${methodBaseName}`] =
+      async function (props: Record<string, unknown>) {
+        const TargetClass = await relation.target();
+        const role = relation.props?.role || "";
+        return this.createTargetNode(TargetClass, props, { role });
+      };
+
+    // Generate delete method
+    (instance as Record<string, unknown>)[`delete${methodBaseName}`] =
+      async function (
+        options?: { deleteNode?: boolean },
+      ) {
+        const related = await this[`find${methodBaseName}`]();
+        if (!related) return;
+
+        // Import BfEdge to query and delete edges
+        const { BfEdge } = await import(
+          "@bfmono/apps/bfDb/nodeTypes/BfEdge.ts"
+        );
+
+        // Query for edges in both directions (since we don't know which way the edge points)
+        const edgesFromThis = await BfEdge.query(
+          this.currentViewer,
+          {
+            bfSid: this.metadata.bfGid,
+            bfTid: related.metadata.bfGid,
+            bfOid: this.currentViewer.orgBfOid,
+          },
+          {},
+          [],
+        );
+
+        const edgesToThis = await BfEdge.query(
+          this.currentViewer,
+          {
+            bfSid: related.metadata.bfGid,
+            bfTid: this.metadata.bfGid,
+            bfOid: this.currentViewer.orgBfOid,
+          },
+          {},
+          [],
+        );
+
+        const edges = [...edgesFromThis, ...edgesToThis];
+
+        // Delete all edges
+        for (const edge of edges) {
+          await edge.delete();
+        }
+
+        // Optionally delete the node itself
+        if (options?.deleteNode) {
+          await related.delete();
+        }
+      };
+  }
+}
+
+/**
+ * Example of how the types would work:
+ *
+ * class BfGraderResult extends BfNode {
+ *   static bfNodeSpec = this.defineBfNode((f) =>
+ *     f.one("bfGrader", () => BfGrader)
+ *      .one("bfSample", () => BfSample)
+ *   );
+ * }
+ *
+ * // Generated methods on BfGraderResult instances:
+ * graderResult.findBfGrader() // returns Promise<BfGrader | null>
+ * graderResult.createBfGrader({ graderText: "..." }) // returns Promise<BfGrader>
+ * graderResult.deleteBfGrader({ deleteNode: true }) // returns Promise<void>
+ *
+ * graderResult.findBfSample() // returns Promise<BfSample | null>
+ * graderResult.createBfSample({ name: "...", ... }) // returns Promise<BfSample>
+ * graderResult.deleteBfSample() // returns Promise<void>
+ */

--- a/apps/bfDb/builders/bfDb/relationshipMethods.ts
+++ b/apps/bfDb/builders/bfDb/relationshipMethods.ts
@@ -88,7 +88,7 @@ export function generateRelationshipMethods<T extends AnyBfNodeCtor>(
 
     // Generate find method
     (instance as Record<string, unknown>)[`find${methodBaseName}`] =
-      async function () {
+      async function (this: typeof instance) {
         // For "one" relationships, query for the single related node
         if (relation.cardinality === "one") {
           // Need to determine if this is an outgoing or incoming relationship
@@ -117,7 +117,7 @@ export function generateRelationshipMethods<T extends AnyBfNodeCtor>(
 
     // Generate create method
     (instance as Record<string, unknown>)[`create${methodBaseName}`] =
-      async function (props: Record<string, unknown>) {
+      async function (this: typeof instance, props: Record<string, unknown>) {
         const TargetClass = await relation.target();
         const role = relation.props?.role || "";
         return this.createTargetNode(TargetClass, props, { role });
@@ -126,6 +126,7 @@ export function generateRelationshipMethods<T extends AnyBfNodeCtor>(
     // Generate delete method
     (instance as Record<string, unknown>)[`delete${methodBaseName}`] =
       async function (
+        this: typeof instance,
         options?: { deleteNode?: boolean },
       ) {
         const related = await this[`find${methodBaseName}`]();

--- a/apps/bfDb/classes/BfNode.ts
+++ b/apps/bfDb/classes/BfNode.ts
@@ -19,6 +19,7 @@ import type {
   RelationSpec,
 } from "@bfmono/apps/bfDb/builders/bfDb/types.ts";
 import { makeBfDbSpec } from "@bfmono/apps/bfDb/builders/bfDb/makeBfDbSpec.ts";
+import { generateRelationshipMethods } from "@bfmono/apps/bfDb/builders/bfDb/relationshipMethods.ts";
 
 const logger = getLogger(import.meta);
 
@@ -349,6 +350,9 @@ export abstract class BfNode<TProps extends PropsBase = {}>
       metadata,
     );
     this.currentViewer = currentViewer;
+
+    // Generate relationship methods based on bfNodeSpec relations
+    generateRelationshipMethods(this.constructor as AnyBfNodeCtor, this);
   }
 
   get props(): TProps {

--- a/infra/bft/tasks/codebot.bft.ts
+++ b/infra/bft/tasks/codebot.bft.ts
@@ -511,38 +511,50 @@ FIRST TIME SETUP:
   const copyWorkspacePromise = reusingWorkspace
     ? Promise.resolve()
     : (async () => {
-      // Pull internalbf-docs before copying
-      ui.output("📥 Pulling internalbf-docs repository...");
-      const slPullCmd = new Deno.Command("sl", {
-        args: ["pull"],
-        cwd: "../internalbf-docs",
-        stdout: "piped",
-        stderr: "piped",
-      });
-      const slPullResult = await slPullCmd.output();
-
-      if (!slPullResult.success) {
-        const errorText = new TextDecoder().decode(slPullResult.stderr);
-        ui.output(`⚠️ Failed to pull internalbf-docs: ${errorText}`);
-      } else {
-        ui.output("✅ Pulled internalbf-docs successfully");
+      // Check if internalbf-docs directory exists
+      const internalDocsPath = "../internalbf-docs";
+      let internalDocsExists = false;
+      try {
+        const stat = await Deno.stat(internalDocsPath);
+        internalDocsExists = stat.isDirectory;
+      } catch {
+        ui.output("⚠️ internalbf-docs directory not found - skipping sync");
       }
 
-      // Go to remote/main with --clean
-      ui.output("🔄 Switching to remote/main --clean...");
-      const slGotoCmd = new Deno.Command("sl", {
-        args: ["goto", "remote/main", "--clean"],
-        cwd: "../internalbf-docs",
-        stdout: "piped",
-        stderr: "piped",
-      });
-      const slGotoResult = await slGotoCmd.output();
+      if (internalDocsExists) {
+        // Pull internalbf-docs before copying
+        ui.output("📥 Pulling internalbf-docs repository...");
+        const slPullCmd = new Deno.Command("sl", {
+          args: ["pull"],
+          cwd: internalDocsPath,
+          stdout: "piped",
+          stderr: "piped",
+        });
+        const slPullResult = await slPullCmd.output();
 
-      if (!slGotoResult.success) {
-        const errorText = new TextDecoder().decode(slGotoResult.stderr);
-        ui.output(`⚠️ Failed to switch to remote/main: ${errorText}`);
-      } else {
-        ui.output("✅ Switched to remote/main successfully");
+        if (!slPullResult.success) {
+          const errorText = new TextDecoder().decode(slPullResult.stderr);
+          ui.output(`⚠️ Failed to pull internalbf-docs: ${errorText}`);
+        } else {
+          ui.output("✅ Pulled internalbf-docs successfully");
+        }
+
+        // Go to remote/main with --clean
+        ui.output("🔄 Switching to remote/main --clean...");
+        const slGotoCmd = new Deno.Command("sl", {
+          args: ["goto", "remote/main", "--clean"],
+          cwd: internalDocsPath,
+          stdout: "piped",
+          stderr: "piped",
+        });
+        const slGotoResult = await slGotoCmd.output();
+
+        if (!slGotoResult.success) {
+          const errorText = new TextDecoder().decode(slGotoResult.stderr);
+          ui.output(`⚠️ Failed to switch to remote/main: ${errorText}`);
+        } else {
+          ui.output("✅ Switched to remote/main successfully");
+        }
       }
 
       // Create the workspace directory structure first to avoid race conditions


### PR DESCRIPTION

- Change WithRelationshipMethods type to use 'any' instead of 'unknown' to allow dynamic method access
- Add explicit 'this' type annotations to generated relationship methods
- Re-add underscore prefix to unused linkedBook variable (removed during merge conflict)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/bolt-foundry/bolt-foundry/pull/1728).
* #1730
* __->__ #1728
* #1724