### PR TITLE
feat: add shelve/unshelve checkout process to codebot

### DIFF
--- a/infra/bft/tasks/codebot.bft.ts
+++ b/infra/bft/tasks/codebot.bft.ts
@@ -21,6 +21,7 @@ interface CodebotArgs {
   memory?: string;
   cpus?: string;
   resume?: boolean;
+  checkout?: string;
 }
 
 async function generateRandomName(): Promise<string> {
@@ -168,7 +169,7 @@ async function codebot(args: Array<string>): Promise<number> {
       "cleanup-containers",
       "resume",
     ],
-    string: ["exec", "workspace", "memory", "cpus"],
+    string: ["exec", "workspace", "memory", "cpus", "checkout"],
     alias: { h: "help" },
   }) as CodebotArgs;
 
@@ -235,6 +236,7 @@ Includes Google Chrome Stable with all dependencies for E2E testing.
 OPTIONS:
   --shell              Enter container shell for debugging
   --exec CMD           Execute command in container
+  --checkout BRANCH    Checkout branch with automatic shelve/unshelve of changes
   --workspace NAME     Reuse existing workspace or create new one with specific name
                        If a container is already running with this name, attach to it
   --resume             Show list of workspaces and choose one to resume
@@ -251,6 +253,7 @@ EXAMPLES:
   bft codebot --cleanup                 # Start and cleanup workspace when done
   bft codebot --shell                   # Open container shell for debugging
   bft codebot --exec "ls -la"           # Run command and exit
+  bft codebot --checkout remote/main    # Checkout branch with auto shelve/unshelve
   bft codebot --memory 8g --cpus 8      # Run with 8GB RAM and 8 CPUs
 
 FIRST TIME SETUP:
@@ -653,6 +656,53 @@ FIRST TIME SETUP:
       }
 
       ui.output("📂 Workspace copy complete");
+
+      // Store current branch before checkout
+      ui.output("📍 Storing current branch information...");
+      const whereAmICmd = new Deno.Command("sl", {
+        args: ["whereami"],
+        cwd: workspacePath,
+        stdout: "piped",
+        stderr: "piped",
+      });
+
+      const whereAmIResult = await whereAmICmd.output();
+      let originalCommit = "";
+      if (whereAmIResult.success) {
+        originalCommit = new TextDecoder().decode(whereAmIResult.stdout).trim();
+
+        // Write current commit to a file for later reference
+        const metadataPath = `${workspacePath}/.codebot-metadata`;
+        await Deno.mkdir(metadataPath, { recursive: true });
+        await Deno.writeTextFile(
+          `${metadataPath}/original-commit`,
+          originalCommit,
+        );
+        ui.output(`📝 Stored original commit: ${originalCommit}`);
+      }
+
+      // Checkout remote/main in the new workspace
+      ui.output("🔄 Checking out remote/main in workspace...");
+      const checkoutCmd = new Deno.Command("sl", {
+        args: ["goto", "remote/main"],
+        cwd: workspacePath,
+        stdout: "piped",
+        stderr: "piped",
+      });
+
+      const checkoutResult = await checkoutCmd.output();
+      if (!checkoutResult.success) {
+        const errorText = new TextDecoder().decode(checkoutResult.stderr);
+        ui.error(`⚠️ Failed to checkout remote/main: ${errorText}`);
+        // Don't fail the workspace creation, just warn
+      } else {
+        ui.output("✅ Checked out remote/main");
+        if (originalCommit) {
+          ui.output(
+            `💡 To return to original commit: sl goto ${originalCommit}`,
+          );
+        }
+      }
     })();
 
   // Container preparation (check if we need to pull or build)
@@ -937,6 +987,33 @@ FIRST TIME SETUP:
     } else {
       ui.output(`📁 Workspace preserved at: ${workspacePath}`);
     }
