### PR TITLE
Add codebot workspace restructure implementation memo

### DIFF
--- a/memos/1-projects/codebot-workspace-restructure.md
+++ b/memos/1-projects/codebot-workspace-restructure.md
@@ -1,0 +1,99 @@
+# Codebot Workspace Restructure Implementation
+
+## Summary
+
+Restructure the codebot container workspace to simplify the directory structure
+and improve the development workflow by consolidating everything under @bfmono
+with @internalbf-docs as an optional git submodule.
+
+## Current State
+
+- Codebot mounts two separate volumes:
+  - `${workspacePath}/@bfmono` → `/@bfmono`
+  - `${workspacePath}/@internalbf-docs` → `/@internalbf-docs`
+- Working directory is unclear/not set
+- Requires copying internalbf-docs separately
+- `.claude` file in @bfmono expects certain directory structure
+
+## Proposed Changes
+
+### 1. Directory Structure
+
+Move to a single-root structure:
+
+```
+/@bfmono/                       # Container working directory
+├── .claude                     # Configuration file
+├── memos/
+│   └── @internalbf-docs/      # Git submodule (optional)
+└── ... (rest of @bfmono)
+```
+
+### 2. Git Submodule Setup
+
+- Add @internalbf-docs as a git submodule at `memos/@internalbf-docs`
+- Submodule remains optional - OSS users get empty directory
+- Internal users with access can initialize: `git submodule update --init`
+
+### 3. Codebot Script Updates
+
+Update `infra/bft/tasks/codebot.bft.ts` to:
+
+- Mount only `${workspacePath}` → `/@bfmono`
+- Set working directory to `/@bfmono`
+- Remove separate @internalbf-docs copying logic
+- Handle optional submodule gracefully (check if initialized before pulling)
+
+### 4. Enhanced Commit Workflow
+
+Extend existing `bft commit` deck (currently AI-powered) with TypeScript
+implementation to:
+
+- Detect if changes exist in submodules
+- Commit submodule changes first
+- Update parent repo's submodule pointer
+- Provide single command for complete commit workflow
+- Work with both Sapling and Git repos
+
+## Implementation Steps
+
+1. **Add submodule to @bfmono**
+   ```bash
+   cd /@bfmono
+   git submodule add <internalbf-docs-repo-url> memos/@internalbf-docs
+   ```
+
+2. **Update codebot.bft.ts**
+   - Remove lines related to separate @internalbf-docs handling
+   - Update volume mount configuration
+   - Add working directory setting
+
+3. **Enhance bft commit command**
+   - Create TypeScript implementation: `infra/bft/tasks/commit.bft.ts`
+   - Extend existing deck functionality
+   - Handle submodule detection and commits
+   - Support both Sapling (main repo) and Git (submodules)
+
+## Benefits
+
+- Simpler directory structure
+- `.claude` file works naturally with relative paths
+- Single volume mount
+- Optional internal docs for OSS users
+- Cleaner workspace management
+
+## Risks & Mitigations
+
+- **Risk**: Forgetting to commit submodule pointer updates
+  - **Mitigation**: `bft commit` command handles this automatically
+
+- **Risk**: OSS users confused by empty submodule directory
+  - **Mitigation**: Add README in memos/ explaining optional submodules
+
+## Testing Plan
+
+1. Create test workspace with new structure
+2. Verify codebot starts correctly
+3. Test with and without submodule initialized
+4. Verify `.claude` file recognizes full project structure
+5. Test `bft commit` with submodule changes


### PR DESCRIPTION

This memo outlines the plan to simplify codebot's workspace structure by:
- Consolidating everything under @bfmono as the single root
- Making @internalbf-docs an optional git submodule at memos/@internalbf-docs
- Updating codebot script to use single mount point and working directory
- Enhancing bft commit to handle submodule workflows

This will make the .claude file work naturally with relative paths and
simplify workspace management.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
