### PR TITLE
Fix: Exclude .codebot-metadata from workspace copy operation

### DIFF
--- a/infra/bft/tasks/codebot.bft.ts
+++ b/infra/bft/tasks/codebot.bft.ts
@@ -679,8 +679,11 @@ FIRST TIME SETUP:
       const copyPromises = [];
 
       for await (const entry of Deno.readDir(".")) {
-        // Skip .bft and tmp directories entirely
-        if (entry.name === ".bft" || entry.name === "tmp") continue;
+        // Skip .bft, tmp, and .codebot-metadata directories entirely
+        if (
+          entry.name === ".bft" || entry.name === "tmp" ||
+          entry.name === ".codebot-metadata"
+        ) continue;
 
         const copyCmd = new Deno.Command("cp", {
           args: [


### PR DESCRIPTION
Prevents the .codebot-metadata directory from being copied during bft codebot workspace creation, ensuring each workspace gets its own fresh metadata directory without interference from previous runs.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/bolt-foundry/bolt-foundry/1766)
<!-- GitContextEnd -->