+    return 0;
+  }
+
+  if (parsed.checkout) {
+    ui.output(`🔄 Running checkout in workspace: ${workspaceId}`);
+    ui.output(`📍 Target branch: ${parsed.checkout}`);
+
+    // Run checkout on the host in the workspace directory
+    // This avoids copy-on-write issues in the container
+    const checkoutCmd = new Deno.Command("bft", {
+      args: ["sl", "checkout", parsed.checkout],
+      cwd: workspacePath,
+      stdin: "inherit",
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+
+    const checkoutChild = checkoutCmd.spawn();
+    const { success } = await checkoutChild.status;
+
+    if (!success) {
+      ui.error("❌ Checkout failed");
+      return 1;
+    }
+
+    ui.output("✅ Checkout completed successfully");
+    ui.output(`📁 Workspace preserved at: ${workspacePath}`);
     return 0;
   }
 

--- a/infra/bft/tasks/sl.bft.ts
+++ b/infra/bft/tasks/sl.bft.ts
@@ -4,6 +4,8 @@ import {
 } from "@bfmono/infra/bff/shellBase.ts";
 import { getLogger } from "@bfmono/packages/logger/logger.ts";
 import type { TaskDefinition } from "@bfmono/infra/bft/bft.ts";
+import { ui } from "@bfmono/packages/cli-ui/cli-ui.ts";
+import { parseArgs } from "@std/cli/parse-args";
 
 const logger = getLogger(import.meta);
 
@@ -251,6 +253,233 @@ async function handleAmend(args: Array<string>): Promise<number> {
 }
 
 /**
+ * Get list of shelved changes
+ */
+async function getShelvedChangesList(): Promise<Array<string>> {
+  const { stdout, code } = await runShellCommandWithOutput([
+    "sl",
+    "shelve",
+    "--list",
+  ]);
+
+  if (code !== 0) {
+    return [];
+  }
+
+  const lines = stdout.split("\n").filter((line) => line.trim());
+  const shelves: Array<string> = [];
+
+  for (const line of lines) {
+    // Parse shelve list output format
+    const match = line.match(/^\s*(\S+)\s+/);
+    if (match) {
+      shelves.push(match[1]);
+    }
+  }
+
+  return shelves;
+}
+
+/**
+ * Enhanced shelve command
+ */
+async function handleShelve(args: Array<string>): Promise<number> {
+  const parsed = parseArgs(args, {
+    string: ["name", "message"],
+    boolean: ["interactive", "keep"],
+    alias: { n: "name", m: "message", i: "interactive", k: "keep" },
+  });
+
+  // Check if we have changes to shelve
+  const changes = await getChangedFiles();
+  if (changes.length === 0) {
+    ui.output("No changes to shelve");
+    return 0;
+  }
+
+  // Generate smart shelve name if not provided
+  const shelveName = parsed.name || `codebot-${Date.now()}`;
+
+  ui.output(`📦 Shelving ${changes.length} file(s) as '${shelveName}'`);
+
+  // Build shelve command
+  const shelveArgs = ["sl", "shelve", "-n", shelveName];
+
+  if (parsed.message) {
+    shelveArgs.push("-m", parsed.message);
+  }
+
+  if (parsed.interactive) {
+    shelveArgs.push("-i");
+  }
+
+  if (parsed.keep) {
+    shelveArgs.push("--keep");
+  }
+
+  // Add any remaining positional arguments (file paths)
+  const positionalArgs = parsed._.map(String);
+  if (positionalArgs.length > 0) {
+    shelveArgs.push(...positionalArgs);
+  }
+
+  const result = await runShellCommand(shelveArgs);
+
+  if (result === 0) {
+    ui.output(`✅ Changes shelved successfully as '${shelveName}'`);
+  }
+
+  return result;
+}
+
+/**
+ * Enhanced unshelve command
+ */
+async function handleUnshelve(args: Array<string>): Promise<number> {
+  const parsed = parseArgs(args, {
+    string: ["name"],
+    boolean: ["keep", "tool"],
+    alias: { n: "name", k: "keep", t: "tool" },
+  });
+
+  const shelveName = parsed.name || parsed._[0]?.toString();
+
+  // If no name provided, list available shelves
+  if (!shelveName) {
+    const shelves = await getShelvedChangesList();
+    if (shelves.length === 0) {
+      ui.output("No shelved changes found");
+      return 0;
+    }
+
+    ui.output("Available shelves:");
+    for (const shelve of shelves) {
+      ui.output(`  - ${shelve}`);
+    }
+    ui.output("\nUsage: bft sl unshelve <name>");
+    return 0;
+  }
+
+  ui.output(`📤 Unshelving '${shelveName}'...`);
+
+  // Build unshelve command
+  const unshelveArgs = ["sl", "unshelve", shelveName];
+
+  if (parsed.keep) {
+    unshelveArgs.push("--keep");
+  }
+
+  if (parsed.tool) {
+    unshelveArgs.push("--tool");
+  }
+
+  const result = await runShellCommand(unshelveArgs);
+
+  if (result === 0) {
+    ui.output(`✅ Successfully unshelved '${shelveName}'`);
+  } else {
+    ui.error(`❌ Failed to unshelve '${shelveName}'`);
+    if (!parsed.tool) {
+      ui.output("💡 Tip: Use --tool flag to resolve conflicts interactively");
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Check if there are uncommitted changes
+ */
+async function hasUncommittedChanges(): Promise<boolean> {
+  const changes = await getChangedFiles();
+  return changes.length > 0;
+}
+
+/**
+ * Enhanced checkout command with automatic shelve/unshelve
+ */
+async function handleCheckout(args: Array<string>): Promise<number> {
+  const parsed = parseArgs(args, {
+    string: ["branch", "shelve-name"],
+    boolean: ["no-shelve", "keep-shelved"],
+    alias: { b: "branch", s: "shelve-name" },
+  });
+
+  const targetBranch = parsed.branch || parsed._[0]?.toString() ||
+    "remote/main";
+  const autoShelveName = parsed["shelve-name"] || `checkout-${Date.now()}`;
+
+  // Check for uncommitted changes
+  let shelvedChanges = false;
+  if (!parsed["no-shelve"] && await hasUncommittedChanges()) {
+    ui.output("🔍 Detected uncommitted changes");
+
+    // Shelve current changes
+    ui.output(`📦 Shelving changes as '${autoShelveName}'...`);
+    const shelveResult = await runShellCommand([
+      "sl",
+      "shelve",
+      "-n",
+      autoShelveName,
+    ]);
+
+    if (shelveResult !== 0) {
+      ui.error("❌ Failed to shelve changes");
+      return shelveResult;
+    }
+
+    shelvedChanges = true;
+    ui.output(`✅ Changes shelved as '${autoShelveName}'`);
+  }
+
+  // Checkout target branch
+  ui.output(`🔄 Checking out '${targetBranch}'...`);
+  const checkoutResult = await runShellCommand(["sl", "goto", targetBranch]);
+
+  if (checkoutResult !== 0) {
+    ui.error(`❌ Failed to checkout '${targetBranch}'`);
+
+    // Try to restore shelved changes if checkout failed
+    if (shelvedChanges) {
+      ui.output(`🔄 Restoring shelved changes...`);
+      await runShellCommand(["sl", "unshelve", autoShelveName]);
+    }
+
+    return checkoutResult;
+  }
+
+  ui.output(`✅ Successfully checked out '${targetBranch}'`);
+
+  // Unshelve changes if requested (default behavior unless --keep-shelved)
+  if (shelvedChanges && !parsed["keep-shelved"]) {
+    ui.output(`📤 Restoring shelved changes...`);
+    const unshelveResult = await runShellCommand([
+      "sl",
+      "unshelve",
+      autoShelveName,
+    ]);
+
+    if (unshelveResult !== 0) {
+      ui.error(`❌ Failed to unshelve changes`);
+      ui.output(`💡 Your changes are still shelved as '${autoShelveName}'`);
+      ui.output(
+        `   Run 'bft sl unshelve ${autoShelveName}' to restore them manually`,
+      );
+      return unshelveResult;
+    }
+
+    ui.output(`✅ Changes restored successfully`);
+  } else if (shelvedChanges) {
+    ui.output(`📦 Changes remain shelved as '${autoShelveName}'`);
+    ui.output(
+      `   Run 'bft sl unshelve ${autoShelveName}' when ready to restore`,
+    );
+  }
+
+  return 0;
+}
+
+/**
  * Main sl proxy command
  */
 export async function slCommand(options: Array<string>): Promise<number> {
@@ -267,6 +496,12 @@ export async function slCommand(options: Array<string>): Promise<number> {
     return await handleCommit(args);
   } else if (subcommand === "amend") {
     return await handleAmend(args);
+  } else if (subcommand === "shelve") {
+    return await handleShelve(args);
+  } else if (subcommand === "unshelve") {
+    return await handleUnshelve(args);
+  } else if (subcommand === "checkout") {
+    return await handleCheckout(args);
   } else {
     // Pass through all other commands
     return await runShellCommand(["sl", ...options]);
@@ -296,6 +531,7 @@ function isSlCommandSafe(args: Array<string>): boolean {
     "purge",
     "shelve",
     "unshelve",
+    "checkout",
     "metaedit",
     "rebase",
     "graft",


### PR DESCRIPTION
- Enhanced sl.bft.ts with shelve, unshelve, and checkout commands
- Added automatic shelving of uncommitted changes before checkout
- Integrated checkout functionality into codebot with --checkout flag
- Made codebot default to checking out remote/main on new workspaces
- Added smart shelve naming and graceful error handling

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/1763)
<!-- GitContextEnd -->