### PR TITLE
feat(bfDb): add .many() relationship support to FieldBuilder

### DIFF
--- a/apps/bfDb/builders/bfDb/makeFieldBuilder.ts
+++ b/apps/bfDb/builders/bfDb/makeFieldBuilder.ts
@@ -40,6 +40,7 @@ export type FieldBuilder<
   ): FieldBuilder<F & { [K in N]: { kind: "enum"; values: V } }, R>;
 
   one: RelationAdder<"out", "one", F, R>;
+  many: RelationAdder<"out", "many", F, R>;
 
   readonly _spec: { fields: F; relations: R };
 };
@@ -149,6 +150,7 @@ export function makeFieldBuilder<
     json,
     enum: enumField,
     one: addRel("out", "one"),
+    many: addRel("out", "many"),
     _spec: out,
   } as FieldBuilder<F, R>;
 }

--- a/memos/1-projects/automatic-relationship-methods/README.md
+++ b/memos/1-projects/automatic-relationship-methods/README.md
@@ -1,0 +1,366 @@
+# Automatic Relationship Methods for bfDb
+
+## Problem
+
+Currently, when working with bfDb relationships, developers need to manually
+write boilerplate code for common operations like finding, creating, and
+deleting related nodes. This leads to repetitive code and inconsistent patterns
+across the codebase.
+
+## Proposed Solution
+
+Automatically generate relationship methods on bfDb nodes for both one-to-one
+and one-to-many relationships.
+
+### For `.one()` relationships:
+
+- `find{RelationName}()` - Find the related node (returns null if not found)
+- `findX{RelationName}()` - Find the related node (throws if not found)
+- `create{RelationName}(props)` - Create and link a new related node
+- `unlink{RelationName}()` - Remove the relationship (edge only)
+- `delete{RelationName}()` - Delete the related node and relationship
+
+### For `.many()` relationships:
+
+- `findAll{RelationName}()` - Find all related nodes
+- `query{RelationName}(args)` - Query related nodes with filters, ordering, and
+  pagination
+- `connectionFor{RelationName}(args)` - GraphQL connection with cursor-based
+  pagination
+- `create{RelationName}(props)` - Create and link a new related node
+- `add{RelationName}(node)` - Link an existing node
+- `remove{RelationName}(node)` - Remove a node from the relationship (edge only)
+- `delete{RelationName}(node)` - Delete the node and remove from relationship
+
+## Example Usage
+
+```typescript
+// Define nodes with relationships
+class BfBook extends BfNode {
+  static bfNodeSpec = this.defineBfNode((f) =>
+    f.string("title")
+      .one("author", () => BfPerson) // Multiple relationships
+      .one("illustrator", () => BfPerson) // to the same type
+      .many("review", () => BfReview) // Use singular for relationship name
+  );
+}
+
+// Automatically generated methods for .one():
+const book = await BfBook.findX(cv, bookId);
+
+// Each relationship gets its own set of methods, even for the same target type
+const author = await book.findAuthor(); // Returns BfPerson | null
+const illustrator = await book.findIllustrator(); // Returns BfPerson | null
+
+const newAuthor = await book.createAuthor({ name: "Jane Smith" });
+const newIllustrator = await book.createIllustrator({ name: "John Doe" });
+
+// Remove just the relationship (edge only)
+await book.unlinkAuthor();
+await book.unlinkIllustrator();
+
+// Delete the node and relationship
+await book.deleteAuthor();
+await book.deleteIllustrator();
+
+// Automatically generated methods for .many():
+const reviews = await book.findAllReview();
+const topReviews = await book.queryReview({
+  where: { rating: { gte: 4 } },
+  orderBy: { createdAt: "desc" },
+  limit: 10,
+});
+const reviewConnection = await book.connectionForReview({
+  first: 20,
+  after: "cursor123",
+  where: { rating: { gte: 4 } },
+});
+const newReview = await book.createReview({ rating: 5, text: "Great!" });
+await book.addReview(existingReview);
+await book.removeReview(review); // Just removes from collection
+await book.deleteReview(review); // Deletes the review node
+```
+
+## Design Decision: Basic Relationships Only
+
+### What We Support
+
+This feature supports basic relationships without roles or edge properties for
+both:
+
+- **One-to-one relationships** (`.one()`) - Single related node
+- **One-to-many relationships** (`.many()`) - Multiple related nodes
+
+### Why Not Extended Relationships?
+
+While bfDb supports complex edges with roles and properties, we're explicitly
+making this an anti-goal because:
+
+1. **Complexity creep**: Supporting roles/edge properties would complicate the
+   API and implementation significantly
+2. **Unclear patterns**: There's no obvious "right way" to expose these in
+   generated methods
+3. **Escape hatch exists**: For complex relationships, developers can still use
+   the lower-level bfDb APIs directly
+
+### Recommendation
+
+If you need relationships with roles or edge properties, don't use the generated
+methods. Instead, use the existing bfDb query and edge creation APIs directly.
+This keeps the generated methods simple and predictable for the 80% use case.
+
+## Type Safety Implementation: Generic Type Mapping
+
+We will use a Generic Type Mapping approach for type safety. This provides full
+type safety without requiring code generation or build steps.
+
+### Implementation Details
+
+This approach creates a type that maps from spec to methods and applies it
+automatically:
+
+```typescript
+// Import existing types from bfDb
+import type {
+  AnyBfNodeCtor,
+  InferProps,
+} from "@bfmono/apps/bfDb/classes/BfNode.ts";
+import type { RelationSpec } from "@bfmono/apps/bfDb/builders/bfDb/types.ts";
+
+// Reuse UnionToIntersection from std library
+type UnionToIntersection<T> =
+  (T extends unknown ? (args: T) => unknown : never) extends
+    (args: infer R) => unknown ? R : never;
+
+// Extract relation names from bfNodeSpec
+type RelationNames<T extends AnyBfNodeCtor> = T extends
+  { bfNodeSpec: { relations: infer R } } ? keyof R
+  : never;
+
+// Get the target type for a specific relation
+type RelationTarget<T extends AnyBfNodeCtor, K extends string> = T extends
+  { bfNodeSpec: { relations: Record<K, RelationSpec> } }
+  ? T["bfNodeSpec"]["relations"][K] extends { target: () => infer Target }
+    ? Target extends AnyBfNodeCtor ? Target : never
+  : never
+  : never;
+
+// Detect relationship cardinality
+type RelationCardinality<T extends AnyBfNodeCtor, K extends string> = T extends
+  { bfNodeSpec: { relations: Record<K, infer R> } }
+  ? R extends { cardinality: infer C } ? C : "one"
+  : never;
+
+// Generate method signatures for .one() relationships
+type OneRelationshipMethods<T extends AnyBfNodeCtor> = UnionToIntersection<
+  RelationNames<T> extends string
+    ? RelationCardinality<T, RelationNames<T>> extends "one" ?
+        & {
+          [K in RelationNames<T> as `find${Capitalize<K>}`]: () => Promise<
+            InstanceType<RelationTarget<T, K>> | null
+          >;
+        }
+        & {
+          [K in RelationNames<T> as `findX${Capitalize<K>}`]: () => Promise<
+            InstanceType<RelationTarget<T, K>>
+          >;
+        }
+        & {
+          [K in RelationNames<T> as `create${Capitalize<K>}`]: (
+            props: InferProps<RelationTarget<T, K>>,
+          ) => Promise<InstanceType<RelationTarget<T, K>>>;
+        }
+        & {
+          [K in RelationNames<T> as `unlink${Capitalize<K>}`]: () => Promise<
+            void
+          >;
+        }
+        & {
+          [K in RelationNames<T> as `delete${Capitalize<K>}`]: () => Promise<
+            void
+          >;
+        }
+    : never
+    : never
+>;
+
+// Query and connection types for .many() relationships
+type QueryArgs<T> = {
+  where?: Partial<InferProps<T>>;
+  orderBy?: { [K in keyof InferProps<T>]?: "asc" | "desc" };
+  limit?: number;
+  offset?: number;
+};
+
+type ConnectionArgs = {
+  first?: number;
+  after?: string;
+  last?: number;
+  before?: string;
+  where?: any; // Same as QueryArgs where clause
+};
+
+// Generate method signatures for .many() relationships
+type ManyRelationshipMethods<T extends AnyBfNodeCtor> = UnionToIntersection<
+  RelationNames<T> extends string
+    ? RelationCardinality<T, RelationNames<T>> extends "many" ?
+        & {
+          [K in RelationNames<T> as `findAll${Capitalize<K>}`]: () => Promise<
+            Array<InstanceType<RelationTarget<T, K>>>
+          >;
+        }
+        & {
+          [K in RelationNames<T> as `query${Capitalize<K>}`]: (
+            args: QueryArgs<RelationTarget<T, K>>,
+          ) => Promise<Array<InstanceType<RelationTarget<T, K>>>>;
+        }
+        & {
+          [K in RelationNames<T> as `connectionFor${Capitalize<K>}`]: (
+            args: ConnectionArgs,
+          ) => Promise<Connection<InstanceType<RelationTarget<T, K>>>>;
+        }
+        & {
+          [K in RelationNames<T> as `create${Capitalize<K>}`]: (
+            props: InferProps<RelationTarget<T, K>>,
+          ) => Promise<InstanceType<RelationTarget<T, K>>>;
+        }
+        & {
+          [K in RelationNames<T> as `add${Capitalize<K>}`]: (
+            node: InstanceType<RelationTarget<T, K>>,
+          ) => Promise<void>;
+        }
+        & {
+          [K in RelationNames<T> as `remove${Capitalize<K>}`]: (
+            node: InstanceType<RelationTarget<T, K>>,
+          ) => Promise<void>;
+        }
+        & {
+          [K in RelationNames<T> as `delete${Capitalize<K>}`]: (
+            node: InstanceType<RelationTarget<T, K>>,
+          ) => Promise<void>;
+        }
+    : never
+    : never
+>;
+
+// Combine both relationship types
+type RelationshipMethods<T extends AnyBfNodeCtor> =
+  & OneRelationshipMethods<T>
+  & ManyRelationshipMethods<T>;
+
+// Combine with base type - return type for findX, create, etc.
+type WithRelationships<T extends BfNode> = T & RelationshipMethods<typeof T>;
+
+// Usage - automatically typed!
+const book = await BfBook.findX(cv, id); // Returns WithRelationships<BfBook>
+book.findAuthor(); // Promise<BfAuthor | null> - fully typed!
+book.findXAuthor(); // Promise<BfAuthor> - throws if not found
+book.createAuthor({ name: "...", bio: "..." }); // Promise<BfAuthor>
+book.unlinkAuthor(); // Promise<void> - removes edge only
+book.deleteAuthor(); // Promise<void> - deletes node and edge
+```
+
+- **Pros**:
+  - No codegen or build step required
+  - Transparent to users - just works
+  - Uses TypeScript's existing type system
+  - All factory methods (findX, create, query) can return WithRelationships<T>
+- **Cons**:
+  - Complex type definitions to maintain
+  - Need to ensure all node creation paths return the augmented type
+
+### Benefits of This Approach
+
+By modifying BfNode's static methods (findX, create, query) to return
+`WithRelationships<T>`, we get:
+
+- Full type safety and autocomplete
+- No build step or generated files
+- Transparent API - users get typed methods automatically
+- Leverages TypeScript's powerful type system
+
+## Implementation Plan
+
+The implementation is broken down into 8 phases:
+
+### One-to-One Relationships (`.one()`)
+
+1. **[Phase 1: Type System Foundation](./phase-1-type-system-foundation.md)** -
+   Build the TypeScript type system
+2. **[Phase 2: Runtime Implementation](./phase-2-runtime-implementation.md)** -
+   Implement method generation
+3. **[Phase 3: Migration & Adoption](./phase-3-migration-adoption.md)** -
+   Migrate existing code
+4. **[Phase 4: Enforcement & Cleanup](./phase-4-enforcement-cleanup.md)** -
+   Ensure consistent usage
+
+### One-to-Many Relationships (`.many()`)
+
+5. **[Phase 5: Type System for Many](./phase-5-type-system-many.md)** - Extend
+   types for collections
+6. **[Phase 6: Runtime Implementation for Many](./phase-6-runtime-implementation-many.md)** -
+   Implement collection methods
+7. **[Phase 7: Advanced Many Features](./phase-7-advanced-many-features.md)** -
+   Add batch operations and optimizations
+8. **[Phase 8: Many Relationship Migration](./phase-8-many-relationship-migration.md)** -
+   Migrate existing patterns
+
+## Important Implementation Notes
+
+### Transaction Context (cv) Parameter
+
+The generated instance methods access the `CurrentViewer` from the node instance
+itself, so cv is not needed as a parameter. The cv was already provided when the
+node was loaded via static methods like `BfBook.findX(cv, id)`.
+
+### Method Naming Convention
+
+All generated methods use singular forms based on the relationship name:
+
+- `findAllReview()` - find all reviews
+- `queryReview()` - query reviews with filters
+- `connectionForReview()` - get GraphQL connection for reviews
+- `createReview()` - creates one review
+- `addReview()` - adds one existing review
+- `removeReview()` - removes one review
+- `deleteReview()` - deletes one review
+
+### Advanced Features (Phase 7+)
+
+The following features will be added in Phase 7:
+
+- **Batch operations**: `addManyReview([reviews])`,
+  `removeManyReview([reviews])`
+- **Async iteration**: `iterateReview()` for memory-efficient processing
+- **Performance optimizations**: Caching, query batching, and connection pooling
+
+### Error Handling
+
+- `findX{RelationName}()` methods throw `NotFoundError` if the relationship
+  doesn't exist
+- All methods properly propagate database errors
+- Transaction rollback is handled automatically on errors
+
+## Key Differences Between `.one()` and `.many()`
+
+- **Method names**: `findAll{RelationName}` vs `find{RelationName}`
+- **Return types**: Arrays/iterators vs single items
+- **Additional methods**:
+  - `query{RelationName}()` for advanced filtering and sorting
+  - `connectionFor{RelationName}()` for GraphQL-compatible connections
+  - `add{RelationName}()` for linking existing nodes
+- **Query parameters**: Object-based API matching GraphQL patterns
+- **GraphQL integration**: Connection-based pagination with cursors
+- **Pagination**: Built-in support for large collections
+- **Filtering**: Type-safe query parameters through parameter objects
+
+## Files to Modify
+
+- `apps/bfDb/builders/bfDb/relationshipMethods.ts` - New file for core
+  implementation of both `.one()` and `.many()` methods
+- `apps/bfDb/types/relationshipMethods.ts` - Type definitions for relationship
+  methods
+- `apps/bfDb/classes/BfNode.ts` - Add integration in constructor
+- `apps/bfDb/builders/bfDb/__tests__/relationshipMethods.test.ts` - Test
+  coverage
+- `apps/bfDb/types/__tests__/relationshipMethods.type.test.ts` - Type tests

