### PR TITLE
Add @internalbf-docs as git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "memos/@internalbf-docs"]
+	path = memos/@internalbf-docs
+	url = https://github.com/bolt-foundry/internalbf-docs


### PR DESCRIPTION
Adds internalbf-docs as a git submodule at memos/@internalbf-docs. This is part of the codebot workspace restructure to consolidate everything under @bfmono. The submodule is optional - OSS users will get an empty directory. Internal users can initialize with: git submodule update --init. Related: #1729

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/1736)
<!-- GitContextEnd -->