### PR TITLE
Fix Nix installation in codebot Dockerfile

### DIFF
--- a/.codebot-metadata/original-commit
+++ b/.codebot-metadata/original-commit
@@ -1,1 +1,1 @@
-e27af810e6a795b8c1ad87d4cd89f42beae43175
+b86bc159e1ef9cd43f040eff9f4feebff65f88fa

--- a/infra/apps/codebot/Dockerfile
+++ b/infra/apps/codebot/Dockerfile
@@ -81,14 +81,24 @@ RUN if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
         && ln -s /usr/bin/chromium /usr/bin/google-chrome-stable; \
     fi
 
+# Install dependencies required by Nix installer
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libssl-dev \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install Nix using Determinate Nix installer
 RUN curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install linux \
     --extra-conf "sandbox = false" \
+    --extra-conf "experimental-features = nix-command flakes" \
     --init none \
     --no-confirm
 
 # Set up PATH to include Nix
 ENV PATH="${PATH}:/nix/var/nix/profiles/default/bin"
+
+# Verify Nix installation
+RUN /nix/var/nix/profiles/default/bin/nix --version || (echo "Nix installation verification failed" && exit 1)
 
 # Copy flake files for caching
 COPY flake.nix flake.lock /@bfmono/


### PR DESCRIPTION
## Summary
- Fix Nix installation failures in the codebot Docker build process
- Add required dependencies for the Nix installer
- Enable experimental features needed for flakes

## Problem
The GitHub Actions workflow was failing during the Docker build step when trying to install Nix using the Determinate Systems installer.

## Solution
- Added `libssl-dev` and `pkg-config` dependencies that may be required by the Nix installer
- Enabled experimental features (nix-command and flakes) during Nix installation
- Added a verification step to ensure Nix is properly installed before proceeding

## Test plan
- [ ] GitHub Actions workflow should complete successfully
- [ ] Docker image should build for both linux/amd64 and linux/arm64 platforms
- [ ] Nix should be properly installed in the resulting container

🤖 Generated with [Claude Code](https://claude.ai/code)