### PR TITLE
fix: Fix codebot exec command by correcting volume mount path

### DIFF
--- a/infra/bft/tasks/codebot.bft.ts
+++ b/infra/bft/tasks/codebot.bft.ts
@@ -126,7 +126,7 @@ function buildContainerArgs(config: ContainerConfig): Array<string> {
     "--volume",
     `${config.claudeDir}:/home/codebot/.claude`,
     "--volume",
-    `${config.workspacePath}:/`,
+    `${config.workspacePath}:/@bfmono`,
     "-w",
     "/@bfmono",
     "--volume",
@@ -954,6 +954,11 @@ FIRST TIME SETUP:
 
     // Add container image and command
     containerArgs.push("codebot", "-c", parsed.exec);
+
+    // Debug: log the full container command
+    ui.output(
+      `🔍 DEBUG: Container command: container ${containerArgs.join(" ")}`,
+    );
 
     const child = new Deno.Command("container", {
       args: containerArgs,


### PR DESCRIPTION
The codebot --exec command was failing with 'No such file or directory' error because it was trying to mount the workspace directory to '/' (root), which is not allowed by the container runtime. Changed the volume mount to mount at '/@bfmono' instead, which resolves the issue and allows exec commands to run successfully.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/1742)
<!-- GitContextEnd -->