--- a/memos/1-projects/automatic-relationship-methods/phase-1-type-system-foundation.md
+++ b/memos/1-projects/automatic-relationship-methods/phase-1-type-system-foundation.md
@@ -1,0 +1,224 @@
+# Phase 1: Type System Foundation
+
+[← Back to README](./README.md) |
+[Next Phase →](./phase-2-runtime-implementation.md)
+
+**Goal**: Get the TypeScript types working correctly with full type safety and
+autocomplete
+
+**Related sections in README:**
+
+- [Type Safety Implementation](./README.md#type-safety-implementation-generic-type-mapping)
+- [For .one() relationships](./README.md#for-one-relationships)
+
+## 1. Create type test file with mock types
+
+Create `apps/bfDb/types/__tests__/relationshipMethods.type.test.ts`
+
+Start by testing the `WithRelationships` type in isolation:
+
+```typescript
+// Mock types to test WithRelationships without full BfNode complexity
+// These mock types should mirror the actual bfNodeSpec structure
+type MockNodeSpec = {
+  relations: {
+    author: { cardinality: "one"; target: () => MockAuthorNode };
+    illustrator: { cardinality: "one"; target: () => MockPersonNode };
+  };
+};
+
+class MockBookNode {
+  static bfNodeSpec: MockNodeSpec;
+  id: string;
+}
+
+class MockAuthorNode {
+  static bfNodeSpec: {};
+  id: string;
+  name: string;
+}
+
+class MockPersonNode {
+  static bfNodeSpec: {};
+  id: string;
+  name: string;
+}
+
+Deno.test("WithRelationships type augments node correctly", () => {
+  // Test that WithRelationships<MockBookNode> has the expected methods
+  // This lets us validate the type logic before integrating with real BfNode
+
+  type BookWithRels = WithRelationships<MockBookNode>;
+
+  // These should type-check once WithRelationships is implemented:
+  // const book: BookWithRels;
+  // book.findAuthor() // should return Promise<MockAuthorNode | null>
+  // book.findXAuthor() // should return Promise<MockAuthorNode>
+  // book.createAuthor({ name: "..." }) // should accept author props
+  // book.unlinkAuthor() // should return Promise<void>
+  // book.deleteAuthor() // should return Promise<void>
+
+  // Same for illustrator relationship
+  // book.findIllustrator() // should return Promise<MockPersonNode | null>
+});
+```
+
+## 2. Create initial type definitions (`apps/bfDb/builders/bfDb/relationshipMethods.ts`)
+
+Note: We're placing type definitions in the builders directory alongside the
+runtime implementation, not in a separate types directory.
+
+Focus on getting the basic type mapping working:
+
+```typescript
+// Start simple - just extract relationship names and generate method signatures
+type RelationshipMethods<T> = {
+  // For each relationship in T.bfNodeSpec.relations
+  // Generate find{Name}, findX{Name}, create{Name}, unlink{Name}, delete{Name}
+  // Instance methods access cv from the node instance itself
+};
+
+type WithRelationships<T> = T & RelationshipMethods<T>;
+```
+
+## 3. Iteratively refine the types
+
+- Get relationship name extraction working
+- Add method generation for each relationship
+- Handle the target type resolution
+- Test with mock types until it works correctly
+
+## 4. Expand test scenarios with real BfNode types
+
+### Core type tests:
+
+```typescript
+Deno.test("Basic single relationship", () => {
+  // Node with one .one() relationship should have findAuthor(), findXAuthor(), createAuthor(), unlinkAuthor(), and deleteAuthor() methods
+  // findAuthor() should return Promise<BfAuthor | null>
+  // findXAuthor() should return Promise<BfAuthor> and throw if not found
+  // createAuthor(props) should require BfAuthor properties and return Promise<BfAuthor>
+  // unlinkAuthor() removes the edge only
+  // deleteAuthor() deletes the node and edge
+  // Instance methods use cv from the node instance
+});
+
+Deno.test("Multiple relationships on same node", () => {
+  // Node with multiple .one() relationships (e.g., author, publisher, editor)
+  // Each relationship should generate its own set of methods
+  // All methods should be available on the same node instance
+});
+
+Deno.test("TypeScript compile-time error scenarios", () => {
+  // book.findPublisher() when BfBook has no publisher relationship - should be TS error
+  // book.createAuthor({ wrongProp: "value" }) - should be TS error for invalid props
+  // Methods on nodes without relationships should not exist
+});
+```
+
+## 5. Handle edge cases in types
+
+Test edge case scenarios:
+
+```typescript
+Deno.test("Node with no relationships", () => {
+  // Should not have any generated methods
+  // Type system should handle this gracefully without errors
+});
+
+Deno.test("Circular relationship references", () => {
+  // Node A has .one("nodeB", () => BfNodeB)
+  // Node B has .one("nodeA", () => BfNodeA)
+  // Type system should not create infinite loops
+});
+
+Deno.test("Self-referential relationship", () => {
+  // Node with .one("manager", () => BfEmployee)
+  // findManager() and findXManager() should both work
+  // Type inference should work with same type as source and target
+});
+```
+
+## 6. Update BfNode type signatures
+
+- Modify return types of `findX`, `create`, `query` to use
+  `WithRelationships<T>`
+- Integration tests:
+
+```typescript
+Deno.test("Integration with BfNode factory methods", () => {
+  // Methods available on BfBook.findX() result
+  // Methods available on BfBook.create() result
+  // Type augmentation shouldn't break existing BfNode functionality
+});
+```
+
+## Success Criteria
+
+- Mock type tests validate `WithRelationships` works correctly
+- Type extraction from `bfNodeSpec` works for relationship names and cardinality
+- Method signatures are correctly generated for each relationship
+- Return types are properly inferred from target nodes
+- Instance methods access cv from the node instance (no cv parameter needed)
+- Type definitions are in `apps/bfDb/builders/bfDb/relationshipMethods.ts`
+- **Do not proceed to Phase 2 until `WithRelationships` type is fully working**
+
+### Validation before moving on:
+
+```typescript
+// This should compile without errors:
+type BookWithRels = WithRelationships<MockBookNode>;
+declare const book: BookWithRels;
+declare const cv: CurrentViewer;
+
+// All these should have correct types (no cv parameter for instance methods):
+const a1: Promise<MockAuthorNode | null> = book.findAuthor();
+const a2: Promise<MockAuthorNode> = book.findXAuthor();
+const a3: Promise<MockAuthorNode> = book.createAuthor({ name: "test" });
+const a4: Promise<void> = book.unlinkAuthor();
+const a5: Promise<void> = book.deleteAuthor();
+```
+
+## Next Steps
+
+1. **Run tests in parallel**:
+   ```bash
+   bft test apps/bfDb/types/__tests__/relationshipMethods.type.test.ts
+   bft lint apps/bfDb/types/
+   bft check apps/bfDb/types/
+   ```
+
+2. **Format code**:
+   ```bash
+   bft format
+   ```
+
+3. **Commit changes**:
+   ```bash
+   bft commit
+   ```
+
+4. **Submit PR**:
+   ```bash
+   sl pr submit
+   ```
+
+5. **Monitor PR**:
+   - Watch the pull request for CI check results
+   - Fix any issues that arise
+   - If fixes needed:
+     ```bash
+     bft amend
+     sl pr submit
+     ```
+
+6. **Once all checks pass**:
+   - Proceed to
+     [Phase 2: Runtime Implementation](./phase-2-runtime-implementation.md)
+   - Begin implementing the runtime method generation
+
+**Important**: Do not proceed to Phase 2 until:
+
+- All type tests pass
+- `WithRelationships` type works correctly with mock types
+- PR checks are green

--- a/memos/1-projects/automatic-relationship-methods/phase-2-runtime-implementation.md
+++ b/memos/1-projects/automatic-relationship-methods/phase-2-runtime-implementation.md
@@ -1,0 +1,117 @@
+# Phase 2: Runtime Implementation
+
+[← Previous Phase](./phase-1-type-system-foundation.md) |
+[Back to README](./README.md) | [Next Phase →](./phase-3-migration-adoption.md)
+
+**Goal**: Implement the actual method generation once types are solid
+
+**Related sections in README:**
+
+- [Example Usage](./README.md#example-usage)
+- [For .one() relationships](./README.md#for-one-relationships)
+
+## 1. Create `apps/bfDb/builders/bfDb/relationshipMethods.ts`
+
+- Implement `generateRelationshipMethods()` function
+- Add runtime method generation for `find`, `findX`, `create`, `unlink`, and
+  `delete` operations
+- Ensure methods match the type signatures exactly
+
+## 2. Integrate with BfNode
+
+- Call `generateRelationshipMethods()` in BfNode constructor
+- Ensure runtime behavior matches type expectations
+- Handle edge cases (missing relationships, null values)
+
+## 3. Unit tests (`apps/bfDb/builders/bfDb/__tests__/relationshipMethods.test.ts`)
+
+### Runtime behavior tests:
+
+```typescript
+Deno.test("Complex property types in target node", () => {
+  // Target node has complex required properties (objects, arrays, enums)
+  // createRelation() should require all properties with correct types
+  // Optional vs required properties should be preserved
+});
+
+Deno.test("Relationship name transformations", () => {
+  // .one("authorInfo") → findAuthorInfo(), createAuthorInfo()
+  // Handle various naming patterns correctly
+});
+```
+
+## 4. Integration testing
+
+### Advanced integration tests:
+
+```typescript
+Deno.test("Type inference through method chaining", () => {
+  // const author = await book.findAuthor()
+  // author should be typed as BfAuthor | null
+  // Further chaining should work if author has relationships
+});
+
+Deno.test("Async type propagation", () => {
+  // Promise<WithRelationships<BfBook>> should properly unwrap
+  // Array methods: books.map(book => book.findAuthor()) should type correctly
+});
+```
+
+## Implementation Notes
+
+- Methods should be added dynamically in the constructor
+- Use proper error handling for `findX` variants (throw NotFound)
+- Methods should access cv from the node instance (this._cv or similar)
+- Handle null/undefined cases gracefully
+
+## Success Criteria
+
+- All runtime tests pass
+- Methods behave exactly as types indicate
+- No performance regression
+- Error messages are helpful and clear
+
+## Next Steps
+
+1. **Run tests in parallel**:
+   ```bash
+   bft test apps/bfDb/builders/bfDb/__tests__/relationshipMethods.test.ts
+   bft test apps/bfDb/
+   bft lint apps/bfDb/builders/bfDb/relationshipMethods.ts
+   bft check apps/bfDb/
+   ```
+
+2. **Format code**:
+   ```bash
+   bft format
+   ```
+
+3. **Commit changes**:
+   ```bash
+   bft commit
+   ```
+
+4. **Submit PR**:
+   ```bash
+   sl pr submit
+   ```
+
+5. **Monitor PR**:
+   - Watch the pull request for CI check results
+   - Fix any issues that arise
+   - If fixes needed:
+     ```bash
+     bft amend
+     sl pr submit
+     ```
+
+6. **Once all checks pass**:
+   - Proceed to [Phase 3: Migration & Adoption](./phase-3-migration-adoption.md)
+   - Begin implementing migration tooling and code updates
+
+**Important**: Do not proceed to Phase 3 until:
+
+- All unit tests pass for relationship method generation
+- Integration tests demonstrate proper type inference
+- Runtime behavior matches type expectations exactly
+- PR checks are green

--- a/memos/1-projects/automatic-relationship-methods/phase-3-migration-adoption.md
+++ b/memos/1-projects/automatic-relationship-methods/phase-3-migration-adoption.md
@@ -1,0 +1,111 @@
+# Phase 3: Migration & Adoption
+
+[← Previous Phase](./phase-2-runtime-implementation.md) |
+[Back to README](./README.md) | [Next Phase →](./phase-4-enforcement-cleanup.md)
+
+**Goal**: Safely migrate existing code to use generated methods
+
+**Related sections in README:**
+
+- [Design Decision: Basic Relationships Only](./README.md#design-decision-basic-relationships-only)
+
+## 1. Audit current usage
+
+- Add disabled lint rule to identify `createTargetNode` usage
+- Generate report of all locations that need updating
+- Identify any special cases or blockers
+
+## 2. Create migration tooling
+
+- Write codemod to automatically update existing code
+- Handle common patterns and edge cases
+- Provide manual migration guide for complex cases
+
+## 3. Execute migration
+
+- Run codemod on codebase
+- Manually review and test changes
+- Update any documentation or examples
+
+## Migration Patterns
+
+### Before:
+
+```typescript
+// Current pattern: createTargetNode with class and props
+const author = await book.createTargetNode(BfAuthor, {
+  name: "Jane",
+});
+```
+
+### After:
+
+```typescript
+// Generated method: relationship name in method, cv comes from instance
+const author = await book.createAuthor({ name: "Jane" });
+```
+
+### Note on createTargetNode Signature
+
+The actual `createTargetNode` signature in BfNode.ts is:
+
+```typescript
+createTargetNode<TProps>(TargetNodeClass, props, options?)
+```
+
+Not the incorrect pattern shown in some examples with a string relationship name
+as the first parameter.
+
+## Success Criteria
+
+- All existing code migrated
+- No breaking changes
+- Tests continue to pass
+- Clear migration documentation
+
+## Next Steps
+
+1. **Run tests in parallel**:
+   ```bash
+   bft test apps/bfDb/
+   bft test apps/boltFoundry/
+   bft lint .
+   bft check .
+   ```
+
+2. **Format code**:
+   ```bash
+   bft format
+   ```
+
+3. **Commit changes**:
+   ```bash
+   bft commit
+   ```
+
+4. **Submit PR**:
+   ```bash
+   sl pr submit
+   ```
+
+5. **Monitor PR**:
+   - Watch the pull request for CI check results
+   - Fix any issues that arise
+   - If fixes needed:
+     ```bash
+     bft amend
+     sl pr submit
+     ```
+
+6. **Once all checks pass**:
+   - Proceed to
+     [Phase 4: Enforcement & Cleanup](./phase-4-enforcement-cleanup.md)
+   - Begin implementing enforcement mechanisms and documentation
+
+**Important**: Do not proceed to Phase 4 until:
+
+- All existing `createTargetNode` usage has been migrated
+- Codemod has been tested and works correctly
+- All tests pass after migration
+- No breaking changes introduced
+- PR checks are green

--- a/memos/1-projects/automatic-relationship-methods/phase-4-enforcement-cleanup.md
+++ b/memos/1-projects/automatic-relationship-methods/phase-4-enforcement-cleanup.md
@@ -1,0 +1,91 @@
+# Phase 4: Enforcement & Cleanup
+
+[← Previous Phase](./phase-3-migration-adoption.md) |
+[Back to README](./README.md) | [Next Phase →](./phase-5-type-system-many.md)
+
+**Goal**: Ensure consistent usage going forward
+
+**Related sections in README:**
+
+- [Files to Modify](./README.md#files-to-modify)
+
+## 1. Enable enforcement
+
+- Enable lint rule to prevent direct `createTargetNode` usage
+- Make `createTargetNode` protected
+- Update developer documentation
+
+## 2. Handle delete functionality
+
+- Implement `BfEdge.delete()` if not already available
+- Ensure `delete{RelationName}()` methods work correctly
+- Add appropriate options (cascade delete, etc.)
+
+## 3. Documentation & training
+
+- Update bfDb documentation
+- Create examples and best practices
+- Train team on new patterns
+
+## Documentation Topics
+
+- How to use relationship methods
+- When to use find vs findX
+- When to use unlink vs delete
+- Best practices for error handling
+- Migration guide from old patterns
+
+## Success Criteria for .one() Implementation
+
+- All one-to-one relationships automatically get typed methods
+- Zero runtime overhead for type safety
+- Existing code migrated without breaking changes
+- Developer experience improved with autocomplete and type checking
+- Clear documentation and examples available
+
+## Next Steps
+
+1. **Run tests in parallel**:
+   ```bash
+   bft test apps/bfDb/
+   bft lint infra/lint/
+   bft lint apps/bfDb/
+   bft check .
+   ```
+
+2. **Format code**:
+   ```bash
+   bft format
+   ```
+
+3. **Commit changes**:
+   ```bash
+   bft commit
+   ```
+
+4. **Submit PR**:
+   ```bash
+   sl pr submit
+   ```
+
+5. **Monitor PR**:
+   - Watch the pull request for CI check results
+   - Fix any issues that arise
+   - If fixes needed:
+     ```bash
+     bft amend
+     sl pr submit
+     ```
+
+6. **Once all checks pass**:
+   - Proceed to
+     [Phase 5: Type System for Many Relationships](./phase-5-type-system-many.md)
+   - Begin implementing many relationship type system
+
+**Important**: Do not proceed to Phase 5 until:
+
+- Lint rules are enabled and preventing direct `createTargetNode` usage
+- `createTargetNode` is properly protected
+- Delete functionality works correctly
+- Documentation is complete and accurate
+- PR checks are green

--- a/memos/1-projects/automatic-relationship-methods/phase-5-type-system-many.md
+++ b/memos/1-projects/automatic-relationship-methods/phase-5-type-system-many.md
@@ -1,0 +1,175 @@
+# Phase 5: Type System for Many Relationships
+
+[← Previous Phase](./phase-4-enforcement-cleanup.md) |
+[Back to README](./README.md) |
+[Next Phase →](./phase-6-runtime-implementation-many.md)
+
+**Goal**: Extend the type system to handle one-to-many relationships
+
+**Related sections in README:**
+
+- [For .many() relationships](./README.md#for-many-relationships)
+- [Key Differences Between .one() and .many()](./README.md#key-differences-between-one-and-many)
+
+## 1. Extend type definitions
+
+- Add `ManyRelationshipMethods<T>` type for `.many()` relationships
+- All methods use **singular forms** based on the relationship name:
+  - `findAll{RelationName}()` - Find all related nodes
+  - `query{RelationName}()` - Query with filters/sorting
+  - `connectionFor{RelationName}()` - GraphQL connection
+  - `create{RelationName}()` - Create one related node
+  - `add{RelationName}()` - Link one existing node
+  - `remove{RelationName}()` - Unlink one node
+  - `delete{RelationName}()` - Delete one node
+- Return types:
+  - `findAll`: `Promise<Array<T>>`
+  - `query`: `Promise<Array<T>>`
+  - `connectionFor`: `Promise<Connection<T>>`
+  - `create/add`: `Promise<T>`
+
+## 2. Type test scenarios for `.many()`:
+
+```typescript
+Deno.test("Basic many relationship", () => {
+  // Node with .many("comment", () => BfComment)
+  // Should have findAllComment(), queryComment(), connectionForComment(), createComment(), addComment(), removeComment()
+  // findAllComment() returns Promise<BfComment[]>
+  // queryComment(args) accepts query parameters and returns Promise<BfComment[]>
+  // connectionForComment(args) returns GraphQL connection type
+  // Instance methods access cv from the node instance
+});
+
+Deno.test("Query parameters for many relationships", () => {
+  // queryComment({ where: { authorId: "123" }, orderBy: { createdAt: "desc" }, limit: 10 })
+  // Accepts parameter object with type-safe filtering
+  // where: type-safe filter conditions based on node properties
+  // orderBy: type-safe field and direction
+  // limit/offset: pagination support
+  // Returns Promise<BfComment[]> with filtered results
+});
+
+Deno.test("GraphQL connection for many relationships", () => {
+  // connectionForComment({ first: 10, after: "cursor" })
+  // Accepts standard GraphQL connection arguments
+  // Returns typed connection: { edges: [...], pageInfo: {...}, totalCount }
+  // Edge type includes node and cursor
+  // Integrates with existing graphql-relay Connection types
+});
+
+Deno.test("Mixed one and many relationships", () => {
+  // Node with both .one() and .many() relationships
+  // All methods should coexist without conflicts
+  // Proper type inference for each relationship type
+});
+```
+
+## Type Definitions
+
+Add to `apps/bfDb/builders/bfDb/relationshipMethods.ts`:
+
+```typescript
+// Import connection types from graphql-relay
+import type { Connection } from "graphql-relay";
+
+// Query parameter types
+type QueryArgs<T> = {
+  where?: Partial<InferProps<T>>;
+  orderBy?: { [K in keyof InferProps<T>]?: "asc" | "desc" };
+  limit?: number;
+  offset?: number;
+};
+
+type ConnectionArgs = {
+  first?: number;
+  after?: string;
+  last?: number;
+  before?: string;
+  where?: any; // Same as QueryArgs where clause
+};
+
+// Detect cardinality from RelationSpec
+type RelationCardinality<T extends AnyBfNodeCtor, K extends string> = T extends
+  { bfNodeSpec: { relations: Record<K, infer R> } }
+  ? R extends { cardinality: infer C } ? C : "one"
+  : never;
+
+// Generate methods for .many() relationships
+type ManyRelationshipMethods<T extends AnyBfNodeCtor> = UnionToIntersection<
+  RelationNames<T> extends string
+    ? RelationCardinality<T, RelationNames<T>> extends "many" ?
+        & {
+          [K in RelationNames<T> as `findAll${Capitalize<K>}`]: () => Promise<
+            Array<InstanceType<RelationTarget<T, K>>>
+          >;
+        }
+        & {
+          [K in RelationNames<T> as `query${Capitalize<K>}`]: (
+            args: QueryArgs<RelationTarget<T, K>>,
+          ) => Promise<Array<InstanceType<RelationTarget<T, K>>>>;
+        }
+      // ... other methods
+    : never
+    : never
+>;
+```
+
+- Extend existing `RelationshipMethods<T>` to combine
+  `OneRelationshipMethods<T>` and `ManyRelationshipMethods<T>`
+- Create proper return types for connections using graphql-relay types
+- Ensure parameter types are properly inferred from node specs
+- Use consistent singular naming for all methods
+
+## Success Criteria
+
+- Type safety for all `.many()` methods
+- Proper inference of collection types
+- GraphQL connection types work correctly
+- No conflicts with `.one()` methods
+
+## Next Steps
+
+1. **Run tests in parallel**:
+   ```bash
+   bft test apps/bfDb/builders/bfDb/__tests__/relationshipTypes.test.ts
+   bft test apps/bfDb/
+   bft lint apps/bfDb/builders/bfDb/types/
+   bft check apps/bfDb/
+   ```
+
+2. **Format code**:
+   ```bash
+   bft format
+   ```
+
+3. **Commit changes**:
+   ```bash
+   bft commit
+   ```
+
+4. **Submit PR**:
+   ```bash
+   sl pr submit
+   ```
+
+5. **Monitor PR**:
+   - Watch the pull request for CI check results
+   - Fix any issues that arise
+   - If fixes needed:
+     ```bash
+     bft amend
+     sl pr submit
+     ```
+
+6. **Once all checks pass**:
+   - Proceed to
+     [Phase 6: Runtime Implementation for Many](./phase-6-runtime-implementation-many.md)
+   - Begin implementing runtime methods for many relationships
+
+**Important**: Do not proceed to Phase 6 until:
+
+- All type definitions for `.many()` relationships are working
+- `ManyRelationshipMethods<T>` types are properly defined
+- GraphQL connection types are correctly typed
+- Mixed one and many relationships work without conflicts
+- PR checks are green

--- a/memos/1-projects/automatic-relationship-methods/phase-6-runtime-implementation-many.md
+++ b/memos/1-projects/automatic-relationship-methods/phase-6-runtime-implementation-many.md
@@ -1,0 +1,113 @@
+# Phase 6: Runtime Implementation for Many
+
+[← Previous Phase](./phase-5-type-system-many.md) |
+[Back to README](./README.md) |
+[Next Phase →](./phase-7-advanced-many-features.md)
+
+**Goal**: Implement runtime methods for many relationships
+
+**Related sections in README:**
+
+- [Example Usage](./README.md#example-usage)
+- [For .many() relationships](./README.md#for-many-relationships)
+
+## 1. Extend `generateRelationshipMethods()`
+
+- Detect `.many()` relationships from node spec
+- Generate appropriate methods with different signatures
+- Handle pagination and filtering options
+
+## 2. Runtime behavior tests:
+
+```typescript
+Deno.test("Create and find in many relationship", () => {
+  // post.createComment({ text: "..." }) creates and links
+  // post.findAllComment() returns all linked comments
+  // Handle empty results gracefully
+});
+
+Deno.test("Add existing node to many relationship", () => {
+  // post.addComment(existingComment) creates edge only
+  // Should not duplicate if already linked
+  // Verify edge creation without node creation
+});
+
+Deno.test("Remove from many relationship", () => {
+  // post.removeComment(comment) removes edge only
+  // post.deleteComment(comment) deletes node too
+  // Handle non-existent relationships gracefully
+});
+```
+
+## Implementation Details
+
+### Method Signatures
+
+- `findAll{RelationName}()`: Return all related nodes
+- `query{RelationName}(args)`: Filter and sort with parameters
+- `connectionFor{RelationName}(args)`: GraphQL-compatible connection
+- `create{RelationName}(props)`: Create and link new node
+- `add{RelationName}(node)`: Link existing node
+- `remove{RelationName}(node)`: Remove from collection (edge only)
+- `delete{RelationName}(node)`: Delete node and remove from collection
+
+### Edge Cases
+
+- Empty collections
+- Duplicate prevention in `add`
+- Non-existent nodes in `remove`/`delete`
+- Proper transaction handling
+
+## Success Criteria
+
+- All `.many()` methods work correctly
+- Proper handling of collections
+- No duplicate edges
+- Clear error messages
+
+## Next Steps
+
+1. **Run tests in parallel**:
+   ```bash
+   bft test apps/bfDb/builders/bfDb/__tests__/relationshipMethods.test.ts
+   bft test apps/bfDb/
+   bft lint apps/bfDb/builders/bfDb/relationshipMethods.ts
+   bft check apps/bfDb/
+   ```
+
+2. **Format code**:
+   ```bash
+   bft format
+   ```
+
+3. **Commit changes**:
+   ```bash
+   bft commit
+   ```
+
+4. **Submit PR**:
+   ```bash
+   sl pr submit
+   ```
+
+5. **Monitor PR**:
+   - Watch the pull request for CI check results
+   - Fix any issues that arise
+   - If fixes needed:
+     ```bash
+     bft amend
+     sl pr submit
+     ```
+
+6. **Once all checks pass**:
+   - Proceed to
+     [Phase 7: Advanced Many Relationship Features](./phase-7-advanced-many-features.md)
+   - Begin implementing advanced features like batch operations
+
+**Important**: Do not proceed to Phase 7 until:
+
+- All `.many()` relationship methods are working correctly
+- Collection handling is properly implemented
+- Edge case scenarios are handled gracefully
+- No duplicate edges are created
+- PR checks are green

--- a/memos/1-projects/automatic-relationship-methods/phase-7-advanced-many-features.md
+++ b/memos/1-projects/automatic-relationship-methods/phase-7-advanced-many-features.md
@@ -1,0 +1,119 @@
+# Phase 7: Advanced Many Relationship Features
+
+[← Previous Phase](./phase-6-runtime-implementation-many.md) |
+[Back to README](./README.md) |
+[Next Phase →](./phase-8-many-relationship-migration.md)
+
+**Goal**: Add advanced features for many relationships
+
+**Related sections in README:**
+
+- [Key Differences Between .one() and .many()](./README.md#key-differences-between-one-and-many)
+
+## 1. Enhanced filtering and ordering
+
+- Extend `query{RelationName}()` with more advanced filtering capabilities
+- Add support for complex query operations
+- Type-safe filter predicates and operators
+
+## 2. Batch operations
+
+- `addMany{RelationName}([item1, item2])` for bulk operations - distinct from
+  single `add{RelationName}()`
+- `removeMany{RelationName}([item1, item2])` for bulk removal - distinct from
+  single `remove{RelationName}()`
+- `createMany{RelationName}([props1, props2])` for bulk creation
+- Transaction support for atomicity
+
+## 3. Performance optimizations
+
+- Add `iterate{RelationName}()` method for lazy loading with async iterators
+- Efficient queries for large collections
+- Caching strategies
+- Memory-efficient processing of large datasets
+
+## Example Usage
+
+```typescript
+// Batch operations - note the distinct method names with 'Many' suffix
+await post.addManyComment([comment1, comment2, comment3]);
+await post.removeManyComment([comment1, comment2]);
+await post.createManyComment([
+  { text: "First comment", authorId: user1.id },
+  { text: "Second comment", authorId: user2.id },
+]);
+
+// Advanced filtering with queryComment (singular)
+const recentComments = await post.queryComment({
+  where: { createdAt: { gte: lastWeek } },
+  orderBy: { createdAt: "desc" },
+  limit: 10,
+});
+
+// Future enhancement: Async iteration for large collections
+// This would be an additional method beyond the core API
+for await (const comment of post.iterateComment()) {
+  // Process each comment without loading all into memory
+}
+```
+
+## Implementation Considerations
+
+- Batch operations should be atomic
+- Consider database-specific optimizations
+- Memory efficiency for large collections
+- Progress reporting for long operations
+
+## Success Criteria
+
+- Batch operations work correctly
+- Performance improvements measurable
+- No memory issues with large collections
+- Maintains type safety
+
+## Next Steps
+
+1. **Run tests in parallel**:
+   ```bash
+   bft test apps/bfDb/builders/bfDb/__tests__/relationshipMethods.test.ts
+   bft test apps/bfDb/__tests__/performance/
+   bft lint apps/bfDb/builders/bfDb/relationshipMethods.ts
+   bft check apps/bfDb/
+   ```
+
+2. **Format code**:
+   ```bash
+   bft format
+   ```
+
+3. **Commit changes**:
+   ```bash
+   bft commit
+   ```
+
+4. **Submit PR**:
+   ```bash
+   sl pr submit
+   ```
+
+5. **Monitor PR**:
+   - Watch the pull request for CI check results
+   - Fix any issues that arise
+   - If fixes needed:
+     ```bash
+     bft amend
+     sl pr submit
+     ```
+
+6. **Once all checks pass**:
+   - Proceed to
+     [Phase 8: Many Relationship Migration](./phase-8-many-relationship-migration.md)
+   - Begin migrating existing many relationship patterns
+
+**Important**: Do not proceed to Phase 8 until:
+
+- Batch operations are working and atomic
+- Performance optimizations show measurable improvements
+- Memory efficiency is validated with large collections
+- Async iteration patterns work correctly
+- PR checks are green

--- a/memos/1-projects/automatic-relationship-methods/phase-8-many-relationship-migration.md
+++ b/memos/1-projects/automatic-relationship-methods/phase-8-many-relationship-migration.md
@@ -1,0 +1,135 @@
+# Phase 8: Many Relationship Migration
+
+[← Previous Phase](./phase-7-advanced-many-features.md) |
+[Back to README](./README.md)
+
+**Goal**: Migrate existing many relationship patterns
+
+**Related sections in README:**
+
+- [Design Decision: Basic Relationships Only](./README.md#design-decision-basic-relationships-only)
+- [Files to Modify](./README.md#files-to-modify)
+
+## 1. Identify current patterns
+
+- Manual edge creation for one-to-many
+- Custom query methods
+- Pagination implementations
+
+## 2. Migration strategy
+
+- Codemod for common patterns
+- Preserve existing functionality
+- Gradual adoption path
+
+## Common Migration Patterns
+
+### Manual Edge Creation
+
+Before:
+
+```typescript
+const comment = await BfComment.create(cv, { text: "Great post!" });
+await BfEdge.create(cv, post, "comments", comment);
+```
+
+After:
+
+```typescript
+const comment = await post.createComment({ text: "Great post!" });
+```
+
+### Custom Query Methods
+
+Before:
+
+```typescript
+async function getPostComments(post: BfPost) {
+  const edges = await BfEdge.query(cv)
+    .where({ sourceId: post.id, type: "comments" })
+    .all();
+  return edges.map((e) => e.target);
+}
+```
+
+After:
+
+```typescript
+const comments = await post.findAllComment();
+```
+
+### Pagination
+
+Before:
+
+```typescript
+const edges = await BfEdge.query(cv)
+  .where({ sourceId: post.id, type: "comments" })
+  .limit(10)
+  .after(cursor)
+  .all();
+```
+
+After:
+
+```typescript
+const connection = await post.connectionForComment({
+  first: 10,
+  after: cursor,
+});
+```
+
+## Success Criteria for .many() Implementation
+
+- All one-to-many relationships automatically get typed methods
+- Proper handling of collections with pagination support
+- Efficient bulk operations available
+- Seamless integration with existing .one() methods
+- Type safety maintained throughout
+
+## Next Steps
+
+1. **Run tests in parallel**:
+   ```bash
+   bft test apps/bfDb/
+   bft test apps/boltFoundry/
+   bft lint .
+   bft check .
+   ```
+
+2. **Format code**:
+   ```bash
+   bft format
+   ```
+
+3. **Commit changes**:
+   ```bash
+   bft commit
+   ```
+
+4. **Submit PR**:
+   ```bash
+   sl pr submit
+   ```
+
+5. **Monitor PR**:
+   - Watch the pull request for CI check results
+   - Fix any issues that arise
+   - If fixes needed:
+     ```bash
+     bft amend
+     sl pr submit
+     ```
+
+6. **Once all checks pass**:
+   - All phases complete!
+   - Automatic relationship methods are now available throughout the codebase
+
+**Important**: Do not consider the project complete until:
+
+- All existing many relationship patterns have been migrated
+- Codemod has successfully updated all relevant code
+- All tests pass after migration
+- Performance is maintained or improved
+- Documentation is updated with new patterns
+- PR checks are green


### PR DESCRIPTION

Extend FieldBuilder to support .many() relationships by adding the many
property alongside the existing one property. This enables defining
many-to-many relationships in the type system.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
