### PR TITLE
Implement codebot workspace restructure from PR1729

### DIFF
--- a/infra/bft/tasks/amend.bft.ts
+++ b/infra/bft/tasks/amend.bft.ts
@@ -1,0 +1,300 @@
+#!/usr/bin/env -S bft run
+
+import type { TaskDefinition } from "../bft.ts";
+import { parseArgs } from "@std/cli/parse-args";
+import { ui } from "@bfmono/packages/cli-ui/cli-ui.ts";
+import { getLogger } from "@bfmono/packages/logger/logger.ts";
+
+const logger = getLogger(import.meta);
+
+interface AmendArgs {
+  help?: boolean;
+  message?: string;
+  "no-edit"?: boolean;
+  _: Array<string>;
+}
+
+async function checkIfSapling(): Promise<boolean> {
+  try {
+    // Check if .sl directory exists
+    const slStat = await Deno.stat(".sl");
+    return slStat.isDirectory;
+  } catch {
+    return false;
+  }
+}
+
+async function getSubmodules(): Promise<Array<string>> {
+  try {
+    // Check for .gitmodules file
+    await Deno.stat(".gitmodules");
+  } catch {
+    // No submodules
+    return [];
+  }
+
+  const submoduleStatusCmd = new Deno.Command("git", {
+    args: ["submodule", "status"],
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const result = await submoduleStatusCmd.output();
+
+  if (!result.success) {
+    return [];
+  }
+
+  const output = new TextDecoder().decode(result.stdout);
+  const submodules: Array<string> = [];
+
+  const lines = output.trim().split("\n").filter((line) => line.length > 0);
+  for (const line of lines) {
+    const match = line.match(/^[\s\+\-\*]?([a-f0-9]+)\s+([^\s]+)/);
+    if (match) {
+      submodules.push(match[2]);
+    }
+  }
+
+  return submodules;
+}
+
+async function amendInSubmodule(
+  submodulePath: string,
+  message?: string,
+  noEdit?: boolean,
+): Promise<boolean> {
+  ui.output(`📝 Amending commit in submodule: ${submodulePath}`);
+
+  const amendArgs = ["commit", "--amend"];
+
+  if (noEdit) {
+    amendArgs.push("--no-edit");
+  }
+
+  if (message) {
+    amendArgs.push("-m", message);
+  }
+
+  const amendCmd = new Deno.Command("git", {
+    args: ["-C", submodulePath, ...amendArgs],
+    stdin: noEdit ? undefined : "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+
+  const result = await amendCmd.output();
+
+  if (!result.success) {
+    ui.error(`Failed to amend in ${submodulePath}`);
+    return false;
+  }
+
+  ui.output(`✅ Amended commit in ${submodulePath}`);
+  return true;
+}
+
+async function updateSubmodulePointer(submodulePath: string): Promise<boolean> {
+  // Stage the updated submodule pointer
+  const addCmd = new Deno.Command("git", {
+    args: ["add", submodulePath],
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const addResult = await addCmd.output();
+
+  if (!addResult.success) {
+    const error = new TextDecoder().decode(addResult.stderr);
+    ui.error(
+      `Failed to update submodule pointer for ${submodulePath}: ${error}`,
+    );
+    return false;
+  }
+
+  return true;
+}
+
+async function amend(args: Array<string>): Promise<number> {
+  const parsed = parseArgs(args, {
+    boolean: ["help", "no-edit"],
+    string: ["message"],
+    alias: { h: "help", m: "message" },
+  }) as AmendArgs;
+
+  if (parsed.help) {
+    ui.output(`
+Usage: bft amend [OPTIONS] [FILES...]
+
+Amend the last commit, with automatic handling of submodule changes.
+
+OPTIONS:
+  -m, --message MSG    New commit message
+  --no-edit           Amend without changing the commit message
+  -h, --help          Show this help message
+
+FEATURES:
+  - Automatically detects if amendments are needed in submodules
+  - Updates parent repository submodule pointers after amending
+  - Works with both Git and Sapling repositories
+  - Preserves commit message by default (use -m to change)
+
+EXAMPLES:
+  bft amend                                    # Amend and edit message
+  bft amend --no-edit                          # Amend without editing message
+  bft amend -m "Updated commit message"        # Amend with new message
+  bft amend src/file.ts                        # Add file to last commit
+
+NOTE:
+  When amending in a repository with submodules, this command will:
+  1. Check if any submodules have changes that need amending
+  2. Amend commits in submodules first (if needed)
+  3. Update submodule pointers in the parent repository
+  4. Amend the parent repository commit
+`);
+    return 0;
+  }
+
+  const isSapling = await checkIfSapling();
+  const vcs = isSapling ? "sl" : "git";
+
+  // For Git repos, check if we need to handle submodules
+  if (!isSapling) {
+    const submodules = await getSubmodules();
+
+    if (submodules.length > 0) {
+      ui.output("🔍 Checking submodules for changes...");
+
+      let submodulePointersUpdated = false;
+
+      for (const submodulePath of submodules) {
+        // Check if submodule has uncommitted changes
+        const statusCmd = new Deno.Command("git", {
+          args: ["-C", submodulePath, "status", "--porcelain"],
+          stdout: "piped",
+          stderr: "piped",
+        });
+        const statusResult = await statusCmd.output();
+
+        if (statusResult.success) {
+          const statusOutput = new TextDecoder().decode(statusResult.stdout)
+            .trim();
+
+          if (statusOutput.length > 0) {
+            // Submodule has changes
+            ui.output(`  Found changes in ${submodulePath}`);
+
+            // Ask user if they want to amend the submodule
+            ui.output(`Amend changes in submodule ${submodulePath}? (y/N)`);
+            const response = prompt(">");
+
+            if (response?.toLowerCase() === "y") {
+              // Stage all changes in submodule first
+              const addCmd = new Deno.Command("git", {
+                args: ["-C", submodulePath, "add", "-A"],
+                stdout: "piped",
+                stderr: "piped",
+              });
+              await addCmd.output();
+
+              // Amend the submodule
+              const success = await amendInSubmodule(
+                submodulePath,
+                parsed.message,
+                parsed["no-edit"],
+              );
+
+              if (!success) {
+                return 1;
+              }
+
+              // Update the submodule pointer
+              const pointerUpdated = await updateSubmodulePointer(
+                submodulePath,
+              );
+              if (!pointerUpdated) {
+                return 1;
+              }
+
+              submodulePointersUpdated = true;
+            }
+          }
+        }
+      }
+
+      if (submodulePointersUpdated) {
+        ui.output("✅ Submodule pointers updated");
+      }
+    }
+  }
+
+  // Build amend command args
+  const amendArgs = ["commit", "--amend"];
+
+  if (parsed["no-edit"]) {
+    amendArgs.push("--no-edit");
+  }
+
+  if (parsed.message) {
+    amendArgs.push("-m", parsed.message);
+  }
+
+  // Add specific files if provided
+  if (parsed._.length > 0) {
+    if (isSapling) {
+      // For Sapling, need to add files first
+      const addCmd = new Deno.Command("sl", {
+        args: ["add", ...parsed._],
+        stdout: "piped",
+        stderr: "piped",
+      });
+      const addResult = await addCmd.output();
+      if (!addResult.success) {
+        const error = new TextDecoder().decode(addResult.stderr);
+        ui.error(`Failed to stage files: ${error}`);
+        return 1;
+      }
+    } else {
+      // For Git, stage the files first
+      const addCmd = new Deno.Command("git", {
+        args: ["add", ...parsed._],
+        stdout: "piped",
+        stderr: "piped",
+      });
+      const addResult = await addCmd.output();
+      if (!addResult.success) {
+        const error = new TextDecoder().decode(addResult.stderr);
+        ui.error(`Failed to stage files: ${error}`);
+        return 1;
+      }
+    }
+  }
+
+  // Execute the amend command
+  const amendCmd = new Deno.Command(vcs, {
+    args: amendArgs,
+    stdin: parsed["no-edit"] ? undefined : "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+
+  const result = await amendCmd.output();
+
+  if (result.success) {
+    ui.output("✅ Successfully amended commit");
+  }
+
+  return result.success ? 0 : 1;
+}
+
+// Export the task definition for autodiscovery
+export const bftDefinition = {
+  description: "Amend commits with automatic submodule handling",
+  aiSafe: true,
+  fn: amend,
+} satisfies TaskDefinition;
+
+// When run directly as a script
+if (import.meta.main) {
+  const scriptArgs = Deno.args.slice(2);
+  const result = await amend(scriptArgs);
+  Deno.exit(result);
+}

--- a/infra/bft/tasks/commit.bft.ts
+++ b/infra/bft/tasks/commit.bft.ts
@@ -1,0 +1,312 @@
+#!/usr/bin/env -S bft run
+
+import type { TaskDefinition } from "../bft.ts";
+import { parseArgs } from "@std/cli/parse-args";
+import { ui } from "@bfmono/packages/cli-ui/cli-ui.ts";
+import { getLogger } from "@bfmono/packages/logger/logger.ts";
+
+const logger = getLogger(import.meta);
+
+interface CommitArgs {
+  help?: boolean;
+  message?: string;
+  all?: boolean;
+  _: Array<string>;
+}
+
+async function checkSubmoduleChanges(): Promise<{
+  hasSubmoduleChanges: boolean;
+  submodules: Array<{ path: string; changes: string }>;
+}> {
+  try {
+    // Check for .gitmodules file to see if submodules exist
+    await Deno.stat(".gitmodules");
+  } catch {
+    // No submodules in this repository
+    return { hasSubmoduleChanges: false, submodules: [] };
+  }
+
+  const submodules: Array<{ path: string; changes: string }> = [];
+
+  // Get list of submodules
+  const submoduleStatusCmd = new Deno.Command("git", {
+    args: ["submodule", "status"],
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const submoduleStatusResult = await submoduleStatusCmd.output();
+
+  if (!submoduleStatusResult.success) {
+    logger.debug("Failed to check submodule status");
+    return { hasSubmoduleChanges: false, submodules: [] };
+  }
+
+  const submoduleStatusOutput = new TextDecoder().decode(
+    submoduleStatusResult.stdout,
+  );
+  const submoduleLines = submoduleStatusOutput.trim().split("\n").filter((
+    line,
+  ) => line.length > 0);
+
+  // Check each submodule for changes
+  for (const line of submoduleLines) {
+    const match = line.match(/^[\s\+\-\*]?([a-f0-9]+)\s+([^\s]+)/);
+    if (match) {
+      const submodulePath = match[2];
+
+      // Check if submodule has uncommitted changes
+      const submoduleDiffCmd = new Deno.Command("git", {
+        args: ["-C", submodulePath, "diff", "--stat"],
+        stdout: "piped",
+        stderr: "piped",
+      });
+      const submoduleDiffResult = await submoduleDiffCmd.output();
+
+      if (submoduleDiffResult.success) {
+        const diffOutput = new TextDecoder().decode(submoduleDiffResult.stdout)
+          .trim();
+        if (diffOutput.length > 0) {
+          submodules.push({ path: submodulePath, changes: diffOutput });
+        }
+      }
+
+      // Check if submodule has uncommitted staged changes
+      const submoduleStagedCmd = new Deno.Command("git", {
+        args: ["-C", submodulePath, "diff", "--staged", "--stat"],
+        stdout: "piped",
+        stderr: "piped",
+      });
+      const submoduleStagedResult = await submoduleStagedCmd.output();
+
+      if (submoduleStagedResult.success) {
+        const stagedOutput = new TextDecoder().decode(
+          submoduleStagedResult.stdout,
+        ).trim();
+        if (
+          stagedOutput.length > 0 &&
+          !submodules.find((s) => s.path === submodulePath)
+        ) {
+          submodules.push({ path: submodulePath, changes: stagedOutput });
+        }
+      }
+    }
+  }
+
+  return { hasSubmoduleChanges: submodules.length > 0, submodules };
+}
+
+async function commitSubmoduleChanges(
+  submodulePath: string,
+  message: string,
+): Promise<boolean> {
+  ui.output(`📝 Committing changes in submodule: ${submodulePath}`);
+
+  // Stage all changes in the submodule
+  const addCmd = new Deno.Command("git", {
+    args: ["-C", submodulePath, "add", "-A"],
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const addResult = await addCmd.output();
+
+  if (!addResult.success) {
+    const error = new TextDecoder().decode(addResult.stderr);
+    ui.error(`Failed to stage changes in ${submodulePath}: ${error}`);
+    return false;
+  }
+
+  // Commit with the same message
+  const commitCmd = new Deno.Command("git", {
+    args: ["-C", submodulePath, "commit", "-m", message],
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const commitResult = await commitCmd.output();
+
+  if (!commitResult.success) {
+    const error = new TextDecoder().decode(commitResult.stderr);
+    ui.error(`Failed to commit in ${submodulePath}: ${error}`);
+    return false;
+  }
+
+  ui.output(`✅ Committed changes in ${submodulePath}`);
+  return true;
+}
+
+async function updateSubmodulePointer(submodulePath: string): Promise<boolean> {
+  // Stage the submodule pointer update
+  const addCmd = new Deno.Command("git", {
+    args: ["add", submodulePath],
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const addResult = await addCmd.output();
+
+  if (!addResult.success) {
+    const error = new TextDecoder().decode(addResult.stderr);
+    ui.error(
+      `Failed to update submodule pointer for ${submodulePath}: ${error}`,
+    );
+    return false;
+  }
+
+  return true;
+}
+
+async function checkIfSapling(): Promise<boolean> {
+  try {
+    // Check if .sl directory exists
+    const slStat = await Deno.stat(".sl");
+    return slStat.isDirectory;
+  } catch {
+    return false;
+  }
+}
+
+async function commit(args: Array<string>): Promise<number> {
+  const parsed = parseArgs(args, {
+    boolean: ["help", "all"],
+    string: ["message"],
+    alias: { h: "help", m: "message", a: "all" },
+  }) as CommitArgs;
+
+  if (parsed.help) {
+    ui.output(`
+Usage: bft commit [OPTIONS] [FILES...]
+
+Create a commit with automatic handling of submodule changes.
+
+OPTIONS:
+  -m, --message MSG    Commit message
+  -a, --all           Stage all changes before committing
+  -h, --help          Show this help message
+
+FEATURES:
+  - Automatically detects and commits submodule changes first
+  - Updates parent repository submodule pointers
+  - Falls back to deck-based AI commit message generation if no message provided
+  - Works with both Git and Sapling repositories
+
+EXAMPLES:
+  bft commit -m "Add new feature"              # Commit with message
+  bft commit -a -m "Fix all the things"        # Stage all and commit
+  bft commit                                    # Use AI to generate message
+  bft commit src/file.ts src/other.ts          # Commit specific files
+`);
+    return 0;
+  }
+
+  const isSapling = await checkIfSapling();
+
+  // Check for submodule changes (only in Git repos)
+  if (!isSapling) {
+    const { hasSubmoduleChanges, submodules } = await checkSubmoduleChanges();
+
+    if (hasSubmoduleChanges) {
+      ui.output("🔍 Detected changes in submodules:");
+      for (const submodule of submodules) {
+        ui.output(`  - ${submodule.path}`);
+      }
+
+      // If we have a message, use it for submodule commits
+      if (parsed.message) {
+        for (const submodule of submodules) {
+          const success = await commitSubmoduleChanges(
+            submodule.path,
+            parsed.message,
+          );
+          if (!success) {
+            ui.error("❌ Failed to commit submodule changes");
+            return 1;
+          }
+
+          // Update the submodule pointer in the parent repo
+          const pointerUpdated = await updateSubmodulePointer(submodule.path);
+          if (!pointerUpdated) {
+            ui.error("❌ Failed to update submodule pointer");
+            return 1;
+          }
+        }
+        ui.output("✅ All submodule changes committed and pointers updated");
+      } else {
+        ui.output(
+          "⚠️  Submodule changes detected but no commit message provided.",
+        );
+        ui.output(
+          "Please provide a commit message with -m or use the deck-based flow.",
+        );
+        // Fall through to deck-based flow
+      }
+    }
+  }
+
+  // Handle main repository commit
+  if (parsed.message) {
+    // Direct commit with provided message
+    const vcs = isSapling ? "sl" : "git";
+
+    // Build commit command args
+    const commitArgs = ["commit", "-m", parsed.message];
+
+    if (parsed.all) {
+      if (isSapling) {
+        // Sapling doesn't have -a flag, need to add files first
+        const addCmd = new Deno.Command("sl", {
+          args: ["add", "."],
+          stdout: "piped",
+          stderr: "piped",
+        });
+        const addResult = await addCmd.output();
+        if (!addResult.success) {
+          const error = new TextDecoder().decode(addResult.stderr);
+          ui.error(`Failed to stage changes: ${error}`);
+          return 1;
+        }
+      } else {
+        commitArgs.push("-a");
+      }
+    }
+
+    // Add specific files if provided
+    if (parsed._.length > 0) {
+      commitArgs.push(...parsed._);
+    }
+
+    const commitCmd = new Deno.Command(vcs, {
+      args: commitArgs,
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+
+    const commitResult = await commitCmd.output();
+    return commitResult.success ? 0 : 1;
+  } else {
+    // Use deck-based AI commit message generation
+    ui.output("🤖 Using AI to generate commit message...");
+
+    // Execute the deck file
+    const deckCmd = new Deno.Command("bft", {
+      args: ["deck", "infra/bft/tasks/commit.bft.deck.md"],
+      stdin: "inherit",
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+
+    const deckResult = await deckCmd.output();
+    return deckResult.success ? 0 : 1;
+  }
+}
+
+// Export the task definition for autodiscovery
+export const bftDefinition = {
+  description: "Commit changes with automatic submodule handling",
+  aiSafe: true,
+  fn: commit,
+} satisfies TaskDefinition;
+
+// When run directly as a script
+if (import.meta.main) {
+  const scriptArgs = Deno.args.slice(2);
+  const result = await commit(scriptArgs);
+  Deno.exit(result);
+}

--- a/memos/README.md
+++ b/memos/README.md
@@ -50,7 +50,7 @@ Can be rougher/more technical than public docs.
 ### 3. Internal-Only / Confidential (`@internalbf-docs`)
 
 **Purpose**: Sensitive information that should not be in the public monorepo\
-**Location**: `/@internalbf-docs/` workspace (access controlled)\
+**Location**: `memos/@internalbf-docs/` (Git submodule, optional)\
 **Audience**: Bolt Foundry team only\
 **Organization**: PARA Method
 
@@ -128,3 +128,44 @@ Remember: When in doubt about where something belongs, ask yourself:
 - Does it contain names, numbers, or legal obligations? → `@internalbf-docs`
 - Is it vision, philosophy, or technical discussion? → `/memos`
 - Is it user-facing documentation? → `/docs`
+
+## Optional Submodules
+
+The `@internalbf-docs` directory is implemented as a Git submodule, making it
+optional for open-source contributors. This allows:
+
+- **OSS Contributors**: Work with the public codebase without needing access to
+  confidential docs
+- **Internal Team**: Access both public and private documentation seamlessly
+
+### For Internal Team Members
+
+If you have access to the internal docs repository, initialize the submodule:
+
+```bash
+git submodule update --init memos/@internalbf-docs
+```
+
+To update to the latest internal docs:
+
+```bash
+git submodule update --remote memos/@internalbf-docs
+```
+
+### For OSS Contributors
+
+The `memos/@internalbf-docs/` directory will be empty in your checkout. This is
+expected and won't affect your ability to contribute to the public codebase.
+
+### Committing with Submodules
+
+When using `bft commit`:
+
+- Changes in submodules are automatically detected
+- Submodule commits are created first
+- Parent repository submodule pointers are updated automatically
+
+When using `bft amend`:
+
+- Amendments in submodules are handled automatically
+- Submodule pointers are updated after amending


### PR DESCRIPTION
This implements the codebot workspace restructure plan by:
- Consolidating everything under @bfmono as the single root
- Making @internalbf-docs an optional git submodule at memos/@internalbf-docs
- Updating codebot script to use single mount point and working directory
- Enhancing bft commit to handle submodule workflows

Changes:
- Update codebot.bft.ts to mount workspace directly as /@bfmono with --workdir
- Remove separate @internalbf-docs volume mount and copying logic
- Add submodule detection and handling for optional @internalbf-docs
- Create TypeScript implementation for bft commit with submodule support
- Create bft amend command with automatic submodule handling
- Update memos/README.md with Optional Submodules documentation

Test plan:
1. Run bft codebot to verify single mount point works
2. Test with and without @internalbf-docs submodule initialized
3. Use bft commit with submodule changes to verify auto-detection
4. Use bft amend to verify submodule pointer updates

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/1735)
<!-- GitContextEnd -->