### PR TITLE
Improve boltfoundry-com dev server with remote access and stop command

### DIFF
--- a/apps/boltfoundry-com/server.tsx
+++ b/apps/boltfoundry-com/server.tsx
@@ -490,7 +490,7 @@ const handler = async (request: Request): Promise<Response> => {
 };
 
 // Start the server
-const server = Deno.serve({ port }, handler);
+const server = Deno.serve({ port, hostname: "0.0.0.0" }, handler);
 
 logger.println(`BoltFoundry.com server running at http://localhost:${port}`);
 logger.println(`Mode: ${isDev ? "development" : "production"}`);


### PR DESCRIPTION

Enable access from host machines by binding to all interfaces and add convenient
stop command for managing background processes. This improves developer experience
when working in containerized environments.

Changes:
- Bind server to 0.0.0.0 instead of localhost for external access
- Replace Deno.Command spawn with nohup for reliable background execution
- Add --stop flag to terminate running dev server processes
- Improve background mode to verify server startup before returning
- Update help documentation with new --stop command examples

Test plan:
1. Start server: `bft dev boltfoundry-com`
2. Verify accessible from host at http://[hostname]:8000
3. Check logs being written to tmp/boltfoundry-com-dev.log
4. Stop server: `bft dev boltfoundry-com --stop`
5. Verify all processes terminated with `ps aux | grep boltfoundry-com`

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
